### PR TITLE
EOS-27541: Add Github Action for shellcheck

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches:
+     - integration
+     - main
+  pull_request: ~
+  workflow_dispatch:
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Shellcheck
+        uses: ludeeus/action-shellcheck@1.1.0
+        # Temporarily pass until files are fixed
+        continue-on-error: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
 name: Lint
 
 on:
@@ -6,7 +20,6 @@ on:
      - integration
      - main
   pull_request: ~
-  workflow_dispatch:
 
 jobs:
   shellcheck:
@@ -15,6 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run Shellcheck
-        uses: ludeeus/action-shellcheck@1.1.0
+        uses: Seagate/action-shellcheck@1.1.0
         # Temporarily pass until files are fixed
         continue-on-error: true

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+enable=check-extra-masked-returns
+enable=require-double-brackets
+enable=require-variable-braces


### PR DESCRIPTION
Lint all bash scripts using [shellcheck](https://github.com/koalaman/shellcheck) for any push to main or integration branches and PRs.

Some extra strict options are enabled in .shellcheckrc (v0.8.0 required). All of the enabled checks cover some aspects of several Bash style guides, although they aren't all identical:

  - [bahamas10/bash-style-guide](https://github.com/bahamas10/bash-style-guide)
  - [BashGuide/Practices](http://mywiki.wooledge.org/BashGuide/Practices)
  - [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)

For now, the Action is configured to always succeed because of existing failures.

Signed-off-by: Keith Pine <keith.pine@seagate.com>