### PR TITLE
EOS-27403 - Initial pass at simple setup_size impl

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/config-template.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/config-template.yaml
@@ -25,7 +25,7 @@ cortx:
       name: CORTX
       version: <<.Values.cortx.common.release.version>>
     environment_type: K8
-    setup_size: large
+    setup_size: <<.Values.cortx.common.setup_size>>
     service:
       admin: admin
       secret: common_admin_secret

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -615,6 +615,11 @@ function deployCortxConfigMap()
         splitDockerImage "${image}"
         ./parse_scripts/subst.sh $new_gen_file "cortx.common.release.version" $tag
 
+        # Pass through setup_size parameter
+        ## THIS IS PLACEHOLDER FUNCTION UNTIL PI-6 WHEN WE WILL IMPLEMENT
+        ## PROPER setup_size => container_resource MAPPINGS
+        ./parse_scripts/subst.sh $new_gen_file "cortx.common.setup_size" $(extractBlock 'solution.common.setup_size')
+
         # Generate node file with type storage_node in "node-info" folder
         new_gen_file="$node_info_folder/cluster-storage-node-${node_name_list[$i]}.yaml"
         cp "$cfgmap_path/templates/cluster-node-template.yaml" $new_gen_file

--- a/k8_cortx_cloud/destroy-cortx-cloud.sh
+++ b/k8_cortx_cloud/destroy-cortx-cloud.sh
@@ -138,7 +138,7 @@ num_motr_client=$(extractBlock 'solution.common.motr.num_client_inst')
 function deleteCortxClient()
 {
     printf "########################################################\n"
-    printf "# Delete CORTX HA                                       \n"
+    printf "# Delete CORTX Client                                   \n"
     printf "########################################################\n"
     for i in "${!node_selector_list[@]}"; do
         helm uninstall "cortx-client-${node_name_list[$i]}-$namespace" -n $namespace
@@ -150,9 +150,7 @@ function deleteCortxHa()
     printf "########################################################\n"
     printf "# Delete CORTX HA                                       \n"
     printf "########################################################\n"
-    for i in "${!node_selector_list[@]}"; do
-        helm uninstall "cortx-ha-$namespace" -n $namespace
-    done
+    helm uninstall "cortx-ha-$namespace" -n $namespace
 }
 
 function deleteCortxServer()

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -25,6 +25,7 @@ solution:
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
     busybox: ghcr.io/seagate/busybox:latest
   common:
+    setup_size: large
     storage_provisioner_path: /mnt/fs-local-volume
     container_path:
       local: /etc/cortx

--- a/k8_cortx_cloud/solution_dummy.yaml
+++ b/k8_cortx_cloud/solution_dummy.yaml
@@ -25,6 +25,7 @@ solution:
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
     busybox: ghcr.io/seagate/busybox:latest
   common:
+    setup_size: large
     storage_provisioner_path: /mnt/fs-local-volume
     container_path:
       local: /etc/cortx

--- a/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
@@ -21,6 +21,7 @@ solution:
     zookeeper: required
     rancher: required
   common:
+    setup_size: required
     storage_provisioner_path: required
     container_path:
       local: required


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

This is an initial implementation to allow deployers to specify setup_size in the solution.yaml and have it passed into the running containers to allow for downstream resource management.

This fix will be replaced in the future with business logic that will map setup_size to specific CPU & RAM container resources, to be implemented in Helm Chart logic, that would then specify the explicit limits and requests on each container running in the system. See updated [EOS-27448](https://jts.seagate.com/browse/EOS-27448)