### PR TITLE
EOS-28022: Support default IAM configuration fields

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/config-template.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/config-template.yaml
@@ -40,7 +40,10 @@ cortx:
       device_certificate: /etc/cortx/solution/ssl/stx.pem
   utils:
     message_bus_backend: kafka
-  s3:
+  rgw:
+    auth_user: <<.Values.cortx.rgw.auth_user>>
+    auth_admin: <<.Values.cortx.rgw.auth_admin>>
+    auth_secret: s3_default_iam_secret_key
     iam:
       endpoints:
       - https://<<.Values.cortx.io.svc>>:9443

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -611,13 +611,22 @@ function deployCortxConfigMap()
         ./parse_scripts/subst.sh $new_gen_file "cortx.external.openldap.endpoints" $openldap_endpoint
         ./parse_scripts/yaml_insert_block.sh $new_gen_file "$openldap_servers" 8 "cortx.external.openldap.servers"
         ./parse_scripts/subst.sh $new_gen_file "cortx.external.consul.endpoints" $consul_endpoint
+
+        # RGW / S3 configuration
+        ./parse_scripts/subst.sh $new_gen_file "cortx.rgw.auth_user" $(extractBlock 'solution.common.s3.default_iam_user.name')
+        ./parse_scripts/subst.sh $new_gen_file "cortx.rgw.auth_admin" $(extractBlock 'solution.common.s3.default_iam_user.access_key')
         ./parse_scripts/subst.sh $new_gen_file "cortx.io.svc" "cortx-io-svc"
         ./parse_scripts/subst.sh $new_gen_file "cortx.num_s3_inst" $(extractBlock 'solution.common.s3.num_inst')
         ./parse_scripts/subst.sh $new_gen_file "cortx.max_start_timeout" $(extractBlock 'solution.common.s3.max_start_timeout')
+
+        # Motr configuration
         ./parse_scripts/subst.sh $new_gen_file "cortx.num_motr_inst" $(extractBlock 'solution.common.motr.num_client_inst')
+
+        # Common storage configration
         ./parse_scripts/subst.sh $new_gen_file "cortx.common.storage.local" $local_storage
         ./parse_scripts/subst.sh $new_gen_file "cortx.common.storage.shared" $shared_storage
         ./parse_scripts/subst.sh $new_gen_file "cortx.common.storage.log" $log_storage
+
 
         image=$(parseSolution 'solution.images.cortxdata')
         image=$(echo $image | cut -f2 -d'>')
@@ -886,6 +895,7 @@ function deployCortxSecrets()
         printf "$secret_fname" >> $server_secret_path
         printf "$secret_fname" >> $ha_secret_path
     done
+
 }
 
 function silentKill()

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -10,6 +10,7 @@ solution:
       s3_auth_admin_secret: ldapadmin
       csm_auth_admin_secret: seagate2
       csm_mgmt_admin_secret: Cortxadmin@123
+      s3_default_iam_secret_key: cortx_default_secret
   images:
     cortxcontrolprov: ghcr.io/seagate/cortx-all:2.0.0-624-custom-ci
     cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-624-custom-ci
@@ -32,6 +33,10 @@ solution:
       shared: /share
       log: /etc/cortx/log
     s3:
+      default_iam_user:
+        name: cortxadmin
+        access_key: cortx_default_admin
+        #secret_key defined in solution->secrets as s3_default_iam_secret_key
       num_inst: 2
       start_port_num: 28051
       max_start_timeout: 240


### PR DESCRIPTION
New configuration fields in solution.yaml:

```yaml
solution:
  common:
    s3:
      default_iam_user:
```

Also new corresponding secret: `s3_default_iam_secret_key`

This also changes the "s3" section in config.yaml to "rgw"