### PR TITLE
CORTX-29144: Fix shellcheck issues in logs-cortx-cloud.sh

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,5 +29,17 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Shellcheck
         uses: Seagate/action-shellcheck@1.1.0
-        # Temporarily pass until files are fixed
-        continue-on-error: true
+        with:
+          # Temporarily ignore these until they are fixed
+          ignore_paths: >-
+            openldap-replication
+            parse_scripts
+            solution_validation_scripts
+          ignore_names: >-
+            deploy-cortx-cloud.sh
+            generate-cvg-yaml.sh
+            prereq-deploy-cortx-cloud.sh
+            shutdown-cortx-cloud.sh
+            start-cortx-cloud.sh
+            status-cortx-cloud.sh
+            upgrade-cortx-cloud.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run Shellcheck
-        uses: Seagate/action-shellcheck@1.1.0
+        uses: Seagate/action-shellcheck@203a3fd018dfe73f8ae7e3aa8da2c149a5f41c33
         with:
           # Temporarily ignore these until they are fixed
           ignore_paths: >-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,6 +37,7 @@ jobs:
             solution_validation_scripts
           ignore_names: >-
             deploy-cortx-cloud.sh
+            destroy-cortx-cloud.sh
             generate-cvg-yaml.sh
             prereq-deploy-cortx-cloud.sh
             shutdown-cortx-cloud.sh

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -112,7 +112,7 @@ while IFS= read -r line; do
 
   if [[ ${pod_name} != "NAME" && ${pod_status} != "Evicted" ]]; then
     if [[ ${nodename} ]] && \
-       [[ ${nodename} != $(kubectl get pod "${pod_name}" -o jsonpath={.spec.nodeName}) ]]; then
+       [[ ${nodename} != $(kubectl get pod "${pod_name}" -o jsonpath={.spec.nodeName} || true) ]]; then
       continue
     fi
     pods_found=$((pods_found+1))
@@ -135,7 +135,7 @@ while IFS= read -r line; do
     esac
   fi
 
-done <<< "$(kubectl get pods)"
+done <<< "$(kubectl get pods || true)"
 
 if [[ ${nodename} ]] && [[ ${pods_found} == "0" ]]; then
   printf "\n❌ No pods are running on the node: \"%s\".\n" "${nodename}"

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -44,7 +44,7 @@ mkdir "${logs_folder}" -p
 status=""
 
 printf "######################################################\n"
-printf "# ✍️  Generating logs, namespace: ${namespace}, date: ${date}\n"
+printf "# ✍️  Generating logs, namespace: %s, date: %s\n" "${namespace}" "${date}"
 printf "######################################################\n"
 
 function saveLogs()
@@ -140,7 +140,7 @@ done <<< "$(kubectl get pods)"
 if [[ ${nodename} ]] && [[ ${pods_found} == "0" ]]; then
   printf "\n❌ No pods are running on the node: \"%s\".\n" "${nodename}"
 else
