### PR TITLE
CORTX-27775: Update prereq regtest with interface change

### DIFF
--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -200,8 +200,8 @@ class Cluster:
             result += RemoteRun(node, self.user).scp(files, '/tmp/cortx-k8s') # nosec B108
             result += RemoteRun(node, self.user).run(
                                   f'cd /tmp/cortx-k8s; '
-                                  f'./prereq-deploy-cortx-cloud.sh {blkdev} '
-                                  f'{os.path.basename(self.solution_file)}')
+                                  f'./prereq-deploy-cortx-cloud.sh -d {blkdev} '
+                                  f'-s {os.path.basename(self.solution_file)}')
             result += RemoteRun(node, self.user).run('rm -rf /tmp/cortx-k8s')
             print("\n\n")
 


### PR DESCRIPTION
With commit 42f996b the command-line interface to prereq-deploy-cortx-cloud.sh changes so that instead of positional args it takes -d / -s args.  This update to the regtest file adapts to that change.