### PR TITLE
Adding http endpoint in list of consul endpoints

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/config-template.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/config-template.yaml
@@ -17,6 +17,7 @@ cortx:
     consul:
       endpoints:
         - tcp://<<.Values.cortx.external.consul.endpoints>>:8301
+        - http://<<.Values.cortx.external.consul.endpoints>>:8500
       admin: admin
       secret: consul_admin_secret
   common:


### PR DESCRIPTION
Adding new endpoint to list of consul endpoint. This endpoint have protocol http and port pointing to 8500.
This endpoint will be consumed by CSM and S3 for connecting to consul.