### PR TITLE
CORTX-28579:  Basic regression tests for cortx-k8s

### DIFF
--- a/test/regression/checker.py
+++ b/test/regression/checker.py
@@ -1,0 +1,85 @@
+###########################################################
+# checker.py
+#
+# Module to facilitate making specific pass/fail test points
+#
+# Usage:
+# * Create a Checker object.  (If a logger object is not provided
+#     one will be created.
+# * Use "test_pass" or "test_fail" methods to indicate a pass/fail
+# * Use "test" method to log a pass/fail based on the boolean/
+#     conditional that is passed in.
+# * Use "test_equal" to test if a test value is equal to the
+#     expected value.
+#
+# In all cases, the user must provide a message string that will
+# be logged with the result.
+#
+# At then end of a test program, call the result method to
+# print a summary of the results.
+# * Return value 1 indicates at least one test failure
+# * Return value 0 indicates pass
+#
+###########################################################
+
+from utils import Logger
+
+class Checker:
+
+    def __init__(self, logger=None):
+        if not logger:
+            logger = Logger()
+        self.logger = logger
+
+        self.count = 0
+        self.fails = []
+
+
+    def result(self):
+        if self.fails:
+            self.logger.logfail()
+            self.logger.logfail('F '*20)
+            self.logger.logfail(' F'*20)
+            self.logger.logfail()
+            self.logger.logfail('{0} of {1} tests failed'.format(len(self.fails), self.count).center(40))
+            self.logger.logfail()
+            for msg in self.fails:
+                self.logger.logfail('FAIL  ' + msg)
+            self.logger.logfail()
+
+            self.logger.logfail('F '*20)
+            self.logger.logfail(' F'*20)
+            self.logger.logfail()
+            return 1
+        else:
+            self.logger.log()
+            self.logger.logpass('*'*40)
+            self.logger.logpass('*' + ' '*38 + '*')
+            self.logger.logpass('*' + '{0} of {0} tests passed'.format(self.count).center(38) + '*')
+            self.logger.logpass('*' + ' '*38 + '*')
+            self.logger.logpass('*'*40)
+            self.logger.log()
+            return 0
+        
+
+    def test_pass(self, msg):
+        self.logger.logpass('PASS  ' + msg)
+        self.count += 1
+
+    def test_fail(self, msg):
+        self.logger.logfail('FAIL  ' + msg)
+        self.count += 1
+        self.fails.append(msg)
+
+    def test(self, condition, msg):
+        if condition:
+            self.test_pass(msg)
+        else:
+            self.test_fail(msg)
+
+    def test_equal(self, expected, actual, msg):
+        if expected == actual:
+            self.test_pass(msg)
+        else:
+            self.test_fail(msg + ('expected=%s, actual=%s'%(expected, actual)))
+

--- a/test/regression/checker.py
+++ b/test/regression/checker.py
@@ -27,6 +27,7 @@ from utils import Logger
 class Checker:
 
     def __init__(self, logger=None):
+        """Helper class to process pass/fail results."""
         if not logger:
             logger = Logger()
         self.logger = logger
@@ -60,7 +61,6 @@ class Checker:
             self.logger.logpass('*'*40)
             self.logger.log()
             return 0
-        
 
     def test_pass(self, msg):
         self.logger.logpass('PASS  ' + msg)

--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -179,7 +179,6 @@ class Cluster:
 
     def run_prereq(self):
         """Run prereq script on all nodes
-
         First copy the prereq script and solution file to the
         node.  Then run the script."""
 
@@ -262,7 +261,7 @@ class Cluster:
 
 class Client:
     def __init__(self, accesskey=None, endpoints=[], clientsvr=None):
-        """ Represents an S3 client."""
+        """Represents an S3 client."""
         self.accesskey = accesskey
         self.endpoints = endpoints
         if not isinstance(self.endpoints, list):

--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -134,7 +134,7 @@ class Cluster:
             # TODO: parameterize user
             user = 'root'
             node = self.cluster_data['nodes'][0]
-            stdout = subprocess.Popen(['ssh', f'{user}@{node}', f'lsblk {blkdev}'],
+            stdout = subprocess.Popen(['ssh', f'{user}@{node}', f'lsblk {blkdev}'], # nosec B602
                                       stdout=subprocess.PIPE).communicate()[0]
             for line in stdout.splitlines():
                 line = line.decode('utf-8')
@@ -181,7 +181,6 @@ class Cluster:
         """Run prereq script on all nodes
         First copy the prereq script and solution file to the
         node.  Then run the script."""
-
         if not self.cluster_data:
             print("Cannot run prereq-deploy-cortx-cloud.sh.  No cluster config file specified.")
             return
@@ -198,7 +197,7 @@ class Cluster:
                                    'prereq-deploy-cortx-cloud.sh')
                     ]
             print(f"------------- prereq {node} --------------\n")
-            result += RemoteRun(node, self.user).scp(files, '/tmp/cortx-k8s')
+            result += RemoteRun(node, self.user).scp(files, '/tmp/cortx-k8s') # nosec B108
             result += RemoteRun(node, self.user).run(
                                   f'cd /tmp/cortx-k8s; '
                                   f'./prereq-deploy-cortx-cloud.sh {blkdev} '
@@ -257,13 +256,3 @@ class Cluster:
                 result = 1
 
         return result
-
-
-class Client:
-    def __init__(self, accesskey=None, endpoints=[], clientsvr=None):
-        """Represents an S3 client."""
-        self.accesskey = accesskey
-        self.endpoints = endpoints
-        if not isinstance(self.endpoints, list):
-            self.endpoints = [self.endpoints]
-        self.clientsvr = clientsvr

--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -178,9 +178,9 @@ class Cluster:
                                             '../../k8_cortx_cloud'))
 
     def run_prereq(self):
-        """Run prereq script on all nodes
-        First copy the prereq script and solution file to the
-        node.  Then run the script."""
+        """Run prereq script on all nodes"""
+        #First copy the prereq script and solution file to the
+        #node.  Then run the script.
         if not self.cluster_data:
             print("Cannot run prereq-deploy-cortx-cloud.sh.  No cluster config file specified.")
             return

--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -9,7 +9,7 @@
 
 
 import os
-import subprocess
+import subprocess  # nosec
 from yaml import safe_load, dump
 
 import utils

--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -178,7 +178,7 @@ class Cluster:
                                             '../../k8_cortx_cloud'))
 
     def run_prereq(self):
-        """Run prereq script on all nodes"""
+        """Run prereq script on all nodes."""
         #First copy the prereq script and solution file to the
         #node.  Then run the script.
         if not self.cluster_data:

