### PR TITLE
removing CODEOWNERS from cortx-test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-# This is a global CODEOWNERS file for the cortx-k8s repository,
-# which will utilize the "cortx-k8s-admins" group as the main
-# CODEOWNERS functional unit for all code.
-
-*   @Seagate/cortx-k8s-admin


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

Removing CODEOWNERS file from the `cortx-test` branch, as those commits and PRs are not managed or need to be overseen by the `cortx-k8s-admin` group (which is only managing `integration` and `main` branch PRs).

Per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location, the CODEOWNERS file should exist in the base branch we desire code owners to receive requests for. Therefore, it doesn't need to exist in the `cortx-test` branch for the time being. 