### PR TITLE
CORTX-29122: Restore CORTX passwords

### DIFF
--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -6,7 +6,7 @@ solution:
       kafka_admin_secret: Seagate@123
       consul_admin_secret: Seagate@123
       common_admin_secret: Seagate@123
-      s3_auth_admin_secret: cortxadmin
+      s3_auth_admin_secret: ldapadmin
       csm_auth_admin_secret: seagate2
       csm_mgmt_admin_secret: Cortxadmin@123
   images:

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -3,12 +3,12 @@ solution:
   secrets:
     name: cortx-secret
     content:
-      kafka_admin_secret: null
-      consul_admin_secret: null
-      common_admin_secret: null
-      s3_auth_admin_secret: null
-      csm_auth_admin_secret: null
-      csm_mgmt_admin_secret: null
+      kafka_admin_secret: Seagate@123
+      consul_admin_secret: Seagate@123
+      common_admin_secret: Seagate@123
+      s3_auth_admin_secret: cortxadmin
+      csm_auth_admin_secret: seagate2
+      csm_mgmt_admin_secret: Cortxadmin@123
   images:
     cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-686
     cortxdata: ghcr.io/seagate/cortx-all:2.0.0-686

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -6,7 +6,7 @@ solution:
       kafka_admin_secret: Seagate@123
       consul_admin_secret: Seagate@123
       common_admin_secret: Seagate@123
-      s3_auth_admin_secret: cortxadmin
+      s3_auth_admin_secret: ldapadmin
       csm_auth_admin_secret: seagate2
       csm_mgmt_admin_secret: Cortxadmin@123
   images:

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -3,12 +3,12 @@ solution:
   secrets:
     name: cortx-secret
     content:
-      kafka_admin_secret: null
-      consul_admin_secret: null
-      common_admin_secret: null
-      s3_auth_admin_secret: null
-      csm_auth_admin_secret: null
-      csm_mgmt_admin_secret: null
+      kafka_admin_secret: Seagate@123
+      consul_admin_secret: Seagate@123
+      common_admin_secret: Seagate@123
+      s3_auth_admin_secret: cortxadmin
+      csm_auth_admin_secret: seagate2
+      csm_mgmt_admin_secret: Cortxadmin@123
   images:
     cortxcontrol: ghcr.io/seagate/centos:7
     cortxdata: ghcr.io/seagate/centos:7


### PR DESCRIPTION
We have decided that rather than make such a significant
change as generating passwords by default that we would
first issue a written warning that this will happen in the
next release.

This changeset restores the CORTX passwords that were removed
as part of the prior CORTX-29122 change.  This change
will be reverted in the next release in a few weeks after
the QA and DevOps teams have had a chance to accommodate
these changes.