### PR TITLE
CORTX-28699: Update `cortx_support_bundle` command for log collection

### DIFF
--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -91,7 +91,12 @@ function getInnerLogs()
   local name="bundle-logs-${pod}-${date}"
 
   printf "\n ⭐ Generating support-bundle logs for pod: %s\n" "${pod}"
-  kubectl exec "${pod}" "${container_arg[@]}" --namespace="${namespace}" -- cortx_support_bundle generate --location file://${path} --bundle_id "${name}" --message "${name}"
+  kubectl exec "${pod}" "${container_arg[@]}" --namespace="${namespace}" -- \
+    cortx_support_bundle generate \
+      --cluster_conf_path yaml:///etc/cortx/cluster.conf \
+      --location file://${path} \
+      --bundle_id "${name}" \
+      --message "${name}"
   kubectl cp "${pod}:${path}/${name}" "${logs_folder}/${name}" "${container_arg[@]}" --namespace="${namespace}"
   tar --append --file "${logs_folder}.tar" "${logs_folder}/${name}"
   kubectl exec "${pod}" "${container_arg[@]}" --namespace="${namespace}" -- bash -c "rm -rf ${path}"


### PR DESCRIPTION
The `cortx_support_bundle generate` command was recently changed to require the `--cluster_conf_path` argument. Not specifying it results in a cryptic Python error. Previously we relied on the default being selected.

Update the container exec command to specify the argument as newly required.

This is confirmed to work using image `cortx-all:2.0.0-632-PI61.2`.