--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -19,8 +19,7 @@ from utils import RemoteRun, Logger
 class Cluster:
 
     def __init__(self, solution_file, cluster_file=None, logger=None, logdir=None):
-        """ Represents a CORTX cluster """
-
+        """Represents a CORTX cluster."""
         if cluster_file and cluster_file.lower() == 'none':
             # Special case -- this allows for the special name
             # of "none" for the cluster file to allow tests that
@@ -108,11 +107,13 @@ class Cluster:
         # Set cortx version
         #
         if cortx_ver:
-            image_url_base = 'ghcr.io/seagate/cortx-all'
             images = solution['solution']['images']
             for image in images:
-                if image.startswith('cortx'):
-                    images[image] = image_url_base + ':' + cortx_ver
+                if image == 'cortxserver':
+                    if 'cortx_rgw' in cortx_ver:
+                        images[image] = cortx_ver['cortx_rgw']
+                elif image.startswith('cortx'):
+                    images[image] = cortx_ver['cortx_all']
 
         #
         # Set nodes
@@ -203,6 +204,7 @@ class Cluster:
                                   f'cd /tmp/cortx-k8s; '
                                   f'./prereq-deploy-cortx-cloud.sh {blkdev} '
                                   f'{os.path.basename(self.solution_file)}')
+            result += RemoteRun(node, self.user).run('rm -rf /tmp/cortx-k8s')
             print("\n\n")
 
         return result
@@ -260,7 +262,7 @@ class Cluster:
 
 class Client:
     def __init__(self, accesskey=None, endpoints=[], clientsvr=None):
-        """ Represents an S3 client"""
+        """ Represents an S3 client."""
         self.accesskey = accesskey
         self.endpoints = endpoints
         if not isinstance(self.endpoints, list):

--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -1,0 +1,268 @@
+##################################################
+# cluster.py - Work In Progress
+#
+# Represents a CORTX cluster.
+#
+# This is used to facilitate test programming.
+#
+##################################################
+
+
+import os
+import subprocess
+from yaml import safe_load, dump
+
+import utils
+from utils import RemoteRun, Logger
+
+
+class Cluster:
+
+    def __init__(self, solution_file, cluster_file=None, logger=None, logdir=None):
+        """ Represents a CORTX cluster """
+
+        if cluster_file and cluster_file.lower() == 'none':
+            # Special case -- this allows for the special name
+            # of "none" for the cluster file to allow tests that
+            # require a cluster_file to use this value.
+            cluster_file = None
+
+        if not logger:
+            logger = Logger()
+        self.logger = logger
+
+        if not solution_file:
+            solution_file = os.environ.get('SOLUTION_FILE')
+            if solution_file:
+                print(f"Using SOLUTION_FILE {solution_file}")
+            else:
+                solution_file = os.path.relpath(os.path.join(
+                                           os.path.dirname(__file__),
+                                           '../../k8_cortx_cloud/solution.yaml'))
+                print(f"No solution file specified: using {solution_file}")
+
+        self.solution_file = solution_file
+        self.user = 'root'  # TODO: parameterize this
+
+        self.cluster_file = cluster_file
+        self.cluster_data = None
+        if self.cluster_file:
+            f = open(self.cluster_file)
+            self.cluster_data = safe_load(f)
+            f.close()
+
+            self._verify_cluster_yaml()
+            self.localfs = self.cluster_data['storage']['local-fs']
+
+            self.generate_solution_file()
+
+        solution = safe_load(open(self.solution_file))
+        nodes = solution['solution']['nodes']
+        self.nodes = [ nodes[n]['name'] for n in nodes ]
+
+
+    def _verify_cluster_yaml(self):
+        if not self.cluster_data['nodes']:
+            raise ValueError(f"Error in {self.cluster_file}: "
+                             "'nodes' not present")
+        if not isinstance(self.cluster_data['nodes'], list):
+            raise ValueError(f"Error in {self.cluster_file}: "
+                             "'nodes' must be a list of hostnames")
+        if not self.cluster_data['storage']:
+            raise ValueError(f"Error in {self.cluster_file}: "
+                             "'storage' not present")
+
+        # TODO: check the structure of 'storage'
+        fail = False
+        for node in self.cluster_data['nodes']:
+            self.logger.log(f'Testing remote access to {self.user}@{node}')
+            try:
+                RemoteRun(node, self.user).test()
+            except AssertionError:
+                self.logger.logfail(f'Cannot remote access {self.user}@{node}')
+                fail = True
+
+        if fail:
+            raise AssertionError('Cannot ssh to one or more nodes.')
+
+    def generate_solution_file(self):
+
+        cortx_ver = self.cluster_data.get('cortx_ver')
+        setup_size = self.cluster_data.get('setup_size')
+        generated_solution = self.cluster_data.get('generated_solution')
+
+        if not generated_solution:
+            self.logger.log("'generated_solution' field not in cluster config "
+                            "file.  No new solution will be generated'")
+            return
+
+        solution = safe_load(open(self.solution_file))
+
+        #
+        # Set setup_size
+        #
+        if setup_size:
+            solution['solution']['common']['setup_size'] = setup_size
+
+        #
+        # Set cortx version
+        #
+        if cortx_ver:
+            image_url_base = 'ghcr.io/seagate/cortx-all'
+            images = solution['solution']['images']
+            for image in images:
+                if image.startswith('cortx'):
+                    images[image] = image_url_base + ':' + cortx_ver
+
+        #
+        # Set nodes
+        #
+        i = 1
+        nodes = {}
+        for node in self.cluster_data['nodes']:
+            nodekey = f'node{i}'
+            nodes[nodekey] = {'name': node}
+            i += 1
+        solution['solution']['nodes'] = nodes
+
+        #
+        # Set storage
+        #
+
+        def get_device_size(blkdev):
+            # TODO: parameterize user
+            user = 'root'
+            node = self.cluster_data['nodes'][0]
+            stdout = subprocess.Popen(['ssh', f'{user}@{node}', f'lsblk {blkdev}'],
+                                      stdout=subprocess.PIPE).communicate()[0]
+            for line in stdout.splitlines():
+                line = line.decode('utf-8')
+                if line.startswith('NAME'):
+                    continue
+                size = line.split()[3]
+                return size
+
+        solution_storage = {}
+        cluster_storage = self.cluster_data.get('storage')
+
+        for cvg in cluster_storage:
+            if cvg == 'local-fs':
+                continue
+
+            solution_storage[cvg] = {'name': cvg, 'type': 'ios', 'devices': {}}
+            device = solution_storage[cvg]['devices']
+
+            metablk = cluster_storage[cvg]['metadata']
+            metasize = get_device_size(metablk)
+            device['metadata'] = {'device': metablk, 'size': metasize}
+
+            device['data'] = {}
+            i = 1
+            for datablk in cluster_storage[cvg]['data']:
+                datasize = get_device_size(datablk)
+                device['data'][f'd{i}'] = {'device': datablk, 'size': datasize}
+                i += 1
+        solution['solution']['storage'] = solution_storage
+
+        print("Writing generated solution file: " + generated_solution)
+        f = open(generated_solution, 'w')
+        dump(solution, f)
+        f.close()
+
+        self.solution_file = generated_solution
+
+    @staticmethod
+    def _get_k8_cortx_cloud_dir():
+        return os.path.relpath(os.path.join(os.path.dirname(__file__),
+                                            '../../k8_cortx_cloud'))
+
+    def run_prereq(self):
+        """Run prereq script on all nodes
+
+        First copy the prereq script and solution file to the
+        node.  Then run the script."""
+
+        if not self.cluster_data:
+            print("Cannot run prereq-deploy-cortx-cloud.sh.  No cluster config file specified.")
+            return
+
+        blkdev = self.localfs
+        result = 0
+
+        print("\nRunning prereq-deploy-cortx-cloud.sh\n")
+
+        for node in self.nodes:
+            files = [
+                      self.solution_file,
+                      os.path.join(self._get_k8_cortx_cloud_dir(),
+                                   'prereq-deploy-cortx-cloud.sh')
+                    ]
+            print(f"------------- prereq {node} --------------\n")
+            result += RemoteRun(node, self.user).scp(files, '/tmp/cortx-k8s')
+            result += RemoteRun(node, self.user).run(
+                                  f'cd /tmp/cortx-k8s; '
+                                  f'./prereq-deploy-cortx-cloud.sh {blkdev} '
+                                  f'{os.path.basename(self.solution_file)}')
+            print("\n\n")
+
+        return result
+
+    def deploy(self):
+        cmd = ['./deploy-cortx-cloud.sh', os.path.abspath(self.solution_file)]
+        result = utils.run(cmd, cwd=self._get_k8_cortx_cloud_dir())
+        if result != 0:
+            print("\nDeploy FAILED!\n")
+        return result
+
+    def destroy(self):
+        cmd = ['./destroy-cortx-cloud.sh', os.path.abspath(self.solution_file)]
+        result = utils.run(cmd, cwd=self._get_k8_cortx_cloud_dir())
+        if result != 0:
+            print("\nDestroy FAILED!\n")
+        return result
+
+    def shutdown(self):
+        cmd = ['./shutdown-cortx-cloud.sh', os.path.abspath(self.solution_file)]
+        result = utils.run(cmd, cwd=self._get_k8_cortx_cloud_dir())
+        if result != 0:
+            print("\nShutdown FAILED!\n")
+        return result
+
+    def start(self):
+        cmd = ['./start-cortx-cloud.sh', os.path.abspath(self.solution_file)]
+        result = utils.run(cmd, cwd=self._get_k8_cortx_cloud_dir())
+        if result != 0:
+            print("\nStart FAILED!\n")
+        return result
+
+    def status(self):
+        cmd = ['./status-cortx-cloud.sh', os.path.abspath(self.solution_file)]
+        result, stdout = utils.run(cmd, cwd=self._get_k8_cortx_cloud_dir(),
+                                   return_stdout=True)
+        # Scan stdout for anything but PASS
+        numfails = False
+        for line in stdout.splitlines():
+            if 'STATUS' not in line:
+                continue
+            if 'PASSED' not in line:
+                numfails += 1
+
+        if result != 0 or numfails != 0:
+            print(f"\nStatus FAILED!  {numfails} failed checks.\n")
+
+            # This is a workaround until status-cortx-cloud.sh returns
+            # a valid return value.  (Currently it always returns 0.)
+            if result == 0:
+                result = 1
+
+        return result
+
+
+class Client:
+    def __init__(self, accesskey=None, endpoints=[], clientsvr=None):
+        """ Represents an S3 client"""
+        self.accesskey = accesskey
+        self.endpoints = endpoints
+        if not isinstance(self.endpoints, list):
+            self.endpoints = [self.endpoints]
+        self.clientsvr = clientsvr

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -6,25 +6,25 @@ template files are functioning as expected.  These tests are not
 comprehensive CORTX system tests.
 
 ## Test Pre-Requisites
