### PR TITLE
CORTX-27683: Update hax and motr endpoint values

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
@@ -48,14 +48,14 @@ spec:
       - name: cortx-setup
         image: {{ .Values.cortxclient.image }}
         imagePullPolicy: IfNotPresent
-        command: 
+        command:
           - /bin/sh
         {{- if eq .Values.cortxclient.image  "ghcr.io/seagate/centos:7" }}
         args:
           - -c
           - sleep $(shuf -i 5-10 -n 1)s
         {{- else }}
-        args: 
+        args:
           - -c
           {{- if .Values.cortxclient.machineid.value }}
           - set -x;
@@ -136,7 +136,7 @@ spec:
             - /bin/sh
           args:
             - -c
-            - /opt/seagate/cortx/hare_setup start --config yaml:///etc/cortx/cluster.conf;
+            - /opt/seagate/cortx/hare/bin/hare_setup start --config yaml:///etc/cortx/cluster.conf;
               sleep infinity;
           {{- end }}
           volumeMounts:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
@@ -121,6 +121,9 @@ cortx:
     {{- if gt (len .Values.cortxMotr.clientEndpoints) 0 }}
       - name: motr_client
         num_instances: {{ len .Values.cortxMotr.clientEndpoints }}
+        num_subscriptions: 1
+        subscriptions:
+        - fdmi
         endpoints: {{- toYaml .Values.cortxMotr.clientEndpoints | nindent 8 }}
     {{- end }}
     limits:

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -603,8 +603,8 @@ function deployCortxConfigMap()
 
     for idx in "${!node_name_list[@]}"; do
         helm_install_args+=(
-            --set "cortxHare.haxDataEndpoints[${idx}]=tcp://cortx-data-headless-svc-${node_name_list[${idx}]}:22002"
-            --set "cortxHare.haxServerEndpoints[${idx}]=tcp://cortx-server-headless-svc-${node_name_list[${idx}]}:22002"
+            --set "cortxHare.haxDataEndpoints[${idx}]=tcp://cortx-data-headless-svc-${node_name_list[${idx}]}:22001"
+            --set "cortxHare.haxServerEndpoints[${idx}]=tcp://cortx-server-headless-svc-${node_name_list[${idx}]}:22001"
             --set "cortxMotr.confdEndpoints[${idx}]=tcp://cortx-data-headless-svc-${node_name_list[${idx}]}:22002"
             --set "cortxMotr.iosEndpoints[${idx}]=tcp://cortx-data-headless-svc-${node_name_list[${idx}]}:21001"
             --set "cortxMotr.rgwEndpoints[${idx}]=tcp://cortx-server-headless-svc-${node_name_list[${idx}]}:21001"
@@ -614,7 +614,7 @@ function deployCortxConfigMap()
     if ((num_motr_client > 0)); then
         for idx in "${!node_name_list[@]}"; do
             helm_install_args+=(
-                --set "cortxMotr.clientEndpoints[${idx}]=tcp://cortx-client-headless-svc-${node_name_list[${idx}]}:21001"
+                --set "cortxMotr.clientEndpoints[${idx}]=tcp://cortx-client-headless-svc-${node_name_list[${idx}]}:21201"
                 --set "cortxHare.haxClientEndpoints[${idx}]=tcp://cortx-client-headless-svc-${node_name_list[${idx}]}:22001"
             )
         done


### PR DESCRIPTION
Updating according to latest [sample config.yaml](https://github.com/Seagate/cortx-prvsnr/blob/2210210cb493cd7f7a3ee99496bc90e69179f1ea/conf/solution/config.yaml.sample) example.

Fix container command for client pods.

After deploying with this change, the `config.yaml` in the ConfigMap matches the sample file. However, I am unable to test any kind of functionality. As far as I can tell, these settings are ignored by the CORTX components, as I cannot find any processes listening on the configured ports. Regardless, `hctl status` looks normal, and S3 I/O is successful.

Signed-off-by: Keith Pine <keith.pine@seagate.com>