### PR TITLE
EOS-27546: Silence 'Defaulting container name' log collection messages

### DIFF
--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -85,14 +85,16 @@ function savePodDetail()
 function getInnerLogs()
 {
   local pod="$1"
+  local container_arg=()
+  [[ -n $2 ]] && container_arg+=(--container "$2")
   local path="/var/cortx/support_bundle"
   local name="bundle-logs-${pod}-${date}"
 
   printf "\n ⭐ Generating support-bundle logs for pod: %s\n" "${pod}"
-  kubectl exec "${pod}" --namespace="${namespace}" -- cortx_support_bundle generate --location file://${path} --bundle_id "${name}" --message "${name}"
-  kubectl cp "${pod}":"${path}/${name}" "${logs_folder}/${name}"
+  kubectl exec "${pod}" "${container_arg[@]}" --namespace="${namespace}" -- cortx_support_bundle generate --location file://${path} --bundle_id "${name}" --message "${name}"
+  kubectl cp "${pod}:${path}/${name}" "${logs_folder}/${name}" "${container_arg[@]}" --namespace="${namespace}"
   tar --append --file "${logs_folder}.tar" "${logs_folder}/${name}"
-  kubectl exec "${pod}" --namespace="${namespace}" -- bash -c "rm -rf ${path}"
+  kubectl exec "${pod}" "${container_arg[@]}" --namespace="${namespace}" -- bash -c "rm -rf ${path}"
 }
 
 while IFS= read -r line; do
@@ -116,7 +118,7 @@ while IFS= read -r line; do
           saveLogs $pod "${item}"
         done
         savePodDetail $pod
-        getInnerLogs $pod
+        getInnerLogs "${pod[0]}" "${containers[0]}"
         ;;
       *)
         saveLogs $pod


### PR DESCRIPTION
When `kubectl exec` or `kubectl cp` are used without a container name, a
warning is printed and the first container is used automatically. This
is fine but the warnings might confuse the status of the results so we
prefer to avoid them.

For support bundle generation, any of the pod's containers are a valid
selection, so use the first one listed.

Note that for kubectl v1.21+, the
`kubectl.kubernetes.io/default-container` annotation could be used to
select a default container, thus avoiding any special logic to pick a
container.

Signed-off-by: Keith Pine <keith.pine@seagate.com>