### PR TITLE
CORTX-29234: Default nodePorts to `null` in solution.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,11 @@ This section contains common parameters that affect all CORTX components running
 | `common.external_services.s3.count`                   | The number of service instances to create when service type is `LoadBalancer`                     | `1` |
 | `common.external_services.s3.ports.http`              | Non-secure (http) port number used for S3 IO                                                      | `8000` |
 | `common.external_services.s3.ports.https`             | Secure (https) service port number for S3 IO                                                      | `8443` |
-| `common.external_services.s3.nodePorts.http`          |  _(Optional)_ Node port for non-secure (http) S3 IO                                               | None |
-| `common.external_services.s3.nodePorts.https`         |  _(Optional)_ Node port for secure (https) S3 IO                                                  | None |
+| `common.external_services.s3.nodePorts.http`          |  _(Optional)_ Node port for non-secure (http) S3 IO                                               | `null` |
+| `common.external_services.s3.nodePorts.https`         |  _(Optional)_ Node port for secure (https) S3 IO                                                  | `null` |
 | `common.external_services.control.type`               | Kubernetes Service type for external access to CSM Management API                                 | `NodePort` |
 | `common.external_services.control.ports.https`        | Secure (https) service port number for CSM Management API.                                        | `8081` |
-| `common.external_services.control.nodePorts.https`    | _(Optional)_ Node port for secure (https) CSM Management API.                                     | None |
+| `common.external_services.control.nodePorts.https`    | _(Optional)_ Node port for secure (https) CSM Management API.                                     | `null` |
 | `common.resource_allocation.*.storage`                | The desired storage space allocated to PVCs used by that component                                | See `solution.yaml` |
 | `common.resource_allocation.*.resources.requests.*`   | CPU & Memory requested for Pods managed by a specific component                                   | See `solution.yaml` |
 | `common.resource_allocation.*.resources.limits.*`     | CPU & Memory limits for Pods managed by a specific component                                      | See `solution.yaml` |

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -93,7 +93,7 @@ function extractBlock()
 #   Wildcard paths are not accepted, e.g. "solution.nodes.node*.name".
 # Outputs:
 #   Writes the value to stdout. An empty string "" is printed if
-#   the value does not exist.
+#   the value does not exist, or the value is YAML `null` or `~`.
 # Returns:
 #   1 if the yaml path contains a wildcard, 0 otherwise.
 #######################################
@@ -108,7 +108,9 @@ function getSolutionValue()
     local value
     value=$(parseSolution "${yaml_path}")
     # discard everything before and including the first '>'
-    echo "${value#*>}"
+    value="${value#*>}"
+    [[ ${value} == "null" || ${value} == "~" ]] && value=""
+    echo "${value}"
 }
 
 namespace=$(parseSolution 'solution.namespace')

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -55,14 +55,14 @@ solution:
           http: 8000
           https: 8443
         nodePorts:
-          http: ""
-          https: ""
+          http: null
+          https: null
       control:
         type: NodePort
         ports:
           https: 8081
         nodePorts:
-          https: ""
+          https: null
     resource_allocation:
       consul:
         server:

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -54,14 +54,14 @@ solution:
           http: 8000
           https: 8443
         nodePorts:
-          http: ""
-          https: ""
+          http: null
+          https: null
       control:
         type: NodePort
         ports:
           https: 8081
         nodePorts:
-          https: ""
+          https: null
     resource_allocation:
       consul:
         server:


### PR DESCRIPTION
Cosmetic change only, no functional difference. Since the port value is an integer, `null` makes a little more sense to use than an empty string.

`""`, '~'`, `null` or the omission of the node port values are all valid and have the exact same behavior, which results in the assignment of random port numbers.

Signed-off-by: Keith Pine <keith.pine@seagate.com>

-----
[View rendered README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-29234_nodeport-defaults/README.md)