### PR TITLE
CORTX-28509: Remove secrets mounts from non-init containers

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
@@ -113,11 +113,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ $.Values.cortxclient.localpathpvc.mountpath }}
-            {{- range $.Files.Lines $.Values.cortxclient.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ $.Values.cortxclient.name }}
@@ -150,11 +145,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxclient.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxclient.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxclient.name }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
@@ -95,7 +95,7 @@ spec:
           {{- if eq .Values.cortxcontrol.image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
-          command: 
+          command:
             - /bin/sh
           args:
             - -c
@@ -113,11 +113,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxcontrol.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxcontrol.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxcontrol.name }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
@@ -81,15 +81,15 @@ spec:
       initContainers:
       - name: cortx-setup
         image: {{ .Values.cortxdata.image }}
-        imagePullPolicy: IfNotPresent        
-        command: 
+        imagePullPolicy: IfNotPresent
+        command:
           - /bin/sh
         {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
-        args: 
+        args:
           - -c
           - sleep $(shuf -i 5-10 -n 1)s
         {{- else }}
-        args: 
+        args:
           - -c
           {{- if .Values.cortxdata.machineid.value }}
           - /opt/seagate/cortx/provisioner/bin/cortx_deploy -n $MACHINE_ID -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
@@ -136,13 +136,13 @@ spec:
             readOnly: true
           {{- end }}
         env:
-          - name: MACHINE_ID            
+          - name: MACHINE_ID
             value: {{ printf "%s" .Values.cortxdata.machineid.value | quote }}
         ports:
         - containerPort: 5050
       - name: node-config
         image: {{ .Values.cortxdata.image }}
-        imagePullPolicy: IfNotPresent        
+        imagePullPolicy: IfNotPresent
         command:
           - /nodeconfig/entrypoint.sh
         volumeMounts:
@@ -155,10 +155,10 @@ spec:
         - name: cortx-hax
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
+          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
-          command: 
+          command:
             - /bin/sh
           args:
             - -c
@@ -175,11 +175,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxdata.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxdata.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxdata.name }}
@@ -190,7 +185,7 @@ spec:
         - name: cortx-motr-confd
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
+          {{- if eq .Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -232,11 +227,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxdata.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxdata.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxdata.name }}
@@ -253,7 +243,7 @@ spec:
               value: {{ $.Values.cortxdata.name }}
             - name: IO_INDEX
               value: {{ printf "%d" (add 1 $i) | quote }}
-          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}          
+          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -295,11 +285,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ $.Values.cortxdata.localpathpvc.mountpath }}
-            {{- range $.Files.Lines $.Values.cortxdata.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           ports:
           - containerPort: {{ printf "%d" (add $i $.Values.cortxdata.motr.startportnum) }}
           securityContext:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
@@ -85,7 +85,7 @@ spec:
             readOnly: true
           {{- end }}
         env:
-          - name: MACHINE_ID            
+          - name: MACHINE_ID
             value: {{ printf "%s" .Values.cortxha.machineid.value | quote }}
         ports:
         - containerPort: 5050
@@ -113,11 +113,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxha.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxha.name }}
@@ -146,11 +141,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxha.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxha.name }}
@@ -179,11 +169,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxha.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxha.name }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
@@ -117,11 +117,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxserver.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxserver.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxserver.name }}
@@ -154,11 +149,6 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxserver.localpathpvc.mountpath }}
-            {{- range .Files.Lines .Values.cortxserver.secretinfo }}
-            - name: {{ printf "%s" . }}
-              mountPath: /etc/cortx/solution/secret
-              readOnly: true
-            {{- end }}
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxserver.name }}


### PR DESCRIPTION
Secrets are only required in init containers, where the secrets are encrypted and stored during provisioning. Regular containers access the secrets via the cluster config file.

Signed-off-by: Keith Pine <keith.pine@seagate.com>