### PR TITLE
Eos 28404 removed unneeded services

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
@@ -20,7 +20,7 @@ spec:
         {{- end }}
         cortx.io/service-type: cortx-control
     spec:
-      hostname: {{ .Values.cortxcontrol.service.headless.name }}
+      hostname: {{ .Values.cortxcontrol.name }}
       serviceAccountName: {{ .Values.cortxcontrol.serviceaccountname }}
       volumes:
         - name: {{ .Values.cortxcontrol.cfgmap.volmountname }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-svc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-svc.yaml
@@ -1,38 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.cortxcontrol.service.clusterip.name }}
-  namespace: {{ .Values.namespace }}
-spec:
-  type: {{ .Values.cortxcontrol.service.clusterip.type }}
-  selector:
-    app: {{ .Values.cortxcontrol.name }}
-  ports:
-    - name: cortx-message-server-28300
-      port: 28300
-      targetPort: 28300
-      protocol: TCP
-    - name: cortx-csm-agent-tcp
-      protocol: TCP
-      port: 8081
-      targetPort: 8081
-  selector:
-    app: {{ .Values.cortxcontrol.name }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ .Values.cortxcontrol.service.headless.name }}
-  namespace: {{ .Values.namespace }}
-spec:
-  publishNotReadyAddresses: true
-  clusterIP: None
-  selector:
-    app: {{ .Values.cortxcontrol.name }}
----
-apiVersion: v1
-kind: Service
-metadata:
   name: {{ .Values.cortxcontrol.service.loadbal.name }}
   namespace: {{ .Values.namespace }}
 spec:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/values.yaml
@@ -5,11 +5,6 @@ cortxcontrol:
   secretinfo: secret-info.txt
   serviceaccountname: cortx-sa
   service:
-    clusterip:
-      name: cortx-control-clusterip-svc
-      type: ClusterIP
-    headless:
-      name: cortx-control-headless-svc
     loadbal:
       name: cortx-control-loadbal-svc
       type: LoadBalancer

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
@@ -23,7 +23,7 @@ spec:
     {{- $nodeparts := split "." $nodeselector }}
     {{- $nodename := $nodeparts._0 }}
     spec:
