### PR TITLE
UDX-6442: set secure container registry

### DIFF
--- a/k8_cortx_cloud/README.txt
+++ b/k8_cortx_cloud/README.txt
@@ -79,13 +79,13 @@ Rancher Local Path mount point in all Pod containers (CORTX Provisioners, Data, 
 
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 The Helm charts work with both "dummy" and "CORTX ALL" containers. 
-If image is centos:7 helm runs in "dummy" mode any other name runs "CORTX ALL" mode
+If image is ghcr.io/seagate/centos:7 helm runs in "dummy" mode any other name runs "CORTX ALL" mode
 
-{- if eq $.Values.cortxdata.image  "centos:7" }}  # DO NOT CHANGE
-command: ["/bin/sleep", "3650d"]                  # DO NOT CHANGE 
-{{- else }}                                       # DO NOT CHANGE
+{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}  # DO NOT CHANGE
+command: ["/bin/sleep", "3650d"]                                  # DO NOT CHANGE 
+{{- else }}                                                       # DO NOT CHANGE
 command: ["/bin/sleep", "3650d"]    #<<=========================== REPLACE THIS WITH THE CORTX ENTRY POINT 
-{{- end }}                                        # DO NOT CHANGE
+{{- end }}                                                        # DO NOT CHANGE
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 See the following example from CORTX Data helm chart, replace the command section
@@ -98,11 +98,11 @@ containers:
 - name: cortx-s3-haproxy
    image: {{ .Values.cortxdata.image }}
    imagePullPolicy: IfNotPresent
-   {- if eq $.Values.cortxdata.image  "centos:7" }}  # DO NOT CHANGE
-   command: ["/bin/sleep", "3650d"]                  # DO NOT CHANGE 
-   {{- else }}                                       # DO NOT CHANGE
+   {- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}  # DO NOT CHANGE
+   command: ["/bin/sleep", "3650d"]                                  # DO NOT CHANGE 
+   {{- else }}                                                       # DO NOT CHANGE
    command: ["/bin/sleep", "3650d"]    #<<=========================== REPLACE THIS WITH THE CORTX ENTRY POINT 
-   {{- end }}                                        # DO NOT CHANGE
+   {{- end }}                                                        # DO NOT CHANGE
    volumeDevices:
    {{- range .Files.Lines .Values.cortxdata.mountblkinfo }}
    - name: {{ printf "cortx-data-%s-pv-%s" ( base .) $nodename }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control-provisioner/templates/cortx-control-prov-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control-provisioner/templates/cortx-control-prov-pod.yaml
@@ -32,7 +32,7 @@ spec:
     imagePullPolicy: IfNotPresent        
     command: 
       - /bin/sh
-    {{- if eq .Values.cortxcontrolprov.image "centos:7" }}
+    {{- if eq .Values.cortxcontrolprov.image "ghcr.io/seagate/centos:7" }}
     args: 
       - -c
       - sleep $(shuf -i 5-10 -n 1)s

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control-provisioner/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control-provisioner/values.yaml
@@ -1,7 +1,7 @@
 namespace: default
 cortxcontrolprov:
   name: cortx-control-prov-pod
-  image: centos:7
+  image: ghcr.io/seagate/centos:7
   secretinfo: secret-info.txt
   serviceaccountname: cortx-sa
   service:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
@@ -39,7 +39,7 @@ spec:
         - name: cortx-free-space-monitor
           image: {{ .Values.cortxcontrol.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxcontrol.image "centos:7" }}      
+          {{- if eq .Values.cortxcontrol.image "ghcr.io/seagate/centos:7" }}      
           command: ["/bin/sleep", "3650d"]
           {{- else }}     
           command: ["/bin/sleep", "3650d"]
@@ -66,7 +66,7 @@ spec:
         - name: cortx-fsm-motr
           image: {{ .Values.cortxcontrol.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxcontrol.image "centos:7" }}          
+          {{- if eq .Values.cortxcontrol.image "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 
@@ -97,7 +97,7 @@ spec:
         - name: cortx-bg-producer
           image: {{ .Values.cortxcontrol.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxcontrol.image "centos:7" }}          
+          {{- if eq .Values.cortxcontrol.image "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 
@@ -128,7 +128,7 @@ spec:
         - name: cortx-csm-agent
           image: {{ .Values.cortxcontrol.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxcontrol.image "centos:7" }}          
+          {{- if eq .Values.cortxcontrol.image "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data-provisioner/templates/cortx-data-prov-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data-provisioner/templates/cortx-data-prov-pod.yaml
@@ -39,7 +39,7 @@ spec:
     imagePullPolicy: IfNotPresent        
     command: 
       - /bin/sh
-    {{- if eq .Values.cortxdataprov.image  "centos:7" }}
+    {{- if eq .Values.cortxdataprov.image  "ghcr.io/seagate/centos:7" }}
     args: 
       - -c
       - sleep $(shuf -i 5-10 -n 1)s

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data-provisioner/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data-provisioner/values.yaml
@@ -1,7 +1,7 @@
 namespace: default
 cortxdataprov:
   name: cortx-data-prov-pod
-  image: centos:7
+  image: ghcr.io/seagate/centos:7
   nodename: node-1
   mountblkinfo: mnt-blk-info.txt
   secretinfo: secret-info.txt

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
@@ -47,7 +47,7 @@ spec:
         - name: cortx-s3-haproxy
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxdata.image  "centos:7" }}          
+          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 
@@ -84,7 +84,7 @@ spec:
         - name: cortx-s3-auth-server
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxdata.image  "centos:7" }}          
+          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 
@@ -121,7 +121,7 @@ spec:
               value: {{ $.Values.cortxdata.name }}
             - name: S3_INDEX
               value: {{ printf "%d" (add 1 $i) | quote }}
-          {{- if eq $.Values.cortxdata.image  "centos:7" }}          
+          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 
@@ -152,7 +152,7 @@ spec:
         - name: cortx-motr-hax
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxdata.image  "centos:7" }}          
+          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 
@@ -184,7 +184,7 @@ spec:
         - name: {{ printf "cortx-motr-client-%03d" (add 1 $i) }}
           image: {{ $.Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq $.Values.cortxdata.image  "centos:7" }}          
+          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: ["/bin/sleep", "3650d"]
@@ -212,7 +212,7 @@ spec:
         - name: cortx-motr-confd
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxdata.image  "centos:7" }}          
+          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -249,7 +249,7 @@ spec:
               value: {{ $.Values.cortxdata.name }}
             - name: IO_INDEX
               value: {{ printf "%d" (add 1 $i) | quote }}
