### PR TITLE
CORTX-29144: Fix shellcheck issues in status-cortx-cloud.sh

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,5 +42,4 @@ jobs:
             prereq-deploy-cortx-cloud.sh
             shutdown-cortx-cloud.sh
             start-cortx-cloud.sh
-            status-cortx-cloud.sh
             upgrade-cortx-cloud.sh

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -764,7 +764,6 @@ while IFS= read -r line; do
     if [[ "${node_name}" != "NAME" ]]; then
         output=$(kubectl describe nodes ${node_name} | grep Taints | grep NoSchedule)
         if [[ "${output}" == "" ]]; then
-            node_list_str="${num_worker_nodes} ${node_name}"
             num_worker_nodes=$((num_worker_nodes+1))
         fi
     fi

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -257,7 +257,7 @@ fi
 
 # Check storage local
 count=0
-num_pvs_pvcs=$(($num_nodes*2))
+num_pvs_pvcs=$(( num_nodes * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "$line"
@@ -296,7 +296,7 @@ fi
 
 # Check storage block devices
 count=0
-num_pvs_pvcs=$((($num_nodes*$num_devices)*2))
+num_pvs_pvcs=$(( (num_nodes * num_devices) * 2 ))
 printf "${INFO}| Checking Storage: Block Devices [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "$line"
@@ -463,7 +463,7 @@ fi
 
 # Check storage local
 count=0
-num_pvs_pvcs=$(($num_nodes*2))
+num_pvs_pvcs=$(( num_nodes * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "$line"
@@ -586,7 +586,7 @@ fi
 
 # Check storage local
 count=0
-num_pvs_pvcs=$(($num_nodes*2))
+num_pvs_pvcs=$(( num_nodes * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "$line"
@@ -719,7 +719,7 @@ if [[ $num_motr_client -gt 0 ]]; then
 
     # Check storage local
     count=0
-    num_pvs_pvcs=$(($num_nodes*2))
+    num_pvs_pvcs=$(( num_nodes * 2 ))
     printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
     while IFS= read -r line; do
         IFS=" " read -r -a status <<< "$line"
@@ -886,7 +886,7 @@ fi
 
 # Check storage local
 count=0
-num_pvs_pvcs=$(($num_replicas*2))
+num_pvs_pvcs=$(( num_replicas * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "$line"
@@ -1028,7 +1028,7 @@ fi
 
 # Check storage local
 count=0
-num_pvs_pvcs=$(($num_replicas*2))
+num_pvs_pvcs=$(( num_replicas * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "$line"
@@ -1118,7 +1118,7 @@ else
 fi
 
 # Check Pods
-num_items=$(($num_replicas+$num_worker_nodes))
+num_items=$(( num_replicas + num_worker_nodes ))
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
@@ -1195,7 +1195,7 @@ fi
 
 # Check storage local
 count=0
-num_pvs_pvcs=$(($num_replicas*2))
+num_pvs_pvcs=$(( num_replicas * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "$line"
@@ -1234,7 +1234,7 @@ fi
 
 printf -- "------------------------------------------\n"
 
-if (( ${failcount} > 0 )); then
+if (( failcount > 0 )); then
     printf "${FAILED}${failcount} status checks failed${NC}\n\n"
     exit 1
 else

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -3,9 +3,9 @@
 solution_yaml=${1:-'solution.yaml'}
 
 # Check if the file exists
-if [ ! -f $solution_yaml ]
+if [ ! -f ${solution_yaml} ]
 then
-    echo "ERROR: $solution_yaml does not exist"
+    echo "ERROR: ${solution_yaml} does not exist"
     exit 1
 fi
 
@@ -19,11 +19,11 @@ NC='\033[0m'              #NO COLOUR
 
 function parseSolution()
 {
-    echo "$(./parse_scripts/parse_yaml.sh $solution_yaml $1)"
+    echo "$(./parse_scripts/parse_yaml.sh ${solution_yaml} $1)"
 }
 
 namespace=$(parseSolution 'solution.namespace')
-namespace=$(echo $namespace | cut -f2 -d'>')
+namespace=$(echo ${namespace} | cut -f2 -d'>')
 
 #########################################################################################
 # CORTX Control
@@ -36,7 +36,7 @@ printf "${ALERT}######################################################${NC}\n"
 count=0
 printf "${INFO}| Checking Deployments |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -48,9 +48,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=$namespace | grep 'cortx-control')"
+done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-control')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -61,7 +61,7 @@ fi
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -73,9 +73,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=$namespace | grep 'cortx-control-')"
+done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-control-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -86,14 +86,14 @@ fi
 count=0
 printf "${INFO}| Checking Services: cortx-control-loadbal-svc |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}...${PASSED}PASSED${NC}"
         count=$((count+1))
     fi
-done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-control-loadbal-')"
+done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-control-loadbal-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -105,7 +105,7 @@ count=0
 num_pvs_pvcs=2
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -116,10 +116,10 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=$namespace | grep 'cortx-control-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-control-fs-local-pvc')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -130,16 +130,16 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=$namespace | grep 'cortx-control-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-control-fs-local-pvc')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
     failcount=$((failcount+1))
 fi
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -150,9 +150,9 @@ fi
 # CORTX Data
 #########################################################################################
 nodes_names=$(parseSolution 'solution.nodes.node*.name')
-num_nodes=$(echo $nodes_names | grep -o '>' | wc -l)
+num_nodes=$(echo ${nodes_names} | grep -o '>' | wc -l)
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-num_devices=$(echo $device_names | grep -o '>' | wc -l)
+num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
 
 printf "${ALERT}######################################################${NC}\n"
 printf "${ALERT}# CORTX Data                                          ${NC}\n"
@@ -161,7 +161,7 @@ printf "${ALERT}######################################################${NC}\n"
 count=0
 printf "${INFO}| Checking Deployments |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -173,9 +173,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=$namespace | grep 'cortx-data-')"
+done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-data-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -186,7 +186,7 @@ fi
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -198,9 +198,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=$namespace | grep 'cortx-data-')"
+done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-data-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -211,7 +211,7 @@ fi
 count=0
 printf "${INFO}| Checking Services: Headless |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -222,9 +222,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-data-headless-')"
+done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-data-headless-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -235,7 +235,7 @@ fi
 count=0
 printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -246,9 +246,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-data-clusterip-')"
+done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-data-clusterip-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -260,7 +260,7 @@ count=0
 num_pvs_pvcs=$(( num_nodes * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -271,10 +271,10 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=$namespace | grep 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-data-fs-local-pvc')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -285,9 +285,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=$namespace | grep 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-data-fs-local-pvc')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -299,7 +299,7 @@ count=0
 num_pvs_pvcs=$(( (num_nodes * num_devices) * 2 ))
 printf "${INFO}| Checking Storage: Block Devices [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -310,10 +310,10 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=$namespace | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -324,9 +324,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=$namespace | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -337,9 +337,9 @@ fi
 # CORTX Server
 #########################################################################################
 nodes_names=$(parseSolution 'solution.nodes.node*.name')
-num_nodes=$(echo $nodes_names | grep -o '>' | wc -l)
+num_nodes=$(echo ${nodes_names} | grep -o '>' | wc -l)
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-num_devices=$(echo $device_names | grep -o '>' | wc -l)
+num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
 
 printf "${ALERT}######################################################${NC}\n"
 printf "${ALERT}# CORTX Server                                        ${NC}\n"
@@ -348,7 +348,7 @@ printf "${ALERT}######################################################${NC}\n"
 count=0
 printf "${INFO}| Checking Deployments |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -360,9 +360,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=$namespace | grep 'cortx-server-')"
+done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-server-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -373,7 +373,7 @@ fi
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -385,9 +385,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=$namespace | grep 'cortx-server-')"
+done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-server-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -398,7 +398,7 @@ fi
 count=0
 printf "${INFO}| Checking Services: Headless |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -409,9 +409,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-server-headless-')"
+done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-server-headless-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -422,7 +422,7 @@ fi
 count=0
 printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -433,9 +433,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-server-clusterip-')"
+done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-server-clusterip-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -444,17 +444,17 @@ fi
 
 # Check services load balance
 count=0
-num_load_bal=$num_nodes
+num_load_bal=${num_nodes}
 printf "${INFO}| Checking Services: cortx-server-loadbal-svc |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}...${PASSED}PASSED${NC}"
         count=$((count+1))
     fi
-done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-server-loadbal-')"
+done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-server-loadbal-')"
 
-if [[ $num_load_bal -eq $count ]]; then
+if [[ ${num_load_bal} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -466,7 +466,7 @@ count=0
 num_pvs_pvcs=$(( num_nodes * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -477,10 +477,10 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=$namespace | grep 'cortx-server-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-server-fs-local-pvc')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -491,9 +491,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=$namespace | grep 'cortx-server-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-server-fs-local-pvc')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -505,7 +505,7 @@ fi
 #########################################################################################
 num_nodes=1
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-num_devices=$(echo $device_names | grep -o '>' | wc -l)
+num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
 
 printf "${ALERT}######################################################${NC}\n"
 printf "${ALERT}# CORTX HA                                            ${NC}\n"
@@ -514,7 +514,7 @@ printf "${ALERT}######################################################${NC}\n"
 count=0
 printf "${INFO}| Checking Deployments |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -526,9 +526,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=$namespace | grep 'cortx-ha')"
+done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-ha')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -539,7 +539,7 @@ fi
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -551,9 +551,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=$namespace | grep 'cortx-ha-')"
+done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-ha-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -564,7 +564,7 @@ fi
 count=0
 printf "${INFO}| Checking Services: Headless |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -575,9 +575,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-ha-headless-')"
+done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-ha-headless-')"
 
-if [[ $num_nodes -eq $count ]]; then
+if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -589,7 +589,7 @@ count=0
 num_pvs_pvcs=$(( num_nodes * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -600,10 +600,10 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=$namespace | grep 'cortx-ha-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-ha-fs-local-pvc')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -614,9 +614,9 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=$namespace | grep 'cortx-ha-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-ha-fs-local-pvc')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -626,19 +626,19 @@ fi
 
 function extractBlock()
 {
-    echo "$(./parse_scripts/yaml_extract_block.sh $solution_yaml $1)"
+    echo "$(./parse_scripts/yaml_extract_block.sh ${solution_yaml} $1)"
 }
 
 num_motr_client=$(extractBlock 'solution.common.motr.num_client_inst')
 
-if [[ $num_motr_client -gt 0 ]]; then
+if [[ ${num_motr_client} -gt 0 ]]; then
     #########################################################################################
     # CORTX Client
     #########################################################################################
     nodes_names=$(parseSolution 'solution.nodes.node*.name')
-    num_nodes=$(echo $nodes_names | grep -o '>' | wc -l)
+    num_nodes=$(echo ${nodes_names} | grep -o '>' | wc -l)
     device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-    num_devices=$(echo $device_names | grep -o '>' | wc -l)
+    num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
 
     printf "${ALERT}######################################################${NC}\n"
     printf "${ALERT}# CORTX Client                                        ${NC}\n"
@@ -647,7 +647,7 @@ if [[ $num_motr_client -gt 0 ]]; then
     count=0
     printf "${INFO}| Checking Deployments |${NC}\n"
     while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
         IFS="/" read -r -a ready_status <<< "${status[1]}"
         if [[ "${status[0]}" != "" ]]; then
             printf "${status[0]}..."
@@ -659,9 +659,9 @@ if [[ $num_motr_client -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get deployments --namespace=$namespace | grep 'cortx-client')"
+    done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-client')"
 
-    if [[ $num_nodes -eq $count ]]; then
+    if [[ ${num_nodes} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
     else
         printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -672,7 +672,7 @@ if [[ $num_motr_client -gt 0 ]]; then
     count=0
     printf "${INFO}| Checking Pods |${NC}\n"
     while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
         IFS="/" read -r -a ready_status <<< "${status[1]}"
         if [[ "${status[0]}" != "" ]]; then
             printf "${status[0]}..."
@@ -684,9 +684,9 @@ if [[ $num_motr_client -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get pods --namespace=$namespace | grep 'cortx-client-')"
+    done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-client-')"
 
-    if [[ $num_nodes -eq $count ]]; then
+    if [[ ${num_nodes} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
     else
         printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -697,7 +697,7 @@ if [[ $num_motr_client -gt 0 ]]; then
     count=0
     printf "${INFO}| Checking Services: Headless |${NC}\n"
     while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
         if [[ "${status[0]}" != "" ]]; then
             printf "${status[0]}..."
             if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -708,9 +708,9 @@ if [[ $num_motr_client -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get services --namespace=$namespace | grep 'cortx-client-headless-')"
+    done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-client-headless-')"
 
-    if [[ $num_nodes -eq $count ]]; then
+    if [[ ${num_nodes} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
     else
         printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -722,7 +722,7 @@ if [[ $num_motr_client -gt 0 ]]; then
     num_pvs_pvcs=$(( num_nodes * 2 ))
     printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
     while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
         if [[ "${status[0]}" != "" ]]; then
             printf "PVC: ${status[0]}..."
             if [[ "${status[1]}" != "Bound" ]]; then
@@ -733,10 +733,10 @@ if [[ $num_motr_client -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get pvc --namespace=$namespace | grep 'cortx-client-fs-local-pvc')"
+    done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-client-fs-local-pvc')"
 
     while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
         if [[ "${status[0]}" != "" ]]; then
             printf "PV: ${status[5]}..."
             if [[ "${status[4]}" != "Bound" ]]; then
@@ -747,9 +747,9 @@ if [[ $num_motr_client -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get pv --namespace=$namespace | grep 'cortx-client-fs-local-pvc')"
+    done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-client-fs-local-pvc')"
 
-    if [[ $num_pvs_pvcs -eq $count ]]; then
+    if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
     else
         printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -761,21 +761,21 @@ fi
 # 3rd Party
 #########################################################################################
 while IFS= read -r line; do
-    IFS=" " read -r -a node_name <<< "$line"
-    if [[ "$node_name" != "NAME" ]]; then
-        output=$(kubectl describe nodes $node_name | grep Taints | grep NoSchedule)
-        if [[ "$output" == "" ]]; then
-            node_list_str="$num_worker_nodes $node_name"
+    IFS=" " read -r -a node_name <<< "${line}"
+    if [[ "${node_name}" != "NAME" ]]; then
+        output=$(kubectl describe nodes ${node_name} | grep Taints | grep NoSchedule)
+        if [[ "${output}" == "" ]]; then
+            node_list_str="${num_worker_nodes} ${node_name}"
             num_worker_nodes=$((num_worker_nodes+1))
         fi
     fi
 done <<< "$(kubectl get nodes)"
 
-num_nodes=$num_worker_nodes
+num_nodes=${num_worker_nodes}
 max_replicas=3
-num_replicas=$num_nodes
-if [[ "$num_nodes" -gt "$max_replicas" ]]; then
-    num_replicas=$max_replicas
+num_replicas=${num_nodes}
+if [[ "${num_nodes}" -gt "${max_replicas}" ]]; then
+    num_replicas=${max_replicas}
 fi
 printf "${ALERT}######################################################${NC}\n"
 printf "${ALERT}# 3rd Party                                           ${NC}\n"
@@ -787,7 +787,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking StatefulSet |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -801,7 +801,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get statefulsets | grep 'kafka')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -809,11 +809,11 @@ else
 fi
 
 # Check Pods
-num_items=$num_replicas
+num_items=${num_replicas}
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -827,7 +827,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get pods | grep 'kafka-')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -839,7 +839,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -852,7 +852,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get services | grep 'kafka' | grep -v 'kafka-headless')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -864,7 +864,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking Services: Headless |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -877,7 +877,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get services | grep 'kafka-headless')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -889,7 +889,7 @@ count=0
 num_pvs_pvcs=$(( num_replicas * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -903,7 +903,7 @@ while IFS= read -r line; do
 done <<< "$(kubectl get pvc | grep 'kafka-')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -916,7 +916,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get pv | grep 'kafka-')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -929,7 +929,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking StatefulSet |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -943,7 +943,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get statefulsets | grep 'zookeeper')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -951,11 +951,11 @@ else
 fi
 
 # Check Pods
-num_items=$num_replicas
+num_items=${num_replicas}
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -969,7 +969,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get pods | grep 'zookeeper-')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -981,7 +981,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -994,7 +994,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get services | grep 'zookeeper' | grep -v 'zookeeper-headless')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1006,7 +1006,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking Services: Headless |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -1019,7 +1019,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get services | grep 'zookeeper-headless')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1031,7 +1031,7 @@ count=0
 num_pvs_pvcs=$(( num_replicas * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -1045,7 +1045,7 @@ while IFS= read -r line; do
 done <<< "$(kubectl get pvc | grep 'zookeeper-')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -1058,7 +1058,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get pv | grep 'zookeeper-')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1071,7 +1071,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking StatefulSet |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -1085,7 +1085,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get statefulsets | grep 'consul')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1097,10 +1097,10 @@ num_items=1
 count=0
 printf "${INFO}| Checking DaemonSet |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
-        if [[ "${status[3]}" != "$num_worker_nodes" ]]; then
+        if [[ "${status[3]}" != "${num_worker_nodes}" ]]; then
             printf "${FAILED}FAILED${NC}\n"
             failcount=$((failcount+1))
         else
@@ -1110,7 +1110,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get daemonsets | grep 'consul')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1122,7 +1122,7 @@ num_items=$(( num_replicas + num_worker_nodes ))
 count=0
 printf "${INFO}| Checking Pods |${NC}\n"
 while IFS= read -r line; do
-        IFS=" " read -r -a status <<< "$line"
+        IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
@@ -1136,7 +1136,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get pods | grep 'consul-')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1148,7 +1148,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -1161,7 +1161,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get services | grep 'consul' | grep -v 'consul-server')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1173,7 +1173,7 @@ num_items=1
 count=0
 printf "${INFO}| Checking Services: Headless |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "${status[0]}..."
         if [[ "${status[1]}" != "ClusterIP" ]]; then
@@ -1186,7 +1186,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get services | grep 'consul-server')"
 
-if [[ $num_items -eq $count ]]; then
+if [[ ${num_items} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
@@ -1198,7 +1198,7 @@ count=0
 num_pvs_pvcs=$(( num_replicas * 2 ))
 printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PVC: ${status[0]}..."
         if [[ "${status[1]}" != "Bound" ]]; then
@@ -1212,7 +1212,7 @@ while IFS= read -r line; do
 done <<< "$(kubectl get pvc | grep 'consul-server-')"
 
 while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "$line"
+    IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
         printf "PV: ${status[5]}..."
         if [[ "${status[4]}" != "Bound" ]]; then
@@ -1225,7 +1225,7 @@ while IFS= read -r line; do
     fi
 done <<< "$(kubectl get pv | grep 'consul-server-')"
 
-if [[ $num_pvs_pvcs -eq $count ]]; then
+if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
 else
     printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -66,7 +66,6 @@ failcount=0
 # CORTX Control
 #########################################################################################
 num_nodes=1
-
 alert_msg "######################################################"
 alert_msg "# CORTX Control                                       "
 alert_msg "######################################################"
@@ -196,7 +195,6 @@ num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 alert_msg "######################################################"
 alert_msg "# CORTX Data                                          "
 alert_msg "######################################################"
-# Check deployments
 # Check deployments
 count=0
 msg_info "| Checking Deployments |"
@@ -482,7 +480,7 @@ else
     failcount=$((failcount+1))
 fi
 
-# Check services load balaNOFORMATe
+# Check services load balancer
 count=0
 num_load_bal=${num_nodes}
 msg_info "| Checking Services: cortx-server-loadbal-svc |"
@@ -1271,10 +1269,9 @@ fi
 printf -- "------------------------------------------\n"
 
 if (( failcount > 0 )); then
-    msg_failed "${failcount} status checks failed "
+    msg "${RED}${failcount} status checks failed${NOFORMAT}\n\n"
     exit 1
 else
-    msg_passed "All status checks passed"
-    printf "\n"
+    msg "${GREEN}All status checks passed${NOFORMAT}\n\n"
     exit 0
 fi

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -20,11 +20,11 @@ NC='\033[0m'              #NO COLOUR
 
 function parseSolution()
 {
-    ./parse_scripts/parse_yaml.sh ${solution_yaml} $1
+    ./parse_scripts/parse_yaml.sh "${solution_yaml}" "$1"
 }
 
 namespace=$(parseSolution 'solution.namespace')
-namespace=$(echo ${namespace} | cut -f2 -d'>')
+namespace=$(echo "${namespace}" | cut -f2 -d'>')
 
 #########################################################################################
 # CORTX Control
@@ -49,7 +49,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-control')"
+done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-control')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -74,7 +74,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-control-')"
+done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-control-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -92,7 +92,7 @@ while IFS= read -r line; do
         printf "${status[0]}...${PASSED}PASSED${NC}"
         count=$((count+1))
     fi
-done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-control-loadbal-')"
+done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-control-loadbal-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -117,7 +117,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-control-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-control-fs-local-pvc')"
 
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
@@ -131,7 +131,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-control-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-control-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -151,9 +151,9 @@ fi
 # CORTX Data
 #########################################################################################
 nodes_names=$(parseSolution 'solution.nodes.node*.name')
-num_nodes=$(echo ${nodes_names} | grep -o '>' | wc -l)
+num_nodes=$(echo "${nodes_names}" | grep -o '>' | wc -l)
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
+num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
 printf "${ALERT}######################################################${NC}\n"
 printf "${ALERT}# CORTX Data                                          ${NC}\n"
@@ -174,7 +174,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-data-')"
+done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-data-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -199,7 +199,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-data-')"
+done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-data-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -223,7 +223,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-data-headless-')"
+done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-data-headless-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -247,7 +247,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-data-clusterip-')"
+done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-data-clusterip-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -272,7 +272,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-data-fs-local-pvc')"
 
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
@@ -286,7 +286,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-data-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -311,7 +311,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
 
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
@@ -325,7 +325,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -338,9 +338,9 @@ fi
 # CORTX Server
 #########################################################################################
 nodes_names=$(parseSolution 'solution.nodes.node*.name')
-num_nodes=$(echo ${nodes_names} | grep -o '>' | wc -l)
+num_nodes=$(echo "${nodes_names}" | grep -o '>' | wc -l)
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
+num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
 printf "${ALERT}######################################################${NC}\n"
 printf "${ALERT}# CORTX Server                                        ${NC}\n"
@@ -361,7 +361,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-server-')"
+done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-server-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -386,7 +386,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-server-')"
+done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-server-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -410,7 +410,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-server-headless-')"
+done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-server-headless-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -434,7 +434,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-server-clusterip-')"
+done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-server-clusterip-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -453,7 +453,7 @@ while IFS= read -r line; do
         printf "${status[0]}...${PASSED}PASSED${NC}"
         count=$((count+1))
     fi
-done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-server-loadbal-')"
+done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-server-loadbal-')"
 
 if [[ ${num_load_bal} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -478,7 +478,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-server-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-server-fs-local-pvc')"
 
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
@@ -492,7 +492,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-server-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-server-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -506,7 +506,7 @@ fi
 #########################################################################################
 num_nodes=1
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
+num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
 printf "${ALERT}######################################################${NC}\n"
 printf "${ALERT}# CORTX HA                                            ${NC}\n"
@@ -527,7 +527,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-ha')"
+done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-ha')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -552,7 +552,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-ha-')"
+done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-ha-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -576,7 +576,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-ha-headless-')"
+done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-ha-headless-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -601,7 +601,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-ha-fs-local-pvc')"
+done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-ha-fs-local-pvc')"
 
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
@@ -615,7 +615,7 @@ while IFS= read -r line; do
             count=$((count+1))
         fi
     fi
-done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-ha-fs-local-pvc')"
+done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-ha-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
     printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -627,7 +627,7 @@ fi
 
 function extractBlock()
 {
-    ./parse_scripts/yaml_extract_block.sh ${solution_yaml} $1
+    ./parse_scripts/yaml_extract_block.sh "${solution_yaml}" "$1"
 }
 
 num_motr_client=$(extractBlock 'solution.common.motr.num_client_inst')
@@ -637,9 +637,9 @@ if [[ ${num_motr_client} -gt 0 ]]; then
     # CORTX Client
     #########################################################################################
     nodes_names=$(parseSolution 'solution.nodes.node*.name')
-    num_nodes=$(echo ${nodes_names} | grep -o '>' | wc -l)
+    num_nodes=$(echo "${nodes_names}" | grep -o '>' | wc -l)
     device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
-    num_devices=$(echo ${device_names} | grep -o '>' | wc -l)
+    num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
     printf "${ALERT}######################################################${NC}\n"
     printf "${ALERT}# CORTX Client                                        ${NC}\n"
@@ -660,7 +660,7 @@ if [[ ${num_motr_client} -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get deployments --namespace=${namespace} | grep 'cortx-client')"
+    done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-client')"
 
     if [[ ${num_nodes} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -685,7 +685,7 @@ if [[ ${num_motr_client} -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get pods --namespace=${namespace} | grep 'cortx-client-')"
+    done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-client-')"
 
     if [[ ${num_nodes} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -709,7 +709,7 @@ if [[ ${num_motr_client} -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get services --namespace=${namespace} | grep 'cortx-client-headless-')"
+    done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-client-headless-')"
 
     if [[ ${num_nodes} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -734,7 +734,7 @@ if [[ ${num_motr_client} -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get pvc --namespace=${namespace} | grep 'cortx-client-fs-local-pvc')"
+    done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-client-fs-local-pvc')"
 
     while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
@@ -748,7 +748,7 @@ if [[ ${num_motr_client} -gt 0 ]]; then
                 count=$((count+1))
             fi
         fi
-    done <<< "$(kubectl get pv --namespace=${namespace} | grep 'cortx-client-fs-local-pvc')"
+    done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-client-fs-local-pvc')"
 
     if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
         printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
@@ -764,7 +764,7 @@ fi
 while IFS= read -r line; do
     IFS=" " read -r -a node_name <<< "${line}"
     if [[ "${node_name[0]}" != "NAME" ]]; then
-        output=$(kubectl describe nodes ${node_name[0]} | grep Taints | grep NoSchedule)
+        output=$(kubectl describe nodes "${node_name[0]}" | grep Taints | grep NoSchedule)
         if [[ "${output}" == "" ]]; then
             num_worker_nodes=$((num_worker_nodes+1))
         fi

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -12,14 +12,44 @@ fi
 
 failcount=0
 
-FAILED='\033[0;31m'       #RED
-PASSED='\033[0;32m'       #GREEN
-ALERT='\033[0;33m'        #YELLOW
-INFO='\033[0;36m'        #CYAN
-NC='\033[0m'              #NO COLOUR
+ESC=$(printf '\033')
+RED="${ESC}[0;31m"
+GREEN="${ESC}[0;32m"
+YELLOW="${ESC}[0;33m"
+CYAN="${ESC}[0;36m"
+NC="${ESC}[0m"
 
-function parseSolution()
-{
+print_alert() {
+    printf "%s%s%s" "${YELLOW}" "$1" "${NC}"
+    [[ -z $2 ]] && printf "\n"
+}
+
+print_failed() {
+    printf "%s%s%s" "${RED}" "$1" "${NC}"
+    [[ -z $2 ]] && printf "\n"
+}
+
+print_passed() {
+    printf "%s%s%s" "${GREEN}" "$1" "${NC}"
+    [[ -z $2 ]] && printf "\n"
+}
+
+print_info() {
+    printf "%s%s%s" "${CYAN}" "$1" "${NC}"
+    [[ -z $2 ]] && printf "\n"
+}
+
+print_overall_passed() {
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
+}
+
+print_overall_failed() {
+    printf "OVERALL STATUS: "
+    print_failed "FAILED"
+}
+
+parseSolution() {
     ./parse_scripts/parse_yaml.sh "${solution_yaml}" "$1"
 }
 
@@ -30,90 +60,95 @@ namespace=$(echo "${namespace}" | cut -f2 -d'>')
 # CORTX Control
 #########################################################################################
 num_nodes=1
-printf "${ALERT}######################################################${NC}\n"
-printf "${ALERT}# CORTX Control                                       ${NC}\n"
-printf "${ALERT}######################################################${NC}\n"
+
+print_alert "######################################################"
+print_alert "# CORTX Control                                       "
+print_alert "######################################################"
 # Check deployments
 count=0
-printf "${INFO}| Checking Deployments |${NC}\n"
+print_info "| Checking Deployments |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-control')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check pods
 count=0
-printf "${INFO}| Checking Pods |${NC}\n"
+print_info "| Checking Pods |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-control-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services load balance
 count=0
-printf "${INFO}| Checking Services: cortx-control-loadbal-svc |${NC}\n"
+print_info "| Checking Services: cortx-control-loadbal-svc |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}...${PASSED}PASSED${NC}"
+        printf "%s..." "${status[0]}"
+        print_passed "PASSED"
         count=$((count+1))
     fi
 done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-control-loadbal-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage local
 count=0
 num_pvs_pvcs=2
-printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Local [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -122,28 +157,30 @@ done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-control-fs-
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-control-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
@@ -155,120 +192,125 @@ num_nodes=$(echo "${nodes_names}" | grep -o '>' | wc -l)
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
 num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
-printf "${ALERT}######################################################${NC}\n"
-printf "${ALERT}# CORTX Data                                          ${NC}\n"
-printf "${ALERT}######################################################${NC}\n"
+print_alert "######################################################"
+print_alert "# CORTX Data                                          "
+print_alert "######################################################"
+# Check deployments
 # Check deployments
 count=0
-printf "${INFO}| Checking Deployments |${NC}\n"
+print_info "| Checking Deployments |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-data-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check pods
 count=0
-printf "${INFO}| Checking Pods |${NC}\n"
+print_info "| Checking Pods |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-data-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services headless
 count=0
-printf "${INFO}| Checking Services: Headless |${NC}\n"
+print_info "| Checking Services: Headless |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-data-headless-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services cluster IP
 count=0
-printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
+print_info "| Checking Services: Cluster IP |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-data-clusterip-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    printf "OVERALL STATUS: "
+    print_passed "PASSED"
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage local
 count=0
 num_pvs_pvcs=$(( num_nodes * 2 ))
-printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Local [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -277,37 +319,37 @@ done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-data-fs-loc
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-data-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage block devices
 count=0
 num_pvs_pvcs=$(( (num_nodes * num_devices) * 2 ))
-printf "${INFO}| Checking Storage: Block Devices [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Block Devices [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -316,21 +358,21 @@ done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-data-' | gr
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-data-' | grep -v 'cortx-data-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
@@ -342,139 +384,140 @@ num_nodes=$(echo "${nodes_names}" | grep -o '>' | wc -l)
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
 num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
-printf "${ALERT}######################################################${NC}\n"
-printf "${ALERT}# CORTX Server                                        ${NC}\n"
-printf "${ALERT}######################################################${NC}\n"
+print_alert "######################################################"
+print_alert "# CORTX Server                                        "
+print_alert "######################################################"
 # Check deployments
 count=0
-printf "${INFO}| Checking Deployments |${NC}\n"
+print_info "| Checking Deployments |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-server-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check pods
 count=0
-printf "${INFO}| Checking Pods |${NC}\n"
+print_info "| Checking Pods |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-server-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services headless
 count=0
-printf "${INFO}| Checking Services: Headless |${NC}\n"
+print_info "| Checking Services: Headless |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-server-headless-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services cluster IP
 count=0
-printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
+print_info "| Checking Services: Cluster IP |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-server-clusterip-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services load balance
 count=0
 num_load_bal=${num_nodes}
-printf "${INFO}| Checking Services: cortx-server-loadbal-svc |${NC}\n"
+print_info "| Checking Services: cortx-server-loadbal-svc |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}...${PASSED}PASSED${NC}"
+        printf "%s..." "${status[0]}"
+        print_passed "PASSED"
         count=$((count+1))
     fi
 done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-server-loadbal-')"
 
 if [[ ${num_load_bal} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage local
 count=0
 num_pvs_pvcs=$(( num_nodes * 2 ))
-printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Local [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -483,21 +526,21 @@ done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-server-fs-l
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-server-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
@@ -508,96 +551,96 @@ num_nodes=1
 device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
 num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
-printf "${ALERT}######################################################${NC}\n"
-printf "${ALERT}# CORTX HA                                            ${NC}\n"
-printf "${ALERT}######################################################${NC}\n"
+print_alert "######################################################"
+print_alert "# CORTX HA                                            "
+print_alert "######################################################"
 # Check deployments
 count=0
-printf "${INFO}| Checking Deployments |${NC}\n"
+print_info "| Checking Deployments |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-ha')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check pods
 count=0
-printf "${INFO}| Checking Pods |${NC}\n"
+print_info "| Checking Pods |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-ha-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services headless
 count=0
-printf "${INFO}| Checking Services: Headless |${NC}\n"
+print_info "| Checking Services: Headless |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-ha-headless-')"
 
 if [[ ${num_nodes} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage local
 count=0
 num_pvs_pvcs=$(( num_nodes * 2 ))
-printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Local [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -606,21 +649,21 @@ done <<< "$(kubectl get pvc --namespace="${namespace}" | grep 'cortx-ha-fs-local
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-ha-fs-local-pvc')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
@@ -641,96 +684,97 @@ if [[ ${num_motr_client} -gt 0 ]]; then
     device_names=$(parseSolution 'solution.storage.cvg*.devices*.device')
     num_devices=$(echo "${device_names}" | grep -o '>' | wc -l)
 
-    printf "${ALERT}######################################################${NC}\n"
-    printf "${ALERT}# CORTX Client                                        ${NC}\n"
-    printf "${ALERT}######################################################${NC}\n"
+    print_alert "######################################################"
+    print_alert "# CORTX Client                                        "
+    print_alert "######################################################"
+
     # Check deployments
     count=0
-    printf "${INFO}| Checking Deployments |${NC}\n"
+    print_info "| Checking Deployments |"
     while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
         IFS="/" read -r -a ready_status <<< "${status[1]}"
         if [[ "${status[0]}" != "" ]]; then
-            printf "${status[0]}..."
+            printf "%s..." "${status[0]}"
             if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-                printf "${FAILED}FAILED${NC}\n"
+                print_fail "FAILED"
                 failcount=$((failcount+1))
             else
-                printf "${PASSED}PASSED${NC}\n"
+                print_passed "PASSED"
                 count=$((count+1))
             fi
         fi
     done <<< "$(kubectl get deployments --namespace="${namespace}" | grep 'cortx-client')"
 
     if [[ ${num_nodes} -eq ${count} ]]; then
-        printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+        print_overall_passed
     else
-        printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+        print_overall_failed
         failcount=$((failcount+1))
     fi
 
     # Check pods
     count=0
-    printf "${INFO}| Checking Pods |${NC}\n"
+    print_info "| Checking Pods |"
     while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
         IFS="/" read -r -a ready_status <<< "${status[1]}"
         if [[ "${status[0]}" != "" ]]; then
-            printf "${status[0]}..."
+            printf "%s..." "${status[0]}"
             if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-                printf "${FAILED}FAILED${NC}\n"
+                print_fail "FAILED"
                 failcount=$((failcount+1))
             else
-                printf "${PASSED}PASSED${NC}\n"
+                print_passed "PASSED"
                 count=$((count+1))
             fi
         fi
     done <<< "$(kubectl get pods --namespace="${namespace}" | grep 'cortx-client-')"
 
     if [[ ${num_nodes} -eq ${count} ]]; then
-        printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+        print_overall_passed
     else
-        printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+        print_overall_failed
         failcount=$((failcount+1))
     fi
 
     # Check services headless
     count=0
-    printf "${INFO}| Checking Services: Headless |${NC}\n"
+    print_info "| Checking Services: Headless |"
     while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
         if [[ "${status[0]}" != "" ]]; then
-            printf "${status[0]}..."
+            printf "%s..." "${status[0]}"
             if [[ "${status[1]}" != "ClusterIP" ]]; then
-                printf "${FAILED}FAILED${NC}\n"
+                print_fail "FAILED"
                 failcount=$((failcount+1))
             else
-                printf "${PASSED}PASSED${NC}\n"
+                print_passed "PASSED"
                 count=$((count+1))
             fi
         fi
     done <<< "$(kubectl get services --namespace="${namespace}" | grep 'cortx-client-headless-')"
 
     if [[ ${num_nodes} -eq ${count} ]]; then
-        printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+        print_overall_passed
     else
-        printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+        print_overall_failed
         failcount=$((failcount+1))
     fi
 
     # Check storage local
     count=0
     num_pvs_pvcs=$(( num_nodes * 2 ))
-    printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+    print_info "| Checking Storage: Local [PVCs/PVs] |"
     while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
         if [[ "${status[0]}" != "" ]]; then
-            printf "PVC: ${status[0]}..."
+            printf "PVC: %s..." "${status[0]}"
             if [[ "${status[1]}" != "Bound" ]]; then
-                printf "${FAILED}FAILED${NC}\n"
+                print_fail "FAILED"
                 failcount=$((failcount+1))
             else
-                printf "${PASSED}PASSED${NC}\n"
+                print_passed "PASSED"
                 count=$((count+1))
             fi
         fi
@@ -739,21 +783,21 @@ if [[ ${num_motr_client} -gt 0 ]]; then
     while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
         if [[ "${status[0]}" != "" ]]; then
-            printf "PV: ${status[5]}..."
+            printf "PV: %s..." "${status[5]}"
             if [[ "${status[4]}" != "Bound" ]]; then
-                printf "${FAILED}FAILED${NC}\n"
+                print_fail "FAILED"
                 failcount=$((failcount+1))
             else
-                printf "${PASSED}PASSED${NC}\n"
+                print_passed "PASSED"
                 count=$((count+1))
             fi
         fi
     done <<< "$(kubectl get pv --namespace="${namespace}" | grep 'cortx-client-fs-local-pvc')"
 
     if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-        printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+        print_overall_passed
     else
-        printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+        print_overall_failed
         failcount=$((failcount+1))
     fi
 fi
@@ -777,126 +821,126 @@ num_replicas=${num_nodes}
 if [[ "${num_nodes}" -gt "${max_replicas}" ]]; then
     num_replicas=${max_replicas}
 fi
-printf "${ALERT}######################################################${NC}\n"
-printf "${ALERT}# 3rd Party                                           ${NC}\n"
-printf "${ALERT}######################################################${NC}\n"
+print_alert "######################################################"
+print_alert "# 3rd Party                                           "
+print_alert "######################################################"
 
-printf "${ALERT}### Kafka${NC}\n"
+print_alert "### Kafka"
 # Check StatefulSet
 num_items=1
 count=0
-printf "${INFO}| Checking StatefulSet |${NC}\n"
+print_info "| Checking StatefulSet |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get statefulsets | grep 'kafka')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check Pods
 num_items=${num_replicas}
 count=0
-printf "${INFO}| Checking Pods |${NC}\n"
+print_info "| Checking Pods |"
 while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pods | grep 'kafka-')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services cluster IP
 num_items=1
 count=0
-printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
+print_info "| Checking Services: Cluster IP |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services | grep 'kafka' | grep -v 'kafka-headless')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services headless
 num_items=1
 count=0
-printf "${INFO}| Checking Services: Headless |${NC}\n"
+print_info "| Checking Services: Headless |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services | grep 'kafka-headless')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage local
 count=0
 num_pvs_pvcs=$(( num_replicas * 2 ))
-printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Local [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -905,140 +949,140 @@ done <<< "$(kubectl get pvc | grep 'kafka-')"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv | grep 'kafka-')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
-printf "${ALERT}### Zookeeper${NC}\n"
+print_alert "### Zookeeper"
 # Check StatefulSet
 num_items=1
 count=0
-printf "${INFO}| Checking StatefulSet |${NC}\n"
+print_info "| Checking StatefulSet |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get statefulsets | grep 'zookeeper')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check Pods
 num_items=${num_replicas}
 count=0
-printf "${INFO}| Checking Pods |${NC}\n"
+print_info "| Checking Pods |"
 while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pods | grep 'zookeeper-')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services cluster IP
 num_items=1
 count=0
-printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
+print_info "| Checking Services: Cluster IP |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services | grep 'zookeeper' | grep -v 'zookeeper-headless')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services headless
 num_items=1
 count=0
-printf "${INFO}| Checking Services: Headless |${NC}\n"
+print_info "| Checking Services: Headless |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services | grep 'zookeeper-headless')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage local
 count=0
 num_pvs_pvcs=$(( num_replicas * 2 ))
-printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Local [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -1047,165 +1091,165 @@ done <<< "$(kubectl get pvc | grep 'zookeeper-')"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv | grep 'zookeeper-')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
-printf "${ALERT}### Consul${NC}\n"
+print_alert "### Consul"
 # Check StatefulSet
 num_items=1
 count=0
-printf "${INFO}| Checking StatefulSet |${NC}\n"
+print_info "| Checking StatefulSet |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get statefulsets | grep 'consul')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check DaemonSet
 num_items=1
 count=0
-printf "${INFO}| Checking DaemonSet |${NC}\n"
+print_info "| Checking DaemonSet |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[3]}" != "${num_worker_nodes}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get daemonsets | grep 'consul')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check Pods
 num_items=$(( num_replicas + num_worker_nodes ))
 count=0
-printf "${INFO}| Checking Pods |${NC}\n"
+print_info "| Checking Pods |"
 while IFS= read -r line; do
         IFS=" " read -r -a status <<< "${line}"
     IFS="/" read -r -a ready_status <<< "${status[1]}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pods | grep 'consul-')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services cluster IP
 num_items=1
 count=0
-printf "${INFO}| Checking Services: Cluster IP |${NC}\n"
+print_info "| Checking Services: Cluster IP |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services | grep 'consul' | grep -v 'consul-server')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check services headless
 num_items=1
 count=0
-printf "${INFO}| Checking Services: Headless |${NC}\n"
+print_info "| Checking Services: Headless |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "${status[0]}..."
+        printf "%s..." "${status[0]}"
         if [[ "${status[1]}" != "ClusterIP" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get services | grep 'consul-server')"
 
 if [[ ${num_items} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 # Check storage local
 count=0
 num_pvs_pvcs=$(( num_replicas * 2 ))
-printf "${INFO}| Checking Storage: Local [PVCs/PVs] |${NC}\n"
+print_info "| Checking Storage: Local [PVCs/PVs] |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PVC: ${status[0]}..."
+        printf "PVC: %s..." "${status[0]}"
         if [[ "${status[1]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
@@ -1214,30 +1258,31 @@ done <<< "$(kubectl get pvc | grep 'consul-server-')"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     if [[ "${status[0]}" != "" ]]; then
-        printf "PV: ${status[5]}..."
+        printf "PV: %s..." "${status[5]}"
         if [[ "${status[4]}" != "Bound" ]]; then
-            printf "${FAILED}FAILED${NC}\n"
+            print_fail "FAILED"
             failcount=$((failcount+1))
         else
-            printf "${PASSED}PASSED${NC}\n"
+            print_passed "PASSED"
             count=$((count+1))
         fi
     fi
 done <<< "$(kubectl get pv | grep 'consul-server-')"
 
 if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    printf "OVERALL STATUS: ${PASSED}PASSED${NC}\n"
+    print_overall_passed
 else
-    printf "OVERALL STATUS: ${FAILED}FAILED${NC}\n"
+    print_overall_failed
     failcount=$((failcount+1))
 fi
 
 printf -- "------------------------------------------\n"
 
 if (( failcount > 0 )); then
-    printf "${FAILED}${failcount} status checks failed${NC}\n\n"
+    print_failed "${failcount} status checks failed"
     exit 1
 else
-    printf "${PASSED}All status checks passed${NC}\n\n"
+    print_passed "All status checks passed"
+    printf "\n"
     exit 0
 fi

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -761,8 +761,8 @@ fi
 #########################################################################################
 while IFS= read -r line; do
     IFS=" " read -r -a node_name <<< "${line}"
-    if [[ "${node_name}" != "NAME" ]]; then
-        output=$(kubectl describe nodes ${node_name} | grep Taints | grep NoSchedule)
+    if [[ "${node_name[0]}" != "NAME" ]]; then
+        output=$(kubectl describe nodes ${node_name[0]} | grep Taints | grep NoSchedule)
         if [[ "${output}" == "" ]]; then
             num_worker_nodes=$((num_worker_nodes+1))
         fi

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC2312
+
 solution_yaml=${1:-'solution.yaml'}
 
 # Check if the file exists

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -18,7 +18,7 @@ NC='\033[0m'              #NO COLOUR
 
 function parseSolution()
 {
-    echo "$(./parse_scripts/parse_yaml.sh ${solution_yaml} $1)"
+    ./parse_scripts/parse_yaml.sh ${solution_yaml} $1
 }
 
 namespace=$(parseSolution 'solution.namespace')
@@ -625,7 +625,7 @@ fi
 
 function extractBlock()
 {
-    echo "$(./parse_scripts/yaml_extract_block.sh ${solution_yaml} $1)"
+    ./parse_scripts/yaml_extract_block.sh ${solution_yaml} $1
 }
 
 num_motr_client=$(extractBlock 'solution.common.motr.num_client_inst')

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -3,8 +3,7 @@
 solution_yaml=${1:-'solution.yaml'}
 
 # Check if the file exists
-if [ ! -f ${solution_yaml} ]
-then
+if [[ ! -f ${solution_yaml} ]]; then
     echo "ERROR: ${solution_yaml} does not exist"
     exit 1
 fi


### PR DESCRIPTION
Fix the following shellcheck errors/warnings:

- Don't use variables in the printf format string. Use printf '..%s..' "$foo". [SC2059]
- Double quote to prevent globbing and word splitting. [SC2086]
- Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore). [SC2312]
- Expanding an array without an index only gives the first element. [SC2128]
- Useless echo? Instead of 'echo $(cmd)', just use 'cmd'. [SC2005]
- node_list_str appears unused. Verify use (or export if used externally). [SC2034]
- Prefer [[ ]] over [ ] for tests in Bash/Ksh. [SC2292]
- Prefer putting braces around variable references even when not strictly required. [SC2250]
- $/${} is unnecessary on arithmetic variables. [SC2004]

SC2312 is disabled completely in this script since updating each shell statement to return true has little value. The point of the check is to make sure errors are handled, except we don't check for errors at all (or even implicitly by `set -e`).

Other changes:

- Implement color messages according to bash template example (https://betterdev.blog/minimal-safe-bash-script-template/)
- Enable the checking of `status-cortx-cloud.sh` in the GitHub Lint action
