### PR TITLE
EOS-27425: Distruptive container image upgrades

### DIFF
--- a/k8_cortx_cloud/upgrade-cortx-cloud.sh
+++ b/k8_cortx_cloud/upgrade-cortx-cloud.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trap 'handle_error "$?" "${BASH_COMMAND:-?}" "${FUNCNAME[0]:-main}(${BASH_SOURCE[0]:-?}:${LINENO:-?})"' ERR
+handle_error() {
+  printf "%s Unexpected error caught -- %s %s\n    at %s\n" "${RED-}✘${CLEAR-}" "$2" "${RED-}↩ $1${CLEAR-}" "$3" >&2
+  exit "$1"
+}
+
+SCRIPT=$(readlink -f "$0")
+DIR=$(dirname "${SCRIPT}")
+SCRIPT_NAME=$(basename "${SCRIPT}")
+PIDFILE=/tmp/${SCRIPT_NAME}.pid
+
+readonly SCRIPT
+readonly DIR
+readonly SCRIPT_NAME
+readonly PIDFILE
+
+if [[ -t 1 ]]; then
+    RED=$(tput setaf 1 || true)
+    GREEN=$(tput setaf 2 || true)
+    CYAN=$(tput setaf 6 || true)
+    CLEAR=$(tput sgr0 || true)
+else
+    RED=
+    GREEN=
+    CYAN=
+    CLEAR=
+fi
+
+readonly RED
+readonly GREEN
+readonly CYAN
+readonly CLEAR
+
+# Use a PID file to prevent concurrent upgrades.
+if [[ -s ${PIDFILE} ]]; then
+   echo "An upgrade is already in progress (PID $(< "${PIDFILE}")). If this is incorrect, remove file ${PIDFILE} and try again."
+   exit 1
+fi
+printf "%s" $$ > "${PIDFILE}"
+trap 'rm -f "${PIDFILE}"' EXIT
+
+function usage() {
+    cat << EOF
+
+Usage:
+    ${SCRIPT_NAME} -i IMAGE [-s SOLUTION_CONFIG_FILE]
+    ${SCRIPT_NAME} -h
+
+Options:
+    -h              Prints help information.
+    -i <IMAGE>      REQUIRED. The name of the container image to upgrade to.
+    -s <FILE>       The cluster solution configuration file. Can
+                    also be set with the CORTX_SOLUTION_CONFIG_FILE
+                    environment variable. Defaults to 'solution.yaml'.
+EOF
+}
+
+function parse_solution() {
+  "${DIR}/parse_scripts/parse_yaml.sh" "${SOLUTION_FILE}" "$1"
+}
+
+UPGRADE_IMAGE=
+SOLUTION_FILE="${CORTX_SOLUTION_CONFIG_FILE:-solution.yaml}"
+
+while getopts hi:s: opt; do
+    case ${opt} in
+        h )
+            printf "%s\n" "${SCRIPT_NAME}"
+            usage
+            exit 0
+            ;;
+        i ) UPGRADE_IMAGE=${OPTARG} ;;
+        s ) SOLUTION_FILE=${OPTARG} ;;
+        * )
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+readonly UPGRADE_IMAGE
+readonly SOLUTION_FILE
+
+if [[ -z ${UPGRADE_IMAGE} ]]; then
+    printf "\nERROR: Required option IMAGE is missing.\n"
+    usage
+    exit 1
+fi
+
+if [[ -z ${SOLUTION_FILE} ]]; then
+    printf "\nERROR: Required option SOLUTION_CONFIG_FILE is missing.\n"
+    usage
+    exit 1
+fi
+
+if [[ ! -s ${SOLUTION_FILE} ]]; then
+    printf "\nERROR: SOLUTION_CONFIG_FILE '%s' does not exist or is empty.\n" "${SOLUTION_FILE}"
+    exit 1
+fi
+
+NAMESPACE=$(parse_solution 'solution.namespace' | cut -f2 -d'>')
+if [[ -z ${NAMESPACE} ]]; then
+    printf "\nERROR: Required field 'solution.namespace' not found in SOLUTION_CONFIG_FILE '%s'.\n" "${SOLUTION_FILE}"
+    exit 1
+fi
+
+printf "Using solution config file '%s'\n" "${SOLUTION_FILE}"
+
+# Validate if All Pods are running
+pods_ready=true
+
+readonly cortx_pod_filter="cortx-control-\|cortx-data-\|cortx-ha-\|cortx-server-\|cortx-client-"
+readonly cortx_deployment_filter="cortx-control\|cortx-data-\|cortx-ha\|cortx-server-\|cortx-client-"
+
+printf "\n%s\n" "${CYAN-}Checking Pod readiness:${CLEAR-}"
+
+cortx_pods="$(kubectl get pods --namespace="${NAMESPACE}" | { grep "${cortx_pod_filter}" || true; })"
+if [[ -z ${cortx_pods} ]]; then
+    printf "  no CORTX Pods were found, proceeding with image upgrade anyways\n"
+else
+    while IFS= read -r line; do
+        IFS=" " read -r -a pod_info <<< "${line}"
+        IFS="/" read -r -a ready_counts <<< "${pod_info[1]}"
+        pod_name="${pod_info[0]}"
+        pod_status="${pod_info[2]}"
+        ready_count="${ready_counts[0]}"
+        total_count="${ready_counts[1]}"
+        if [[ -n ${pod_name} ]]; then
+            if [[ ${pod_status} != "Running" ]]; then
+                printf "  %s %s -> status is %s\n" "${RED}✘${CLEAR}" "${pod_name}" "${pod_status}"
+                pods_ready=false
+            elif (( ready_count != total_count )); then
+                printf "  %s %s -> only %s/%s pods are ready\n" "${RED}✘${CLEAR}" "${pod_name}" "${ready_count}" "${total_count}"
+                pods_ready=false
+            else
+                printf "  %s %s\n" "${GREEN}✓${CLEAR}" "${pod_name}"
+            fi
+        fi
+    done <<< "${cortx_pods}"
+fi
+printf "\n"
+
+if [[ ${pods_ready} == false ]]; then
+    printf "Pre-upgrade pod readiness check failed. Ensure all pods are in a healthy state, or manually shutdown the cluster, and try again.\n"
+    exit 1
+fi
+
+# Shutdown all CORTX Pods
+"${DIR}/shutdown-cortx-cloud.sh" "${SOLUTION_FILE}"
+
+cortx_deployments="$(kubectl get deployments --namespace="${NAMESPACE}" --output=jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}" | { grep "${cortx_deployment_filter}" || true; })"
+if [[ -z ${cortx_deployments} ]]; then
+    printf "No CORTX Deployments were found so the image upgrade cannot be performed. The cluster will be restarted.\n"
+else
+    printf "Updating CORTX Deployments to use image %s\n" "${UPGRADE_IMAGE}"
+    while IFS= read -r deployment; do
+        kubectl set image deployment "${deployment}" "*=${UPGRADE_IMAGE}"
+    done <<< "${cortx_deployments}"
+    printf "\n"
+fi
+
+# Start all CORTX Pods
+"${DIR}/start-cortx-cloud.sh" "${SOLUTION_FILE}"