-  * Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
-  * There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
+*  Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
+*  There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
 
 ## Test Configuration
 There is a file in this directory called `example_config.yaml`.  This defines customizations
 over the standard `k8s_cortx_cloud/solution.yaml`.  Copy this file and customize it to
 describe your desired CORTX cluster:
 
-  * **nodes:** The list of hostnames CORTX should be deployed on
-  * **storage:** The description of the storage to be used.
+*  **nodes:** The list of hostnames CORTX should be deployed on
+*  **storage:** The description of the storage to be used.
 
-    * Note: The storage configuration must be identical for all CORTX nodes
-    * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
-    * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
+  *  Note: The storage configuration must be identical for all CORTX nodes
+  *  local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
+  *  cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
 
-      * metadata: Device that stores metadata (there may be only one per cvg in this format)
-      * data: List of devices that store data
+    *  metadata: Device that stores metadata (there may be only one per cvg in this format)
+    *  data: List of devices that store data
 
-  * See `example_config.yaml` for other configuration options
+*  See `example_config.yaml` for other configuration options
 
 The test framework uses this file as input and generates a solution.yaml file based on the
 default `k8_cortx_cloud/solution.yaml` file.
@@ -35,5 +35,5 @@ To run all deploy tests:
 ./testrunner.py -c myconf.conf -t testlists/deploy.yaml
 ```
 Where:
-  * `-c` specifies your [test configuration](#test-configuration)
-  * `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)
+*  `-c` specifies your [test configuration](#test-configuration)
+*  `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -6,8 +6,8 @@ template files are functioning as expected.  These tests are not
 comprehensive CORTX system tests.
 
 ## Test Pre-Requisites
-*  Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
-*  There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
+*    Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
+*    There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
 
 ## Test Configuration
 There is a file in this directory called `example_config.yaml`.  This defines customizations

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -16,14 +16,11 @@ describe your desired CORTX cluster:
 
 * **nodes:** The list of hostnames CORTX should be deployed on
 * **storage:** The description of the storage to be used.
-
   * Note: The storage configuration must be identical for all CORTX nodes
   * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
   * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
-
     * metadata: Device that stores metadata (there may be only one per cvg in this format)
     * data: List of devices that store data
-
 * See `example_config.yaml` for other configuration options
 
 The test framework uses this file as input and generates a solution.yaml file based on the

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -6,25 +6,25 @@ template files are functioning as expected.  These tests are not
 comprehensive CORTX system tests.
 
 ## Test Pre-Requisites
-*    Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
-*    There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
+* Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
+* There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
 
 ## Test Configuration
 There is a file in this directory called `example_config.yaml`.  This defines customizations
 over the standard `k8s_cortx_cloud/solution.yaml`.  Copy this file and customize it to
 describe your desired CORTX cluster:
 
-*    **nodes:** The list of hostnames CORTX should be deployed on
-*    **storage:** The description of the storage to be used.
+* **nodes:** The list of hostnames CORTX should be deployed on
+* **storage:** The description of the storage to be used.
 
-  *    Note: The storage configuration must be identical for all CORTX nodes
-  *    local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
-  *    cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
+  * Note: The storage configuration must be identical for all CORTX nodes
+  * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
+  * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
 
-    *    metadata: Device that stores metadata (there may be only one per cvg in this format)
-    *    data: List of devices that store data
+    * metadata: Device that stores metadata (there may be only one per cvg in this format)
+    * data: List of devices that store data
 
-*    See `example_config.yaml` for other configuration options
+* See `example_config.yaml` for other configuration options
 
 The test framework uses this file as input and generates a solution.yaml file based on the
 default `k8_cortx_cloud/solution.yaml` file.
@@ -35,5 +35,5 @@ To run all deploy tests:
 ./testrunner.py -c myconf.conf -t testlists/deploy.yaml
 ```
 Where:
-*    `-c` specifies your [test configuration](#test-configuration)
-*    `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)
+* `-c` specifies your [test configuration](#test-configuration)
+* `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -6,26 +6,22 @@ template files are functioning as expected.  These tests are not
 comprehensive CORTX system tests.
 
 ## Test Pre-Requisites
-  * Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
-  * There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
+* Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
+* There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
 
 ## Test Configuration
 There is a file in this directory called `example_config.yaml`.  This defines customizations
 over the standard `k8s_cortx_cloud/solution.yaml`.  Copy this file and customize it to
 describe your desired CORTX cluster:
 
-  * **nodes:** The list of hostnames CORTX should be deployed on
-
-  * **storage:** The description of the storage to be used.
-
-    * Note: The storage configuration must be identical for all CORTX nodes
-    * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
-    * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
-
-      * metadata: Device that stores metadata (there may be only one per cvg in this format)
-      * data: List of devices that store data
-
-  * See `example_config.yaml` for other configuration options
+* **nodes:** The list of hostnames CORTX should be deployed on
+* **storage:** The description of the storage to be used.
+  * Note: The storage configuration must be identical for all CORTX nodes
+  * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
+  * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
+    * metadata: Device that stores metadata (there may be only one per cvg in this format)
+    * data: List of devices that store data
+* See `example_config.yaml` for other configuration options
 
 The test framework uses this file as input and generates a solution.yaml file based on the
 default `k8_cortx_cloud/solution.yaml` file.
@@ -36,5 +32,5 @@ To run all deploy tests:
 ./testrunner.py -c myconf.conf -t testlists/deploy.yaml
 ```
 Where:
-  * -c specifies your [test configuration](#test-configuration)
-  * -t specifies the test list to run.  (Currently only `deploy.yaml` is supported.)
+* `-c` specifies your [test configuration](#test-configuration)
+* `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -25,7 +25,6 @@ describe your desired CORTX cluster:
   * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
 
     * metadata: Device that stores metadata (there may be only one per cvg in this format)
-
     * data: List of devices that store data
 
 * See `example_config.yaml` for other configuration options

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -14,17 +14,17 @@ There is a file in this directory called `example_config.yaml`.  This defines cu
 over the standard `k8s_cortx_cloud/solution.yaml`.  Copy this file and customize it to
 describe your desired CORTX cluster:
 
-*  **nodes:** The list of hostnames CORTX should be deployed on
-*  **storage:** The description of the storage to be used.
+*    **nodes:** The list of hostnames CORTX should be deployed on
+*    **storage:** The description of the storage to be used.
 
-  *  Note: The storage configuration must be identical for all CORTX nodes
-  *  local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
-  *  cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
+  *    Note: The storage configuration must be identical for all CORTX nodes
+  *    local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
+  *    cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
 
-    *  metadata: Device that stores metadata (there may be only one per cvg in this format)
-    *  data: List of devices that store data
+    *    metadata: Device that stores metadata (there may be only one per cvg in this format)
+    *    data: List of devices that store data
 
-*  See `example_config.yaml` for other configuration options
+*    See `example_config.yaml` for other configuration options
 
 The test framework uses this file as input and generates a solution.yaml file based on the
 default `k8_cortx_cloud/solution.yaml` file.
@@ -35,5 +35,5 @@ To run all deploy tests:
 ./testrunner.py -c myconf.conf -t testlists/deploy.yaml
 ```
 Where:
-*  `-c` specifies your [test configuration](#test-configuration)
-*  `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)
+*    `-c` specifies your [test configuration](#test-configuration)
+*    `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -6,31 +6,34 @@ template files are functioning as expected.  These tests are not
 comprehensive CORTX system tests.
 
 ## Test Pre-Requisites
-* Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
-* There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
+  * Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
+  * There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
 
 ## Test Configuration
 There is a file in this directory called `example_config.yaml`.  This defines customizations
 over the standard `k8s_cortx_cloud/solution.yaml`.  Copy this file and customize it to
 describe your desired CORTX cluster:
 
-* **nodes:** The list of hostnames CORTX should be deployed on
-* **storage:** The description of the storage to be used.
-  * Note: The storage configuration must be identical for all CORTX nodes
-  * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
-  * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
-    * metadata: Device that stores metadata (there may be only one per cvg in this format)
-    * data: List of devices that store data
-* See `example_config.yaml` for other configuration options
+  * **nodes:** The list of hostnames CORTX should be deployed on
+  * **storage:** The description of the storage to be used.
+
+    * Note: The storage configuration must be identical for all CORTX nodes
+    * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
+    * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
+
+      * metadata: Device that stores metadata (there may be only one per cvg in this format)
+      * data: List of devices that store data
+
+  * See `example_config.yaml` for other configuration options
 
 The test framework uses this file as input and generates a solution.yaml file based on the
 default `k8_cortx_cloud/solution.yaml` file.
 
 ## Run the Tests
 To run all deploy tests:
-```
+```text
 ./testrunner.py -c myconf.conf -t testlists/deploy.yaml
 ```
 Where:
-* `-c` specifies your [test configuration](#test-configuration)
-* `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)
+  * `-c` specifies your [test configuration](#test-configuration)
+  * `-t` specifies the test list to run.  (Currently only `deploy.yaml` is supported.)

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -15,12 +15,19 @@ over the standard `k8s_cortx_cloud/solution.yaml`.  Copy this file and customize
 describe your desired CORTX cluster:
 
 * **nodes:** The list of hostnames CORTX should be deployed on
+
 * **storage:** The description of the storage to be used.
+
   * Note: The storage configuration must be identical for all CORTX nodes
+
   * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
+
   * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
+
     * metadata: Device that stores metadata (there may be only one per cvg in this format)
+
     * data: List of devices that store data
+
 * See `example_config.yaml` for other configuration options
 
 The test framework uses this file as input and generates a solution.yaml file based on the

--- a/test/regression/cortx-k8s-tests.md
+++ b/test/regression/cortx-k8s-tests.md
@@ -1,0 +1,40 @@
+# CORTX-K8s Regression Tests
+
+## Purpose
+CORTX-K8s regression tests are designed to verify that scripts and
+template files are functioning as expected.  These tests are not
+comprehensive CORTX system tests.
+
+## Test Pre-Requisites
+  * Your system has kubectl access to an existing Kubernetes cluster that meets CORTX requirements.
+  * There is no existing CORTX cluster running.  (The tests assume that a new CORTX cluster can be deployed.)
+
+## Test Configuration
+There is a file in this directory called `example_config.yaml`.  This defines customizations
+over the standard `k8s_cortx_cloud/solution.yaml`.  Copy this file and customize it to
+describe your desired CORTX cluster:
+
+  * **nodes:** The list of hostnames CORTX should be deployed on
+
+  * **storage:** The description of the storage to be used.
+
+    * Note: The storage configuration must be identical for all CORTX nodes
+    * local-fs: Path to the devices used for local storage.  This will be formatted as a file system on each node.
+    * cvg1, cvg2, etc: Definitions of the one or more CVGs.  Each has the following two fields:
+
+      * metadata: Device that stores metadata (there may be only one per cvg in this format)
+      * data: List of devices that store data
+
+  * See `example_config.yaml` for other configuration options
+
+The test framework uses this file as input and generates a solution.yaml file based on the
+default `k8_cortx_cloud/solution.yaml` file.
+
+## Run the Tests
+To run all deploy tests:
+```
+./testrunner.py -c myconf.conf -t testlists/deploy.yaml
+```
+Where:
+  * -c specifies your [test configuration](#test-configuration)
+  * -t specifies the test list to run.  (Currently only `deploy.yaml` is supported.)

--- a/test/regression/deploy.py
+++ b/test/regression/deploy.py
@@ -17,5 +17,5 @@ if __name__ == "__main__":
         if result != 0:
             sys.exit(1)
 
-    result = cluster.deploy()
-    sys.exit(result)
+    #result = cluster.deploy()
+    #sys.exit(result)

--- a/test/regression/deploy.py
+++ b/test/regression/deploy.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import argparse
+import sys
+
+from cluster import Cluster
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', dest='solution')
+    parser.add_argument('-c', dest='cluster')
+    args = parser.parse_args()
+
+    cluster = Cluster(args.solution, args.cluster)
+    if args.cluster:
+        result = cluster.run_prereq()
+        if result != 0:
+            sys.exit(1)
+
+    result = cluster.deploy()
+    sys.exit(result)

--- a/test/regression/destroy.py
+++ b/test/regression/destroy.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+import argparse
+import sys
+
+from cluster import Cluster
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', dest='solution')
+    parser.add_argument('-c', dest='cluster')
+    args = parser.parse_args()
+
+    cluster = Cluster(args.solution, args.cluster)
+    result = cluster.destroy()
+    sys.exit(result)

--- a/test/regression/example_config.yaml
+++ b/test/regression/example_config.yaml
@@ -1,0 +1,39 @@
+###################################################
+#
+# k8s-cluster.yaml
+#
+# cluster configuration file for k8s tools
+#
+###################################################
+
+
+# Name of the solution.yaml file that will be generated
+# (relative to cwd)
+generated_solution: /tmp/mysolution.yaml
+
+# Version of cortx-all to use
+# If omitted then the version specified in the
+# default solution.yaml file is used
+#cortx_ver:  2.0.0-latest-custom-ci
+
+
+setup_size: small
+
+
+# Nodes in k8s cluster
+nodes:
+  - node1.example.com
+  - node2.example.com
+  - node3.example.com
+
+
+# Block devs to use
+storage:
+  local-fs: /dev/sdb
+  cvg1:
+    # Note: only one dev for metadata is supported per cvg
+    metadata: /dev/sdc
+    data:
+      - /dev/sdd
+      - /dev/sde
+

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import sys
+
+from checker import Checker
+from cluster import Cluster
+from utils import Logger, StopWatch
+
+
+def run_deploy_test(cluster, logger, checker, shutdown=False):
+
+    sw = StopWatch()
+
+    logger.logheader('Generated Solution File for Test')
+    logger.logfile(cluster.solution_file)
+
+    logger.log('\n\n')
+    logger.logheader('-'*80)
+    logger.logheader('\n\n')
+    logger.logheader('\nRunning prereq-cortx-cloud.sh on each node\n')
+    logger.logheader('\n\n')
+    logger.logheader('-'*80)
+    logger.log('\n\n')
+    sw.start()
+    result = cluster.run_prereq()
+    sw.stop()
+    checker.test_equal(0, result, 'Run prereq-cortx-cloud.sh')
+    logger.log(f'TIMING: Prereq: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
+
+    logger.log('\n\n')
+    logger.logheader('-'*80)
+    logger.logheader('\n\n')
+    logger.logheader('\nRunning deploy-cortx-cloud.sh\n')
+    logger.logheader('\n\n')
+    logger.logheader('-'*80)
+    logger.log('\n\n')
+    sw.start()
+    result = cluster.deploy()
+    sw.stop()
+    checker.test_equal(0, result, 'Run deploy-cortx-cloud.sh')
+    logger.log(f'TIMING: Deploy: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
+
+    logger.log('\n\n')
+    logger.logheader('-'*80)
+    logger.logheader('\n\n')
+    logger.logheader('\nRunning status-cortx-cloud.sh\n')
+    logger.logheader('\n\n')
+    logger.logheader('-'*80)
+    logger.log('\n\n')
+    sw.start()
+    result = cluster.status()
+    sw.stop()
+    checker.test_equal(0, result, 'Run status-cortx-cloud.sh')
+    logger.log(f'TIMING: Status: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
+
+    if shutdown:
+        logger.log('\n\n')
+        logger.logheader('-'*80)
+        logger.logheader('\n\n')
+        logger.logheader('\nRunning shutdown-cortx-cloud.sh\n')
+        logger.logheader('\n\n')
+        logger.logheader('-'*80)
+        logger.log('\n\n')
+        sw.start()
+        result = cluster.shutdown()
+        sw.stop()
+        checker.test_equal(0, result, 'Run shutdown-cortx-cloud.sh')
+        logger.log(f'TIMING: Status: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
+
+        logger.log('\n\n')
+        logger.logheader('-'*80)
+        logger.logheader('\n\n')
+        logger.logheader('\nRunning start-cortx-cloud.sh\n')
+        logger.logheader('\n\n')
+        logger.logheader('-'*80)
+        logger.log('\n\n')
+        sw.start()
+        result = cluster.start()
+        sw.stop()
+        checker.test_equal(0, result, 'Run start-cortx-cloud.sh')
+        logger.log(f'TIMING: Status: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
+
+    logger.log('\n\n')
+    logger.logheader('-'*80)
+    logger.logheader('\n\n')
+    logger.logheader('\nRunning destroy-cortx-cloud.sh\n')
+    logger.logheader('\n\n')
+    logger.logheader('-'*80)
+    logger.log('\n\n')
+    sw.start()
+    result = cluster.destroy()
+    sw.stop()
+    checker.test_equal(0, result, 'Run destroy-cortx-cloud.sh')
+    logger.log(f'TIMING: Destroy: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', dest='cluster')
+    parser.add_argument('-s', dest='solution')
+    parser.add_argument('--shutdown', action='store_true')
+    parser.add_argument('--logdir', dest='logdir', default='.')
+    args = parser.parse_args()
+
+    logger = Logger()
+    checker = Checker(logger)
+    cluster = Cluster(args.solution, args.cluster)
+    run_deploy_test(cluster, logger, checker, args.shutdown)
+
+    sys.exit(checker.result())

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import argparse
-import os
 import sys
 
 from checker import Checker

--- a/test/regression/testlists/alltests.yaml
+++ b/test/regression/testlists/alltests.yaml
@@ -1,0 +1,7 @@
+test_deploy_basic:
+  id: TEST-DEPLOY-0001
+  cmd: ./test_deploy.py -c {{ cluster }} -s {{ k8_cloud_dir }}/solution.yaml --shutdown
+
+test_deploy_stub:
+  id: TEST-DEPLOY-0002
+  cmd: ./test_deploy.py -c {{ cluster }} -s {{ k8_cloud_dir }}/solution_stub.yaml --shutdown

--- a/test/regression/testlists/deploy_all.yaml
+++ b/test/regression/testlists/deploy_all.yaml
@@ -1,0 +1,6 @@
+tests:
+  file: alltests.yaml
+
+testlist:
+ - test_deploy_basic
+ - test_deploy_stub

--- a/test/regression/testlists/deploy_cortx.yaml
+++ b/test/regression/testlists/deploy_cortx.yaml
@@ -1,0 +1,5 @@
+tests:
+  file: alltests.yaml
+
+testlist:
+ - test_deploy_basic

--- a/test/regression/testrunner.py
+++ b/test/regression/testrunner.py
@@ -150,7 +150,7 @@ class TestList:
 
 class Test:
     def __init__(self, name, id_, cmd):
-        """Represents a single regression test"""
+        """Represents a single regression test."""
         #Parameters:
         #  * name of the test
         #  * test id (e.g. TEST-DEPLOY-0001)
@@ -160,7 +160,7 @@ class Test:
         self.cmd = cmd
 
     def run(self):
-        proc = subprocess.Popen(shlex.split(self.cmd), stdout=subprocess.PIPE,
+        proc = subprocess.Popen(shlex.split(self.cmd), stdout=subprocess.PIPE, # nosec B603
                                 stderr=subprocess.STDOUT)
         while True:
             out = proc.stdout.readline()

--- a/test/regression/testrunner.py
+++ b/test/regression/testrunner.py
@@ -31,6 +31,7 @@ def get_duration_str(start, stop):
 
 class TestList:
     def __init__(self, source, vars_):
+        """Represents a test list."""
         filename = None
         if isinstance(source, str):
             filename = source
@@ -155,7 +156,6 @@ class Test:
           * name of the test
           * test id (e.g. TEST-DEPLOY-0001)
           * cmd to run -- any executable"""
-        
         self.name = name
         self.id = id_
         self.cmd = cmd

--- a/test/regression/testrunner.py
+++ b/test/regression/testrunner.py
@@ -9,7 +9,7 @@ import sys
 import re
 import os
 import shlex
-import subprocess
+import subprocess  # nosec
 import argparse
 import time
 

--- a/test/regression/testrunner.py
+++ b/test/regression/testrunner.py
@@ -150,11 +150,11 @@ class TestList:
 
 class Test:
     def __init__(self, name, id_, cmd):
-        """Represents a single regression test
-        Parameters:
-          * name of the test
-          * test id (e.g. TEST-DEPLOY-0001)
-          * cmd to run -- any executable"""
+        """Represents a single regression test"""
+        #Parameters:
+        #  * name of the test
+        #  * test id (e.g. TEST-DEPLOY-0001)
+        #  * cmd to run -- any executable
         self.name = name
         self.id = id_
         self.cmd = cmd

--- a/test/regression/testrunner.py
+++ b/test/regression/testrunner.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python3 -u
+
+#########################################
+# testrunner.py
+########################################
+
+import yaml
+import sys
+import re
+import os
+import shlex
+import subprocess
+import argparse
+import time
+
+from utils import Logger
+
+
+def get_duration_str(start, stop):
+    test_duration = stop-start
+    if test_duration < 300:
+        duration = f'{round(test_duration)} seconds'
+    elif test_duration < 3600:
+        duration = f'{round(test_duration/60)} minutes'
+    else:
+        hours = test_duration // 3600
+        minutes = round(test_duration / 60)
+        duration = f'{hours}h {minutes}m'
+    return duration
+
+
+class TestList:
+    def __init__(self, source, vars_):
+        filename = None
+        if isinstance(source, str):
+            filename = source
+            f = open(source)
+            source = yaml.safe_load(f)
+            f.close()
+
+        if not isinstance(source, dict):
+            raise TypeError('Invalid source specified.  Must be dict '
+                            'or filename.')
+
+        class Replacer:
+            def __init__(self, vars_):
+                self.vars = vars_
+
+            def __call__(self, m):
+                var = m.group(1)
+                if var not in self.vars:
+                    raise ValueError(f'{var} is not a valid replacement '
+                                     'variable')
+                return self.vars[var]
+
+        self.vars = vars_
+        if 'vars' in source:
+            self.vars.update(source['vars'])
+        self.repl = Replacer(self.vars)
+
+        if 'file' in source['tests']:
+            if filename.startswith('/'):
+                fname = filename
+            else:
+                sourcedir = os.path.dirname(filename)
+                fname = os.path.join(sourcedir, source['tests']['file'])
+            f = open(fname)
+            data = yaml.safe_load(f)
+            f.close()
+            self.tests = {}
+            for name, v in data.items():
+                self.tests[name] = v
+        else:
+            self.tests = source['tests']
+
+        # Var replace the test commands
+        for test in self.tests:
+            self.tests[test]['cmd'] = self._replacevar(self.tests[test]['cmd'])
+
+        self.testlist = []
+        for test in source['testlist']:
+            self.testlist.append(Test(test, self.tests[test]['id'],
+                                      self.tests[test]['cmd']))
+
+    def _replacevar(self, s):
+        r = re.sub(r'{{\s*(\w+)\s*}}', self.repl, s)
+        return r
+
+    def run(self, logger=None):
+        if not logger:
+            logger = Logger()
+        logger.log('Starting testlist.  %d tests.' % (len(self.testlist)))
+        for i, test in enumerate(self.testlist):
+            logger.log("%3d.  %s: %s" % (i+1, test.id, test.name))
+        logger.log()
+
+        tests_run = 0
+        tests_failed = 0
+
+        liststart = time.time()
+
+        for i, test in enumerate(self.testlist):
+            logger.logheader()
+            logger.logheader('-'*50)
+            logger.logheader(f'Running {i+1}/{len(self.testlist)}  '
+                             f'{test.id}: {test.name}')
+            logger.logheader(test.cmd)
+            logger.logheader('-'*50)
+            logger.logheader()
+
+            teststart = time.time()
+
+            result = test.run()
+
+            teststop = time.time()
+            duration = get_duration_str(teststart, teststop)
+
+            tests_run += 1
+            if result == 0:
+                logger.logpass(f"Test {test.id}: {test.name} passed "
+                               f"in {duration}")
+            else:
+                logger.logfail(f"Test {test.id}: {test.name} failed "
+                               f"in {duration}")
+                tests_failed += 1
+            logger.log()
+            logger.log()
+
+        liststop = time.time()
+        duration = get_duration_str(liststart, liststop)
+
+        logger.log(f'\n\n  Test List Completed in {duration}\n\n')
+        if tests_failed == 0:
+            logger.logpass('-'*50)
+            logger.logpass()
+            logger.logpass(f'    {tests_run} tests passed')
+            logger.logpass()
+            logger.logpass('-'*50)
+            return True
+
+        else:
+            logger.logfail('-'*50)
+            logger.logfail()
+            logger.logfail(f'    {tests_failed} of {tests_run} tests failed')
+            logger.logfail()
+            logger.logfail('-'*50)
+            return False
+
+
+class Test:
+    def __init__(self, name, id_, cmd):
+        """Represents a single regression test
+
+        Parameters:
+          * name of the test
+          * test id (e.g. TEST-DEPLOY-0001)
+          * cmd to run -- any executable"""
+        
+        self.name = name
+        self.id = id_
+        self.cmd = cmd
+
+    def run(self):
+        proc = subprocess.Popen(shlex.split(self.cmd), stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
+        while True:
+            out = proc.stdout.readline()
+            sys.stdout.write(out.decode('utf-8'))
+            sys.stdout.flush()
+            if not out:
+                break
+
+        result = proc.wait()
+        return result
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', dest='cluster', required=True)
+    parser.add_argument('-t', dest='testlist', required=True)
+    args = parser.parse_args()
+
+    vars_ = {
+                  'cluster': args.cluster,
+                  'k8_cloud_dir': os.path.relpath(os.path.join(
+                                                  os.path.dirname(__file__),
+                                                  '../../k8_cortx_cloud')),
+           }
+    testlist = TestList(args.testlist, vars_)
+    tests_passed = testlist.run()
+    sys.exit(0 if tests_passed else 1)

--- a/test/regression/testrunner.py
+++ b/test/regression/testrunner.py
@@ -151,7 +151,6 @@ class TestList:
 class Test:
     def __init__(self, name, id_, cmd):
         """Represents a single regression test
-
         Parameters:
           * name of the test
           * test id (e.g. TEST-DEPLOY-0001)

--- a/test/regression/utils.py
+++ b/test/regression/utils.py
@@ -24,10 +24,10 @@ class Logger:
     ENDC = '\033[0m'
 
     def __init__(self, logfile=None):
-        """Class for facilitationg test output
-        Key elements:
-          * Prepend a timestamp
-          * Support terminal colord output"""
+        """Class for facilitationg test output"""
+        #Key elements:
+        #  * Prepend a timestamp
+        #  * Support terminal colord output
 
         # Default is to log only things that are logged all the time
         # By raising this level you can get more verbose logging

--- a/test/regression/utils.py
+++ b/test/regression/utils.py
@@ -42,10 +42,9 @@ class Logger:
     def timestamp(self):
         if self.shortdate:
             datestr = datetime.datetime.now().strftime('%H:%M:%S')
-            return datestr + ' '
         else:
             datestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-            return datestr + ' '
+        return datestr + ' '
 
     def log(self, s='', prefix=None, level=0, color=None, log_timestamp=True):
         if level > self.loglevel:
@@ -92,7 +91,7 @@ class Logger:
 
 class StopWatch:
     def __init__(self):
-        """Simple stopwatch utility"""
+        """Simple stopwatch utility."""
         self.starttime = 0
         self.stoptime = 0
 
@@ -122,13 +121,12 @@ def run(cmd, cwd=None, return_stdout=False):
     result = proc.wait()
     if return_stdout:
         return result, '\n'.join(stdout)
-    else:
-        return result
+    return result
 
 
 class RemoteRun:
     def __init__(self, host, user):
-        """Class for facilitating running remote commands"""
+        """Class for facilitating running remote commands."""
         self.host = host
         self.user = user
 

--- a/test/regression/utils.py
+++ b/test/regression/utils.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import shlex
 import subprocess
 import sys
 import time
@@ -26,7 +25,6 @@ class Logger:
 
     def __init__(self, logfile=None):
         """Class for facilitationg test output
-
         Key elements:
           * Prepend a timestamp
           * Support terminal colord output"""

--- a/test/regression/utils.py
+++ b/test/regression/utils.py
@@ -1,0 +1,167 @@
+import datetime
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+
+#################################################################
+#
+# Logger
+#
+################################################################
+
+class Logger:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    CYAN = '\033[36m'
+    BROWN = '\033[33m'
+    PASSING = '\033[92m'
+    WARNING = '\033[93m'
+    FAILING = '\033[91m'
+    ENDC = '\033[0m'
+
+    def __init__(self, logfile=None):
+        """Class for facilitationg test output
+
+        Key elements:
+          * Prepend a timestamp
+          * Support terminal colord output"""
+
+        # Default is to log only things that are logged all the time
+        # By raising this level you can get more verbose logging
+        self.loglevel = 0
+        self.shortdate = False
+        self.f = None
+        if logfile:
+            self.f = open(logfile, 'a')
+
+    def timestamp(self):
+        if self.shortdate:
+            datestr = datetime.datetime.now().strftime('%H:%M:%S')
+            return datestr + ' '
+        else:
+            datestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            return datestr + ' '
+
+    def log(self, s='', prefix=None, level=0, color=None, log_timestamp=True):
+        if level > self.loglevel:
+            return
+
+        if not s:
+            # empty string should at leat print a newline
+            s = ' '
+        for line in s.splitlines():
+            if prefix is not None:
+                line = prefix + ' ' + line
+            if log_timestamp:
+                line = self.timestamp() + line
+            if color:
+                pline = color + line + Logger.ENDC
+            else:
+                pline = line
+            print(pline)
+            if self.f:
+                print(line, file=self.f)
+
+    def logpass(self, s=''):
+        self.log(s, color=Logger.PASSING)
+
+    def logfail(self, s=''):
+        self.log(s, color=Logger.FAILING)
+
+    def logwarning(self, s=''):
+        self.log(s, color=Logger.WARNING)
+
+    def logheader(self, s=''):
+        self.log(s, color=Logger.HEADER)
+
+    def logfile(self, filename, separator_width=75):
+        hstr = f'Contents of {filename}'
+        if len(hstr)+2 >= separator_width:
+            dashstr = ''
+        else:
+            dashstr = '-' * (separator_width - len(hstr))
+        self.log(hstr + ' ' + dashstr)
+        self.log(open(filename).read())
+        self.log('-'*separator_width)
+
+
+class StopWatch:
+    def __init__(self):
+        """Simple stopwatch utility"""
+        self.starttime = 0
+        self.stoptime = 0
+
+    def start(self):
+        self.starttime = time.time()
+
+    def stop(self):
+        self.stoptime = time.time()
+
+    def elapsed(self):
+        return self.stoptime - self.starttime
+
+
+def run(cmd, cwd=None, return_stdout=False):
+    print(f"Running: {cmd}, cwd={cwd}")
+    stdout = []
+    proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
+    while True:
+        out = proc.stdout.readline().decode('utf-8')
+        if not out:
+            break
+        sys.stdout.write(out)
+        sys.stdout.flush()
+        stdout.append(out)
+
+    result = proc.wait()
+    if return_stdout:
+        return result, '\n'.join(stdout)
+    else:
+        return result
+
+
+class RemoteRun:
+    def __init__(self, host, user):
+        """Class for facilitating running remote commands"""
+        self.host = host
+        self.user = user
+
+    def test(self):
+        cmd = 'date &> /dev/null'
+        sys.stdout.flush()
+        sys.stderr.flush()
+        result = os.system(f'ssh {self.user}@{self.host} "{cmd}"')
+        sys.stdout.flush()
+        sys.stderr.flush()
+        if result != 0:
+            raise AssertionError('Cannot remote exec on '
+                                 f'{self.user}@{self.host}')
+
+    def run(self, cmd):
+        cmd = f'ssh {self.user}@{self.host} "{cmd}"'
+        print(f"Running: {cmd}")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        result = os.system(cmd)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        return result
+
+    def scp(self, sourcefiles, dest):
+        if isinstance(sourcefiles, list):
+            sourcefiles = ' '.join(sourcefiles)
+        self.run(f'mkdir -p {dest}')
+        cmd = f'rsync {sourcefiles} {self.user}@{self.host}:{dest}'
+        print(f"Running: {cmd}")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        result = os.system(cmd)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        return result

--- a/test/regression/utils.py
+++ b/test/regression/utils.py
@@ -24,7 +24,7 @@ class Logger:
     ENDC = '\033[0m'
 
     def __init__(self, logfile=None):
-        """Class for facilitationg test output"""
+        """Class for facilitationg test output."""
         #Key elements:
         #  * Prepend a timestamp
         #  * Support terminal colord output
@@ -106,7 +106,7 @@ class StopWatch:
 def run(cmd, cwd=None, return_stdout=False):
     print(f"Running: {cmd}, cwd={cwd}")
     stdout = []
-    proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE,
+    proc = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, # nosec B603
                             stderr=subprocess.STDOUT)
     while True:
         out = proc.stdout.readline().decode('utf-8')

--- a/test/regression/utils.py
+++ b/test/regression/utils.py
@@ -1,6 +1,6 @@
 import datetime
 import os
-import subprocess
+import subprocess  # nosec
 import sys
 import time
 


### PR DESCRIPTION
This PR introduces basic regression tests for cortx-k8s.  The goal of these tests is to implement a smoke test for cortx-k8s scripts and template files.  These tests do not introduce comprehensive system tests for CORTX.

This first release has two tests which follow the same pattern.
* TEST-DEPLOY-0001 deploys using cortx images
* TEST-DEPLOY-0002 deploys using stub (centos7) images

Each test follows this sequence:
1. Run "prereq"
2. deploy-cortx-cloud.sh
3. status-cortx-cloud.sh (confirm everything passes)
4. shutdown-cortx-cloud.sh
5. start-cortx-cloud.sh
6. destroy-cortx-cloud.sh

More checks can be added to this sequence, but at least it exercises all scripts (except upgrade).


-----
[View rendered test/cortx-k8s-tests.md](https://github.com/walterlopatka/cortx-k8s/blob/CORTX-28579_basic_regtest/test/regression/cortx-k8s-tests.md)