### PR TITLE
Fixing broken links and improving them

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ There are numerous ways to install and configure a complete Kubernetes cluster. 
 For reference material, we have provided existing Kubernetes deployment models that have been verified to work with CORTX on Kubernetes. These are only provided for reference and are not meant to be explicit deployment constraints.
 
 1.  [Seagate Internal Jenkins Job](http://eos-jenkins.mero.colo.seagate.com/job/Cortx-kubernetes/job/setup-kubernetes-cluster/)
-2.  [CORTX on AWS and Kubernetes - Quick Install Guide](https://github.com/Seagate/cortx-k8s/blob/main/doc/cortx-aws-k8s-installation.md)
-3.  [CORTX on Minikube - Quick Install Guide](https://github.com/Seagate/cortx-k8s/blob/main/doc/cortx-minikube-k8s-installation.md)
+2.  [CORTX on AWS and Kubernetes - Quick Install Guide](doc/cortx-aws-k8s-installation.md)
+3.  [CORTX on Minikube - Quick Install Guide](doc/cortx-minikube-k8s-installation.md)
 
 Should you have trouble deploying CORTX on Kubernetes to your Kubernetes cluster, please open an [Issue](https://github.com/Seagate/cortx-k8s/issues) in this repository for further troubleshooting.
 


### PR DESCRIPTION
First, the minikube link was 404. While fixing that I noticed that both links were using absolute paths. Relative are better because they resolve appropriately within a branch. Using an absolute link means you have to choose which branch and embed that in the URL.

Signed-off-by: John Bent <john.bent@seagate.com>

-----
[View rendered README.md](https://github.com/Seagate/cortx-k8s/blob/johnbent-patch-1/README.md)