### PR TITLE
EOS-27405: Update log collector to use correct pod names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+logs-cortx-cloud-*.tar


### PR DESCRIPTION
The `cortx-control` and `cortx-data` pod names changed, so the log collector script has been updated to reflect that.

Added additional pods to collect from, `cortx-ha` and `cortx-server`.

I found an unrelated issue where the CSM agent container logs had an error string that caused a bash `printf` to truncate the logs. 

Another issue that I saw (not addressed in this PR) is that the CORTX support bundle generate is not specifying a container to run on, so k8s is picking the first container. This should be followed up to either select a default container to run the bundle on, or determine whether bundles should be generated for each container individually.

Signed-off-by: Keith Pine <keith.pine@seagate.com>