-      hostname: {{ .Values.cortxdata.service.headless.name }}
+      hostname: {{ .Values.cortxdata.name }}
       serviceAccountName: {{ .Values.cortxdata.serviceaccountname }}
       volumes:
         - name: {{ .Values.cortxdata.cfgmap.volmountname }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
@@ -20,7 +20,7 @@ spec:
         name: cortx-ha
         cortx.io/service-type: cortx-ha
     spec:
-      hostname: {{ .Values.cortxha.service.headless.name }}
+      hostname: {{ .Values.cortxha.name }}
       serviceAccountName: {{ .Values.cortxha.serviceaccountname }}
       automountServiceAccountToken: true
       volumes:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
@@ -23,7 +23,7 @@ spec:
     {{- $nodeparts := split "." $nodeselector }}
     {{- $nodename := $nodeparts._0 }}
     spec:
-      hostname: {{ .Values.cortxserver.service.headless.name }}
+      hostname: {{ .Values.cortxserver.name }}
       serviceAccountName: {{ .Values.cortxserver.serviceaccountname }}
       volumes:
         - name: {{ .Values.cortxserver.cfgmap.volmountname }}

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -632,10 +632,10 @@ function deployCortxConfigMap()
         # Generate node file with type storage_node in "node-info" folder
         new_gen_file="$node_info_folder/cluster-storage-node-${node_name_list[$i]}.yaml"
         cp "$cfgmap_path/templates/cluster-node-template.yaml" $new_gen_file
-        ./parse_scripts/subst.sh $new_gen_file "cortx.node.name" "cortx-data-headless-svc-${node_name_list[$i]}"
+        ./parse_scripts/subst.sh $new_gen_file "cortx.node.name" "cortx-data-${node_name_list[$i]}"
         uuid_str=$(UUID=$(uuidgen); echo ${UUID//-/})
         ./parse_scripts/subst.sh $new_gen_file "cortx.pod.uuid" "$uuid_str"
-        ./parse_scripts/subst.sh $new_gen_file "cortx.svc.name" "cortx-data-headless-svc-${node_name_list[$i]}"
+        ./parse_scripts/subst.sh $new_gen_file "cortx.svc.name" "cortx-data-${node_name_list[$i]}"
         ./parse_scripts/subst.sh $new_gen_file "cortx.node.type" "data_node"
         
         # Create data machine id file for cortx data
@@ -646,10 +646,10 @@ function deployCortxConfigMap()
         # Generate cluster server node file with type server_node in "node-info" folder
         cluster_server_node_file="$node_info_folder/cluster-server-node-${node_name_list[$i]}.yaml"
         cp "$cfgmap_path/templates/cluster-node-template.yaml" $cluster_server_node_file
-        ./parse_scripts/subst.sh $cluster_server_node_file "cortx.node.name" "cortx-server-headless-svc-${node_name_list[$i]}"
+        ./parse_scripts/subst.sh $cluster_server_node_file "cortx.node.name" "cortx-server-${node_name_list[$i]}"
         uuid_str=$(UUID=$(uuidgen); echo ${UUID//-/})
         ./parse_scripts/subst.sh $cluster_server_node_file "cortx.pod.uuid" "$uuid_str"
-        ./parse_scripts/subst.sh $cluster_server_node_file "cortx.svc.name" "cortx-server-headless-svc-${node_name_list[$i]}"
+        ./parse_scripts/subst.sh $cluster_server_node_file "cortx.svc.name" "cortx-server-${node_name_list[$i]}"
         ./parse_scripts/subst.sh $cluster_server_node_file "cortx.node.type" "server_node"
         # Create data machine id file for cortx server
         auto_gen_node_path="$cfgmap_path/auto-gen-${node_name_list[$i]}-$namespace/server"
@@ -674,10 +674,10 @@ function deployCortxConfigMap()
     # Generate cluster ha node file with type ha_node in "node-info" folder
     cluster_ha_node_file="$node_info_folder/cluster-ha-node.yaml"
     cp "$cfgmap_path/templates/cluster-node-template.yaml" $cluster_ha_node_file
-    ./parse_scripts/subst.sh $cluster_ha_node_file "cortx.node.name" "cortx-ha-headless-svc"
+    ./parse_scripts/subst.sh $cluster_ha_node_file "cortx.node.name" "cortx-ha"
     uuid_str=$(UUID=$(uuidgen); echo ${UUID//-/})
     ./parse_scripts/subst.sh $cluster_ha_node_file "cortx.pod.uuid" "$uuid_str"
-    ./parse_scripts/subst.sh $cluster_ha_node_file "cortx.svc.name" "cortx-ha-headless-svc"
+    ./parse_scripts/subst.sh $cluster_ha_node_file "cortx.svc.name" "cortx-ha"
     ./parse_scripts/subst.sh $cluster_ha_node_file "cortx.node.type" "ha_node"
     # Create HA machine id file
     auto_gen_ha_path="$cfgmap_path/auto-gen-ha-$namespace"

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -660,10 +660,10 @@ function deployCortxConfigMap()
     # Generate node file with type control_node in "node-info" folder
     new_gen_file="$node_info_folder/cluster-control-node.yaml"
     cp "$cfgmap_path/templates/cluster-node-template.yaml" $new_gen_file
-    ./parse_scripts/subst.sh $new_gen_file "cortx.node.name" "cortx-control-headless-svc"
+    ./parse_scripts/subst.sh $new_gen_file "cortx.node.name" "cortx-control"
     uuid_str=$(UUID=$(uuidgen); echo ${UUID//-/})
     ./parse_scripts/subst.sh $new_gen_file "cortx.pod.uuid" "$uuid_str"
-    ./parse_scripts/subst.sh $new_gen_file "cortx.svc.name" "cortx-control-headless-svc"
+    ./parse_scripts/subst.sh $new_gen_file "cortx.svc.name" "cortx-control"
     ./parse_scripts/subst.sh $new_gen_file "cortx.node.type" "control_node"
 
     # Create control machine id file
@@ -950,8 +950,6 @@ function deployCortxControl()
     helm install "cortx-control-$namespace" cortx-cloud-helm-pkg/cortx-control \
         --set cortxcontrol.name="cortx-control" \
         --set cortxcontrol.image=$cortxcontrol_image \
-        --set cortxcontrol.service.clusterip.name="cortx-control-clusterip-svc" \
-        --set cortxcontrol.service.headless.name="cortx-control-headless-svc" \
         --set cortxcontrol.service.loadbal.name="cortx-control-loadbal-svc" \
         --set cortxcontrol.service.loadbal.type="$external_services_type" \
         --set cortxcontrol.cfgmap.mountpath="/etc/cortx/solution" \


### PR DESCRIPTION
The primary change here is removing the cortx-control-headless-svc and cortx-control-clusterip-svc services.

While making this change, I noticed that all cortx pods were using the same "headless-svc" name as the hostname of the containers.  This strikes me as odd, so I changed the hostname to avoid using "headless-svc".