### PR TITLE
Rename `solution.yaml` to `solution.example.yaml`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,39 +120,44 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
 
 1. Clone this repository to a machine with connectivity to your Kubernetes cluster:
 
-   ```bash
-   git clone https://github.com/Seagate/cortx-k8s
-   ```
+    ```bash
+    git clone https://github.com/Seagate/cortx-k8s
+    ```
 
->  :information_source: You can also use the latest released version of the CORTX on Kubernetes code via the **Releases** page found at https://github.com/Seagate/cortx-k8s/releases/latest
+    >  :information_source: You can also use the latest released version of the CORTX on Kubernetes code via the **Releases** page found at https://github.com/Seagate/cortx-k8s/releases/latest
 
 2. For initial deployments, copy the example solution configuration file [`./k8_cortx_cloud/solution.example.yaml`](k8_cortx_cloud/solution.example.yaml) to `./k8_cortx_cloud/solution.yaml` or to a filename of your choice.
 
 3. Update the solution configuration file to reflect your environment. The most common and expected updates are reflected below:
 
     - Update all passwords. The `csm-secret` should include one special character in cortx-secret.
+
     - Update the images section with cortx-all image tag desired to be used.
         - Each specific release of the CORTX on Kubernetes code will point to a specific predefined container image.
         - This can be overridden as desired.
+
     - Update SNS and DIX durability values. The default value for both parameters is `1+0+0`.
+
     - Update storage cvg devices for data and metadata with respect to the devices in your environment.
