### PR TITLE
UDX-6831 - Add NodePort vs LoadBalancer flag support

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-svc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.cortxcontrol.service.clusterip.name }}
   namespace: {{ .Values.namespace }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.cortxcontrol.service.clusterip.type }}
   selector:
     app: {{ .Values.cortxcontrol.name }}
   ports:
@@ -30,7 +30,7 @@ metadata:
   name: {{ .Values.cortxcontrol.service.loadbal.name }}
   namespace: {{ .Values.namespace }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.cortxcontrol.service.loadbal.type }}
   selector:
     app: {{ .Values.cortxcontrol.name }}
   ports:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/values.yaml
@@ -7,10 +7,12 @@ cortxcontrol:
   service:
     clusterip:
       name: cortx-control-clusterip-svc
+      type: ClusterIP
     headless:
       name: cortx-control-headless-svc
     loadbal:
       name: cortx-control-loadbal-svc
+      type: LoadBalancer
   cfgmap:
     mountpath: /etc/cortx/solution
     name: cortx-control-cfgmap001

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-svc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.cortxdata.service.clusterip.name }}
   namespace: {{ .Values.namespace }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.cortxdata.service.clusterip.type }}
   selector:
     app: {{ .Values.cortxdata.name }}
   ports:
@@ -62,7 +62,7 @@ metadata:
   name: {{ .Values.cortxdata.service.loadbal.name }}
   namespace: {{ .Values.namespace }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.cortxdata.service.loadbal.type }}
   selector:
     app: {{ .Values.cortxdata.name }}
   ports:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
@@ -16,10 +16,12 @@ cortxdata:
   service:
     clusterip:
       name: cortx-data-clusterip-svc
+      type: ClusterIP
     headless:
       name: cortx-data-headless-svc
     loadbal:
       name: cortx-data-loadbal-svc
+      type: LoadBalancer
   cfgmap:
     mountpath: /etc/cortx/solution
     volmountname: config001

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -743,6 +743,9 @@ function deployCortxControl()
     cortxcontrol_image=$(parseSolution 'solution.images.cortxcontrol')
     cortxcontrol_image=$(echo $cortxcontrol_image | cut -f2 -d'>')
 
+    external_services_type=$(parseSolution 'solution.common.external_services.type')
+    external_services_type=$(echo $external_services_type | cut -f2 -d'>')
+
     cortxcontrol_machineid=$(cat $cfgmap_path/auto-gen-control-$namespace/id)
 
     num_nodes=1
@@ -753,6 +756,7 @@ function deployCortxControl()
         --set cortxcontrol.service.clusterip.name="cortx-control-clusterip-svc" \
         --set cortxcontrol.service.headless.name="cortx-control-headless-svc" \
         --set cortxcontrol.loadbal.name="cortx-control-loadbal-svc" \
+        --set cortxcontrol.loadbal.type="$external_services_type" \
         --set cortxcontrol.cfgmap.mountpath="/etc/cortx/solution" \
         --set cortxcontrol.cfgmap.name="cortx-cfgmap-$namespace" \
         --set cortxcontrol.cfgmap.volmountname="config001" \
@@ -801,6 +805,9 @@ function deployCortxData()
     cortxdata_image=$(parseSolution 'solution.images.cortxdata')
     cortxdata_image=$(echo $cortxdata_image | cut -f2 -d'>')
 
+    external_services_type=$(parseSolution 'solution.common.external_services.type')
+    external_services_type=$(echo $external_services_type | cut -f2 -d'>')
+
     num_nodes=0
     for i in "${!node_selector_list[@]}"; do
         num_nodes=$((num_nodes+1))
@@ -817,6 +824,7 @@ function deployCortxData()
             --set cortxdata.service.clusterip.name="cortx-data-clusterip-svc-$node_name" \
             --set cortxdata.service.headless.name="cortx-data-headless-svc-$node_name" \
             --set cortxdata.service.loadbal.name="cortx-data-loadbal-svc-$node_name" \
+            --set cortxdata.service.loadbal.type="$external_services_type" \
             --set cortxdata.cfgmap.name="cortx-cfgmap-$namespace" \
             --set cortxdata.cfgmap.volmountname="config001-$node_name" \
             --set cortxdata.cfgmap.mountpath="/etc/cortx/solution" \

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -39,6 +39,8 @@ solution:
       durability:
         sns: 1+0+0
         dix: 1+0+0
+    external_services:
+      type: LoadBalancer
   storage:
     cvg1:
       name: cvg-01


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

Ability for users to select LoadBalancer versus NodePort exposure for external facing services (`cortx-*-loadbal-svc-*`).