### PR TITLE
EOS-27400: Remove "sleep infinity" from HA container commands

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
@@ -100,8 +100,7 @@ spec:
             - /bin/sh
           args:
             - -c
-            - /opt/seagate/cortx/ha/bin/ha_start -s fault_tolerance -c yaml:///etc/cortx/cluster.conf;
-              sleep infinity;
+            - /opt/seagate/cortx/ha/bin/ha_start -s fault_tolerance -c yaml:///etc/cortx/cluster.conf
           {{- end }}
           volumeMounts:
             - name: {{ .Values.cortxha.cfgmap.volmountname }}
@@ -134,8 +133,7 @@ spec:
             - /bin/sh
           args:
             - -c
-            - /opt/seagate/cortx/ha/bin/ha_start -s health_monitor -c yaml:///etc/cortx/cluster.conf;
-              sleep infinity;
+            - /opt/seagate/cortx/ha/bin/ha_start -s health_monitor -c yaml:///etc/cortx/cluster.conf
           {{- end }}
           volumeMounts:
             - name: {{ .Values.cortxha.cfgmap.volmountname }}
@@ -168,8 +166,7 @@ spec:
             - /bin/sh
           args:
             - -c
-            - /opt/seagate/cortx/ha/bin/ha_start -s k8s_monitor -c yaml:///etc/cortx/cluster.conf;
-              sleep infinity;
+            - /opt/seagate/cortx/ha/bin/ha_start -s k8s_monitor -c yaml:///etc/cortx/cluster.conf
           {{- end }}
           volumeMounts:
             - name: {{ .Values.cortxha.cfgmap.volmountname }}


### PR DESCRIPTION
I tested this by deploying (1-node cluster) and running some S3 IO.