### PR TITLE
UDX-6765 set max map count

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-cm-nodeconfig.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-cm-nodeconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.cortxdata.name }}-node-config
+data:
+  entrypoint.sh: |-
+    #!/bin/sh
+    DESIRED_MAX_MAP_COUNT=30000000
+    OBSERVED_MAX_MAP_COUNT=$(sysctl --values vm.max_map_count)
+    
+    printf "%s\t%s\n" "Desired  'vm.max_map_count'" "${DESIRED_MAX_MAP_COUNT}"
+    printf "%s\t%s\n" "Observed 'vm.max_map_count'" "${OBSERVED_MAX_MAP_COUNT}"
+
+    if [[ "$OBSERVED_MAX_MAP_COUNT" -lt "$DESIRED_MAX_MAP_COUNT" ]]
+    then
+        printf "[WARNING] Detected kernel parameter 'vm.max_map_count' setting (%s) is lower than the desired setting for optimal system performance (%s).\n" "${OBSERVED_MAX_MAP_COUNT}" "${DESIRED_MAX_MAP_COUNT}"
+        printf "Setting 'vm.max_map_count' via 'sysctl' command.\n"
+        sysctl -w vm.max_map_count=$DESIRED_MAX_MAP_COUNT >> /etc/sysctl.d/k8s.conf
+        sleep 60
+    fi

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
@@ -43,6 +43,10 @@ spec:
           secret:
             secretName: {{ printf "%s" . }}
         {{- end }}
+        - name: {{ .Values.cortxdata.name }}-node-config
+          configMap:
+            defaultMode: 0700
+            name: {{ .Values.cortxdata.name }}-node-config
       initContainers:
       - name: cortx-setup
         image: {{ .Values.cortxdata.image }}
@@ -79,6 +83,17 @@ spec:
           {{- end }}
         ports:
         - containerPort: 5050
+      - name: node-config
+        image: {{ .Values.cortxdata.image }}
+        imagePullPolicy: IfNotPresent        
+        command:
+          - /nodeconfig/entrypoint.sh
+        volumeMounts:
+        - name: {{ .Values.cortxdata.name }}-node-config
+          mountPath: /nodeconfig
+          readOnly: true
+        securityContext:
+          privileged: true
       containers:
         - name: cortx-s3-haproxy
           image: {{ .Values.cortxdata.image }}


### PR DESCRIPTION
Implemented node config strategy as discussed on this morning's call. This is robust enough to extend to other configuration options, yet lean enough to be removed should we determine better environment checking strategies. 

-----
[View rendered doc/cortx-aws-k8s-installation.md](https://github.com/Seagate/cortx-k8s/blob/UDX-6765_set_max_map_count/doc/cortx-aws-k8s-installation.md)