-  printf "\n\n📦 \"${logs_folder}.tar\" file generated"
+  printf "\n\n📦 \"%s.tar\" file generated" "${logs_folder}"
 fi
 rm -rf "${logs_folder}"
 printf "\n✔️  All done\n\n"

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -5,7 +5,7 @@ DIR=$(dirname "${SCRIPT}")
 
 function parseSolution()
 {
-  echo "$(${DIR}/parse_scripts/parse_yaml.sh ${solution_yaml} $1)"
+  "${DIR}/parse_scripts/parse_yaml.sh" "${solution_yaml}" "$1"
 }
 
 function usage() {
@@ -38,9 +38,9 @@ while [ $# -gt 0 ]; do
   shift 2
 done
 namespace=$(parseSolution 'solution.namespace')
-namespace=$(echo ${namespace} | cut -f2 -d'>')
+namespace=$(echo "${namespace}" | cut -f2 -d'>')
 logs_folder="logs-cortx-cloud-${date}"
-mkdir ${logs_folder} -p
+mkdir "${logs_folder}" -p
 status=""
 
 printf "######################################################\n"
@@ -109,25 +109,25 @@ while IFS= read -r line; do
 
   if [ "${pod}" != "NAME" -a "${status}" != "Evicted" ]; then
     if [ "${nodename}" ] && \
-       [ "${nodename}" != $(kubectl get pod ${pod} -o jsonpath={.spec.nodeName}) ]; then
+       [ "${nodename}" != $(kubectl get pod "${pod}" -o jsonpath={.spec.nodeName}) ]; then
       continue
     fi
     pods_found=$((pods_found+1))
 
     case ${pod} in
       cortx-control-* | cortx-data-* | cortx-ha-* | cortx-server-*)
-        containers=$(kubectl get pods ${pod} -n ${namespace} -o jsonpath='{.spec.containers[*].name}')
+        containers=$(kubectl get pods "${pod}" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
         containers=(${containers})
         for item in "${containers[@]}";
         do
-          saveLogs ${pod} "${item}"
+          saveLogs "${pod}" "${item}"
         done
-        savePodDetail ${pod}
+        savePodDetail "${pod}"
         getInnerLogs "${pod[0]}" "${containers[0]}"
         ;;
       *)
-        saveLogs ${pod}
-        savePodDetail ${pod}
+        saveLogs "${pod}"
+        savePodDetail "${pod}"
         ;;
     esac
   fi
@@ -135,9 +135,9 @@ while IFS= read -r line; do
 done <<< "$(kubectl get pods)"
 
 if [ "${nodename}" ] && [ "${pods_found}" == "0" ]; then
-  printf "\n❌ No pods are running on the node: \"%s\".\n" ${nodename}
+  printf "\n❌ No pods are running on the node: \"%s\".\n" "${nodename}"
 else
   printf "\n\n📦 \"${logs_folder}.tar\" file generated"
 fi
-rm -rf ${logs_folder}
+rm -rf "${logs_folder}"
 printf "\n✔️  All done\n\n"

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -112,7 +112,7 @@ while IFS= read -r line; do
 
   if [[ ${pod_name} != "NAME" && ${pod_status} != "Evicted" ]]; then
     if [[ ${nodename} ]] && \
-       [[ ${nodename} != $(kubectl get pod "${pod_name}" -o jsonpath={.spec.nodeName} || true) ]]; then
+       [[ ${nodename} != $(kubectl get pod "${pod_name}" -o jsonpath='{.spec.nodeName}' || true) ]]; then
       continue
     fi
     pods_found=$((pods_found+1))

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -22,7 +22,7 @@ function usage() {
 date=$(date +%F_%H-%M)
 solution_yaml="${DIR}/solution.yaml"
 pods_found=0
-while [ $# -gt 0 ]; do
+while [[ $# -gt 0 ]]; do
   case $1 in
     -s|--solution-config )
       declare solution_yaml="$2"
@@ -110,9 +110,9 @@ while IFS= read -r line; do
   pod_name="${pod[0]}"
   pod_status="${status[0]}"
 
-  if [ "${pod_name}" != "NAME" -a "${pod_status}" != "Evicted" ]; then
-    if [ "${nodename}" ] && \
-       [ "${nodename}" != $(kubectl get pod "${pod_name}" -o jsonpath={.spec.nodeName}) ]; then
+  if [[ ${pod_name} != "NAME" -a ${pod_status} != "Evicted" ]]; then
+    if [[ ${nodename} ]] && \
+       [[ ${nodename} != $(kubectl get pod "${pod_name}" -o jsonpath={.spec.nodeName}) ]]; then
       continue
     fi
     pods_found=$((pods_found+1))
@@ -137,7 +137,7 @@ while IFS= read -r line; do
 
 done <<< "$(kubectl get pods)"
 
-if [ "${nodename}" ] && [ "${pods_found}" == "0" ]; then
+if [[ ${nodename} ]] && [[ ${pods_found} == "0" ]]; then
   printf "\n❌ No pods are running on the node: \"%s\".\n" "${nodename}"
 else
   printf "\n\n📦 \"${logs_folder}.tar\" file generated"

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -110,7 +110,7 @@ while IFS= read -r line; do
   pod_name="${pod[0]}"
   pod_status="${status[0]}"
 
-  if [[ ${pod_name} != "NAME" -a ${pod_status} != "Evicted" ]]; then
+  if [[ ${pod_name} != "NAME" && ${pod_status} != "Evicted" ]]; then
     if [[ ${nodename} ]] && \
        [[ ${nodename} != $(kubectl get pod "${pod_name}" -o jsonpath={.spec.nodeName}) ]]; then
       continue

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -120,7 +120,7 @@ while IFS= read -r line; do
     case ${pod_name} in
       cortx-control-* | cortx-data-* | cortx-ha-* | cortx-server-*)
         containers=$(kubectl get pods "${pod_name}" -n "${namespace}" -o jsonpath='{.spec.containers[*].name}')
-        containers=(${containers})
+        IFS=" " read -r -a containers <<< "${containers}"
         for item in "${containers[@]}";
         do
           saveLogs "${pod_name}" "${item}"

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 SCRIPT=$(readlink -f "$0")
-DIR=$(dirname "$SCRIPT")
+DIR=$(dirname "${SCRIPT}")
 
 function parseSolution()
 {
-  echo "$($DIR/parse_scripts/parse_yaml.sh $solution_yaml $1)"
+  echo "$(${DIR}/parse_scripts/parse_yaml.sh ${solution_yaml} $1)"
 }
 
 function usage() {
@@ -13,14 +13,14 @@ function usage() {
   echo -e "Usage: \`sh $0 [-n NODENAME] [-s SOLUTION_CONFIG_FILE]\`\n"
   echo "Optional Arguments:"
   echo "    -s|--solution-config FILE_PATH : path of solution configuration file."
-  echo "                                     default file path is $solution_yaml."
+  echo "                                     default file path is ${solution_yaml}."
   echo "    -n|--nodename NODENAME: collects logs from pods running only on given node".
   echo "                            collects logs from all the nodes by default."
   exit 1
 }
 
 date=$(date +%F_%H-%M)
-solution_yaml="$DIR/solution.yaml"
+solution_yaml="${DIR}/solution.yaml"
 pods_found=0
 while [ $# -gt 0 ]; do
   case $1 in
@@ -38,9 +38,9 @@ while [ $# -gt 0 ]; do
   shift 2
 done
 namespace=$(parseSolution 'solution.namespace')
-namespace=$(echo $namespace | cut -f2 -d'>')
+namespace=$(echo ${namespace} | cut -f2 -d'>')
 logs_folder="logs-cortx-cloud-${date}"
-mkdir $logs_folder -p
+mkdir ${logs_folder} -p
 status=""
 
 printf "######################################################\n"
@@ -103,41 +103,41 @@ function getInnerLogs()
 }
 
 while IFS= read -r line; do
-  IFS=" " read -r -a pod_status <<< "$line"
+  IFS=" " read -r -a pod_status <<< "${line}"
   IFS="/" read -r -a status <<< "${pod_status[2]}"
   IFS="/" read -r -a pod <<< "${pod_status[0]}"
 
-  if [ "$pod" != "NAME" -a "$status" != "Evicted" ]; then
-    if [ "$nodename" ] && \
-       [ "$nodename" != $(kubectl get pod ${pod} -o jsonpath={.spec.nodeName}) ]; then
+  if [ "${pod}" != "NAME" -a "${status}" != "Evicted" ]; then
+    if [ "${nodename}" ] && \
+       [ "${nodename}" != $(kubectl get pod ${pod} -o jsonpath={.spec.nodeName}) ]; then
       continue
     fi
     pods_found=$((pods_found+1))
 
-    case $pod in
+    case ${pod} in
       cortx-control-* | cortx-data-* | cortx-ha-* | cortx-server-*)
         containers=$(kubectl get pods ${pod} -n ${namespace} -o jsonpath='{.spec.containers[*].name}')
-        containers=($containers)
+        containers=(${containers})
         for item in "${containers[@]}";
         do
-          saveLogs $pod "${item}"
+          saveLogs ${pod} "${item}"
         done
-        savePodDetail $pod
+        savePodDetail ${pod}
         getInnerLogs "${pod[0]}" "${containers[0]}"
         ;;
       *)
-        saveLogs $pod
-        savePodDetail $pod
+        saveLogs ${pod}
+        savePodDetail ${pod}
         ;;
     esac
   fi
 
 done <<< "$(kubectl get pods)"
 
-if [ "$nodename" ] && [ "$pods_found" == "0" ]; then
-  printf "\n❌ No pods are running on the node: \"%s\".\n" $nodename
+if [ "${nodename}" ] && [ "${pods_found}" == "0" ]; then
+  printf "\n❌ No pods are running on the node: \"%s\".\n" ${nodename}
 else
-  printf "\n\n📦 \"$logs_folder.tar\" file generated"
+  printf "\n\n📦 \"${logs_folder}.tar\" file generated"
 fi
 rm -rf ${logs_folder}
 printf "\n✔️  All done\n\n"


### PR DESCRIPTION
- This { is literal. Check expression (missing ;/\n?) or quote it. [SC1083]
- Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore). [SC2312]
- Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a. [SC2206]
- In [[..]], use && instead of -a. [SC2108]
- Don't use variables in the printf format string. Use printf '..%s..' "$foo". [SC2059]
- Prefer [[ ]] over [ ] for tests in Bash/Ksh. [SC2292]
- Expanding an array without an index only gives the first element. [SC2128]
- Double quote to prevent globbing and word splitting. [SC2086]
- Prefer putting braces around variable references even when not strictly required. [SC2250]