+
     - Update nodes section with proper node hostnames from your Kubernetes cluster.
         - If the Kubernetes control plane nodes are required to be used for deployment, make sure to remove the taint from it before deploying CORTX.
         - For further details and reference, you can view the official Kubernetes documentation topic on [Taints & Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+
     - For further details on the solution configuration file specifics, review the [Solution YAML Overview](#solution-yaml-overview) section below.
 
 4. Run the `deploy-cortx-cloud.sh` script, passing in the path to your updated `solution.yaml` file.
 
-   ```bash
-   ./deploy-cortx-cloud.sh solution.yaml
-   ```
+    ```bash
+    ./deploy-cortx-cloud.sh solution.yaml
+    ```
 
 5. Validate CORTX on Kubernetes status
 
-   ```bash
-   DATA_POD=$(kubectl get pods -l cortx.io/service-type=cortx-data --no-headers | awk '{print $1}' | head -n 1)
-   kubectl exec -it $DATA_POD -c cortx-hax -- /bin/bash -c "hctl status"
-   ```
+    ```bash
+    DATA_POD=$(kubectl get pods -l cortx.io/service-type=cortx-data --no-headers | awk '{print $1}' | head -n 1)
+    kubectl exec -it $DATA_POD -c cortx-hax -- /bin/bash -c "hctl status"
+    ```
 
 ### Upgrading CORTX on Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -120,44 +120,44 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
 
 1. Clone this repository to a machine with connectivity to your Kubernetes cluster:
 
-    ```bash
-    git clone https://github.com/Seagate/cortx-k8s
-    ```
+   ```bash
+   git clone https://github.com/Seagate/cortx-k8s
+   ```
 
-    >  :information_source: You can also use the latest released version of the CORTX on Kubernetes code via the **Releases** page found at https://github.com/Seagate/cortx-k8s/releases/latest
+   >  :information_source: You can also use the latest released version of the CORTX on Kubernetes code via the **Releases** page found at https://github.com/Seagate/cortx-k8s/releases/latest
 
 2. For initial deployments, copy the example solution configuration file [`./k8_cortx_cloud/solution.example.yaml`](k8_cortx_cloud/solution.example.yaml) to `./k8_cortx_cloud/solution.yaml` or to a filename of your choice.
 
 3. Update the solution configuration file to reflect your environment. The most common and expected updates are reflected below:
 
-    - Update all passwords. The `csm-secret` should include one special character in cortx-secret.
+   - Update all passwords. The `csm-secret` should include one special character in cortx-secret.
 
-    - Update the images section with cortx-all image tag desired to be used.
-        - Each specific release of the CORTX on Kubernetes code will point to a specific predefined container image.
-        - This can be overridden as desired.
+   - Update the images section with cortx-all image tag desired to be used.
+     - Each specific release of the CORTX on Kubernetes code will point to a specific predefined container image.
+     - This can be overridden as desired.
 
-    - Update SNS and DIX durability values. The default value for both parameters is `1+0+0`.
+   - Update SNS and DIX durability values. The default value for both parameters is `1+0+0`.
 
-    - Update storage cvg devices for data and metadata with respect to the devices in your environment.
+   - Update storage cvg devices for data and metadata with respect to the devices in your environment.
 
-    - Update nodes section with proper node hostnames from your Kubernetes cluster.
-        - If the Kubernetes control plane nodes are required to be used for deployment, make sure to remove the taint from it before deploying CORTX.
-        - For further details and reference, you can view the official Kubernetes documentation topic on [Taints & Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+   - Update nodes section with proper node hostnames from your Kubernetes cluster.
+     - If the Kubernetes control plane nodes are required to be used for deployment, make sure to remove the taint from it before deploying CORTX.
+     - For further details and reference, you can view the official Kubernetes documentation topic on [Taints & Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 
-    - For further details on the solution configuration file specifics, review the [Solution YAML Overview](#solution-yaml-overview) section below.
+   - For further details on the solution configuration file specifics, review the [Solution YAML Overview](#solution-yaml-overview) section below.
 
 4. Run the `deploy-cortx-cloud.sh` script, passing in the path to your updated `solution.yaml` file.
 
-    ```bash
-    ./deploy-cortx-cloud.sh solution.yaml
-    ```
+   ```bash
+   ./deploy-cortx-cloud.sh solution.yaml
+   ```
 
 5. Validate CORTX on Kubernetes status
 
-    ```bash
-    DATA_POD=$(kubectl get pods -l cortx.io/service-type=cortx-data --no-headers | awk '{print $1}' | head -n 1)
-    kubectl exec -it $DATA_POD -c cortx-hax -- /bin/bash -c "hctl status"
-    ```
+   ```bash
+   DATA_POD=$(kubectl get pods -l cortx.io/service-type=cortx-data --no-headers | awk '{print $1}' | head -n 1)
+   kubectl exec -it $DATA_POD -c cortx-hax -- /bin/bash -c "hctl status"
+   ```
 
 ### Upgrading CORTX on Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
 
 ### Deploying CORTX on Kubernetes
 
-1.  Clone this repository to a machine with connectivity to your Kubernetes cluster:
+1. Clone this repository to a machine with connectivity to your Kubernetes cluster:
 
    ```bash
    git clone https://github.com/Seagate/cortx-k8s
@@ -126,9 +126,10 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
 
 >  :information_source: You can also use the latest released version of the CORTX on Kubernetes code via the **Releases** page found at https://github.com/Seagate/cortx-k8s/releases/latest
 
-2.  For initial deployments, copy the example solution configuration file [`./k8_cortx_cloud/solution.example.yaml`](k8_cortx_cloud/solution.example.yaml) to `./k8_cortx_cloud/solution.yaml` or to a filename of your choice.
+2. For initial deployments, copy the example solution configuration file [`./k8_cortx_cloud/solution.example.yaml`](k8_cortx_cloud/solution.example.yaml) to `./k8_cortx_cloud/solution.yaml` or to a filename of your choice.
 
-3.  Update the solution configuration file to reflect your environment. The most common and expected updates are reflected below:
+3. Update the solution configuration file to reflect your environment. The most common and expected updates are reflected below:
+
     - Update all passwords. The `csm-secret` should include one special character in cortx-secret.
     - Update the images section with cortx-all image tag desired to be used.
         - Each specific release of the CORTX on Kubernetes code will point to a specific predefined container image.
@@ -140,13 +141,13 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
         - For further details and reference, you can view the official Kubernetes documentation topic on [Taints & Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
     - For further details on the solution configuration file specifics, review the [Solution YAML Overview](#solution-yaml-overview) section below.
 
-4.  Run the `deploy-cortx-cloud.sh` script, passing in the path to your updated `solution.yaml` file.
+4. Run the `deploy-cortx-cloud.sh` script, passing in the path to your updated `solution.yaml` file.
 
    ```bash
    ./deploy-cortx-cloud.sh solution.yaml
    ```
 
-4.  Validate CORTX on Kubernetes status
+5. Validate CORTX on Kubernetes status
 
    ```bash
    DATA_POD=$(kubectl get pods -l cortx.io/service-type=cortx-data --no-headers | awk '{print $1}' | head -n 1)

--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
 
 >  :information_source: You can also use the latest released version of the CORTX on Kubernetes code via the **Releases** page found at https://github.com/Seagate/cortx-k8s/releases/latest
 
-2.  Update or clone `./k8_cortx_cloud/solution.yaml` to reflect your environment. The most common and expected updates are reflected below:
-    - Update all passwords in solution.yaml. The `csm-secret` should include one special character in cortx-secret.
+2.  For initial deployments, copy the example solution configuration file [`./k8_cortx_cloud/solution.example.yaml`](k8_cortx_cloud/solution.example.yaml) to `./k8_cortx_cloud/solution.yaml` or to a filename of your choice.
+
+3.  Update the solution configuration file to reflect your environment. The most common and expected updates are reflected below:
+    - Update all passwords. The `csm-secret` should include one special character in cortx-secret.
     - Update the images section with cortx-all image tag desired to be used.
         - Each specific release of the CORTX on Kubernetes code will point to a specific predefined container image.
         - This can be overridden as desired.
@@ -136,9 +138,9 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
     - Update nodes section with proper node hostnames from your Kubernetes cluster.
         - If the Kubernetes control plane nodes are required to be used for deployment, make sure to remove the taint from it before deploying CORTX.
         - For further details and reference, you can view the official Kubernetes documentation topic on [Taints & Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
-    - For further details on `solution.yaml` specifics, review the [Solution YAML Overview](#solution-yaml-overview) below.
+    - For further details on the solution configuration file specifics, review the [Solution YAML Overview](#solution-yaml-overview) section below.
 
-3.  Run the `deploy-cortx-cloud.sh` script, passing in the path to your updated `solution.yaml` file.
+4.  Run the `deploy-cortx-cloud.sh` script, passing in the path to your updated `solution.yaml` file.
 
    ```bash
    ./deploy-cortx-cloud.sh solution.yaml
@@ -186,7 +188,9 @@ Run the `destroy-cortx-cloud.sh` script, passing in the path to the previously u
 
 ## Solution YAML Overview
 
-The CORTX solution consists of all parameters required to deploy CORTX on Kubernetes. The pre-req, deploy, and destroy scripts parse the solution file and extract information they need to deploy and destroy CORTX.
+The CORTX solution configuration file consists of all parameters required to deploy CORTX on Kubernetes. The pre-req, deploy, and destroy scripts parse the solution configuration file and extract information they need to deploy and destroy CORTX.
+
+An example solution configuration is provided by [`solution.example.yaml`](k8_cortx_cloud/solution.example.yaml).
 
 All paths below are prefixed with `solution.` for fully-qualified naming and are required to have a value unless explicitly marked as _(Optional)_ below.
 
@@ -265,7 +269,7 @@ This section contains common parameters that affect all CORTX components running
 | `common.motr.num_client_inst`                         | TODO       | `0` |
 | `common.motr.start_port_num`                          | TODO       | `29000` |
 | `common.motr.extra_configuration`                     | _(Optional)_ Extra configuration settings to append to the Motr configuration. The value is a multi-line string included verbatim. | `""` |
-| `common.hax.protocol`                                 | Protocol that is used to communicate with HAX components running across Server and Data Pods.     | `https` | 
+| `common.hax.protocol`                                 | Protocol that is used to communicate with HAX components running across Server and Data Pods.     | `https` |
 | `common.hax.service_name`                             | Service name that is used to communicate with HAX components running across Server and Data Pods. | `cortx-hax-svc` |
 | `common.hax.port_num`                                 | Port number that is used to communicate with HAX components running across Server and Data Pods.  | `22003` |
 | `common.external_services.s3.type`                    | Kubernetes Service type for external access to S3 IO                                              | `NodePort` |

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -1,5 +1,3 @@
-# solution.yaml file will be removed in v0.3.0
-# please refer to solution.example.yaml instead
 solution:
   namespace: default
   deployment_type: standard


### PR DESCRIPTION
This serves a few purposes:

- Less chance of accidental modifications to the source controlled example
- Avoids accidental use of the wrong file (default as `solution.yaml`) when using files with different names
- Makes it obvious that the default file is just an example that should be customized

Signed-off-by: Keith Pine <keith.pine@seagate.com>

-----
[View rendered README.md](https://github.com/keithpine/cortx-k8s/blob/solution-rename/README.md)