-          {{- if eq $.Values.cortxdata.image  "centos:7" }}          
+          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -285,7 +285,7 @@ spec:
         - name: cortx-s3-bg-consumer
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxdata.image  "centos:7" }}          
+          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command: 

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
@@ -1,7 +1,7 @@
 namespace: default
 cortxdata:
   name: cortx-data-pod
-  image: centos:7
+  image: ghcr.io/seagate/centos:7
   nodename: node-1
   mountblkinfo: mnt-blk-info.txt
   secretinfo: secret-info.txt

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -55,9 +55,11 @@ function savePodDetail()
 function getInnerLogs()
 {
   path="/var/cortx/support_bundle"
-  name="logs-${date}-${1}"
-  logs_output=$(kubectl exec ${1} -- cortx_support_bundle generate -t file://${path} -b ${name} -m ${name})
-  kubectl cp $1:$path/$name ./${logs_folder}
+  name="bundle-logs-${1}-${date}"
+  printf "\n ⭐ Generating support-bundle logs for pod: ${1}\n"
+  kubectl exec ${1} --namespace="${namespace}" -- cortx_support_bundle generate -t file://${path} -b ${name} -m ${name}
+  kubectl cp $1:$path/$name $logs_folder/$name
+  tar rf $logs_folder.tar $logs_folder/$name
   kubectl exec ${1} --namespace="${namespace}" -- bash -c "rm -rf ${path}"
 }
 

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -16,10 +16,12 @@ solution:
     cortxdataprov: ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci
     cortxdata: ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci
     openldap: ghcr.io/seagate/symas-openldap:2.4.58
-    consul: hashicorp/consul:1.10.0
-    kafka: 3.0.0-debian-10-r7
-    zookeeper: 3.7.0-debian-10-r182
-    rancher: rancher/local-path-provisioner:v0.0.20
+    consul: ghcr.io/seagate/consul:1.10.0
+    kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
+    zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
+    gluster: ghcr.io/seagate/gluster-centos:latest
+    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
+    busybox: ghcr.io/seagate/busybox:latest
   common:
     storage_provisioner_path: /mnt/fs-local-volume
     container_path:

--- a/k8_cortx_cloud/solution_dummy.yaml
+++ b/k8_cortx_cloud/solution_dummy.yaml
@@ -11,15 +11,17 @@ solution:
       csm_auth_admin_secret: seagate2
       csm_mgmt_admin_secret: Cortxadmin@123
   images:
-    cortxcontrolprov: centos:7
-    cortxcontrol: centos:7
-    cortxdataprov: centos:7
-    cortxdata: centos:7
+    cortxcontrolprov: ghcr.io/seagate/centos:7
+    cortxcontrol: ghcr.io/seagate/centos:7
+    cortxdataprov: ghcr.io/seagate/centos:7
+    cortxdata: ghcr.io/seagate/centos:7
     openldap: ghcr.io/seagate/symas-openldap:2.4.58
-    consul: hashicorp/consul:1.10.0
-    kafka: 3.0.0-debian-10-r7
-    zookeeper: 3.7.0-debian-10-r182
-    rancher: rancher/local-path-provisioner:v0.0.20
+    consul: ghcr.io/seagate/consul:1.10.0
+    kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
+    zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
+    gluster: ghcr.io/seagate/gluster-centos:latest
+    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
+    busybox: ghcr.io/seagate/busybox:latest
   common:
     storage_provisioner_path: /mnt/fs-local-volume
     container_path:


### PR DESCRIPTION
Testing deploy zookeeper using Seagate registry:

![image](https://user-images.githubusercontent.com/86394691/140998628-1bb9465a-9547-4447-8c56-2c09d7bc4785.png)

![image](https://user-images.githubusercontent.com/86394691/140998644-d495c0ca-699f-423a-b7ee-bc9e1721117a.png)

Add optional Metal LB to the solution:

In the solution file, it is now possible to add an optional Metal Load Balancer configurations under `common` key:

![image](https://user-images.githubusercontent.com/86394691/142016963-b54ed4ab-4fa1-43b0-8396-1ceec7568694.png)

If those configurations are present, the deployment script is going to deploy a Metal LB with the given parameters.