### PR TITLE
CORTX-28899: Ability to create multiple LoadBalancer IO services

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
@@ -1,4 +1,5 @@
 {{- define "config.yaml" -}}
+{{- $ioSvcName := printf "%s-0" .Values.cortxIoServiceName -}}
 cortx:
   external:
     {{- if .Values.externalKafka.enabled }}
@@ -40,15 +41,15 @@ cortx:
   s3:                                                               # DEPRECATED - ENTIRE S3 KEY
     iam:
       endpoints:
-      - https://{{ .Values.cortxIoServiceName }}:9443
-      - http://{{ .Values.cortxIoServiceName }}:9080
+      - https://{{ $ioSvcName }}:9443
+      - http://{{ $ioSvcName }}:9080
     data:
       endpoints:
-      - http://{{ .Values.cortxIoServiceName }}:80
-      - https://{{ .Values.cortxIoServiceName }}:443
+      - http://{{ $ioSvcName }}:80
+      - https://{{ $ioSvcName }}:443
     internal:
       endpoints:
-      - http://{{ .Values.cortxIoServiceName }}:28049
+      - http://{{ $ioSvcName }}:28049
     {{- with .Values.cortxS3.instanceCount }}
     service_instances: {{ . | int }}
     {{- end }}
@@ -62,16 +63,16 @@ cortx:
   rgw:
     iam:                                                            # DEPRECATED - IAM KEY
       endpoints:
-      - https://{{ .Values.cortxIoServiceName }}:8443
-      - http://{{ .Values.cortxIoServiceName }}:8000
+      - https://{{ $ioSvcName }}:8443
+      - http://{{ $ioSvcName }}:8000
     data:
       endpoints:
-      - http://{{ .Values.cortxIoServiceName }}:8000
-      - https://{{ .Values.cortxIoServiceName }}:8443
+      - http://{{ $ioSvcName }}:8000
+      - https://{{ $ioSvcName }}:8443
     s3:
       endpoints:
-      - http://{{ .Values.cortxIoServiceName }}:8000
-      - https://{{ .Values.cortxIoServiceName }}:8443
+      - http://{{ $ioSvcName }}:8000
+      - https://{{ $ioSvcName }}:8443
     {{- with .Values.cortxS3.instanceCount }}
     service_instances: {{ . | int }}
     {{- end }}
@@ -154,7 +155,7 @@ cortx:
     email_address: cortx@seagate.com
     agent:
       endpoints:
-      - https://{{ .Values.cortxIoServiceName }}:8081
+      - https://{{ $ioSvcName }}:8081
     limits:
       services:
       - name: agent

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-io-svc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-io-svc.yaml
@@ -1,26 +1,32 @@
+{{- $svc := .Values.services.io -}}
+{{- $isLB := eq $svc.type "LoadBalancer" -}}
+{{- $nodePortAllowed := or (eq $svc.type "NodePort") $isLB -}}
+{{- $svcCount := ternary $svc.count 1 $isLB | int -}}
+{{- $root := . -}}
+{{- range $i := until $svcCount -}}
 apiVersion: v1
 kind: Service
-{{- $svc := .Values.services.io }}
 metadata:
-  name: {{ $svc.name }}
-  namespace: {{ .Values.namespace.name }}
+  name: {{ printf "%s-%d" $svc.name $i | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $root.Values.namespace.name }}
 spec:
   type: {{ $svc.type }}
   selector:
     cortx.io/service-type: "cortx-server"
   ports:
-    {{- $nodePortAllowed := or (eq $svc.type "NodePort") (eq $svc.type "LoadBalancer") }}
     - name: cortx-rgw-http
       protocol: TCP
       port: {{ $svc.ports.http }}
       targetPort: 8000
       {{- if and $nodePortAllowed (not (empty $svc.nodePorts.http)) }}
-      nodePort: {{ $svc.nodePorts.http }}
+      nodePort: {{ add $svc.nodePorts.http $i }}
       {{- end }}
     - name: cortx-rgw-https
       protocol: TCP
       port: {{ $svc.ports.https }}
       targetPort: 8443
       {{- if and $nodePortAllowed (not (empty $svc.nodePorts.https)) }}
-      nodePort: {{ $svc.nodePorts.https }}
+      nodePort: {{ add $svc.nodePorts.https $i }}
       {{- end }}
+---
+{{- end }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/values.yaml
@@ -54,6 +54,7 @@ services:
   io:
     name: cortx-io-svc
     type: ClusterIP
+    count: 1
     ports:
       http: 8000
       https: 8443

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -285,6 +285,7 @@ function deployKubernetesPrereqs()
     hax_service_name=$(getSolutionValue 'solution.common.hax.service_name')
     hax_service_port=$(getSolutionValue 'solution.common.hax.port_num')
     s3_service_type=$(getSolutionValue 'solution.common.external_services.s3.type')
+    s3_service_count=$(getSolutionValue 'solution.common.external_services.s3.count')
     s3_service_ports_http=$(getSolutionValue 'solution.common.external_services.s3.ports.http')
     s3_service_ports_https=$(getSolutionValue 'solution.common.external_services.s3.ports.https')
 
@@ -307,6 +308,7 @@ function deployKubernetesPrereqs()
         --set services.hax.name="${hax_service_name}" \
         --set services.hax.port="${hax_service_port}" \
         --set services.io.type="${s3_service_type}" \
+        --set services.io.count="${s3_service_count}" \
         --set services.io.ports.http="${s3_service_ports_http}" \
         --set services.io.ports.https="${s3_service_ports_https}" \
         "${optional_values[@]}" \

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -52,6 +52,7 @@ solution:
     external_services:
       s3:
         type: NodePort
+        count: 1
         ports:
           http: 8000
           https: 8443

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -51,6 +51,7 @@ solution:
     external_services:
       s3:
         type: NodePort
+        count: 1
         ports:
           http: 8000
           https: 8443

--- a/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
@@ -48,6 +48,7 @@ solution:
     external_services:
       s3:
         type: required
+        count: required
         ports:
           http: required
           https: required


### PR DESCRIPTION
The `solution.yaml` and platform Helm chart have been updated to support the ability to create multiple CORTX IO Services. This service provides access to the RGW servers for S3 IO. By default, only one service is created. Multiple services can be created for redundancy in a cloud environment.

- Multiple service instances are only supported for the `LoadBalancer` service type. Defining multiple `ClusterIP` or `NodePort` services doesn't provide any benefit, so those are fixed to a single instance.
- If custom nodePorts are configured, the first instance of the service will take the specified nodePort value, and the port number will be incremented for each additional service instance. The port numbers must not conflict else the deployment will fail.
- The service names are assigned based on the Chart value and a sequential incrementing number, e.g. `cortx-io-svc-0`, `cortx-io-svc-1`, ..., `cortx-io-svc-N`.

**Possible breaking changes**

- Solution configuration field `solution.common.external_services.s3.count` is required. Set to 1 for previous behavior.
- If you previously had a dependency on the service name, then you will need to update to use the generated number-based names instead, e.g. `cortx-io-svc-0` instead of `cortx-io-svc`.

**TODO**
The configmap (config.yaml) makes use of the service name. For now this is fixed to the singular `cortx-io-svc-0`. We need to understand what this value is being used for. For example, the CSM agent endpoint uses this name, which doesn't make much sense.

Signed-off-by: Keith Pine <keith.pine@seagate.com>