### PR DESCRIPTION
Add a utility script to upgrade the container images used in a deployed CORTX cluster. This assumes the solution is the `cortx-all` images which are set uniformally for all containers, e.g. `cortx-all:2.0.0-624-custom-ci`.

Based on #77, this script scales down all the Pods to 0 replicas, updates all of the container images for each of the CORTX Deployments, and scales the Pods back to 1 replica. Scaling up and down are handled by existing scripts. No other upgrade logic is performed besides setting a new image.

We prefer to use Helm to manage all of this and keep a history of changes, but attempts to do so were not successul, so for now this approach is sufficient.

Note that this PR also introduces some improvements to how the solution config file is loaded. In order to discourage the use of the checked-in `solution.yaml` file, a file will be chosen based on the following priority:

1. A file provided with the `-s` command line option, e.g. `./upgrade-cortx-cloud.sh -s local.yaml ...`.
2. A file provided in environment variable `CORTX_SOLUTION_CONFIG_FILE`, e.g. `CORTX_SOLUTION_CONFIG_FILE=local.yaml ./upgrade-cortx-cloud.sh ...`.
3. No file provided, so the default is `solution.yaml`, e.g. `./upgrade-cortx-cloud.sh ...`.

The plan would be to implement the above behavior in the other scripts as well for consistency.

Signed-off-by: Keith Pine <keith.pine@seagate.com>