### PR TITLE
CORTX-29548: Support rgw image in upgrade-cortx-cloud.sh

### DIFF
--- a/k8_cortx_cloud/upgrade-cortx-cloud.sh
+++ b/k8_cortx_cloud/upgrade-cortx-cloud.sh
@@ -157,9 +157,17 @@ cortx_deployments="$(kubectl get deployments --namespace="${NAMESPACE}" --output
 if [[ -z ${cortx_deployments} ]]; then
     printf "No CORTX Deployments were found so the image upgrade cannot be performed. The cluster will be restarted.\n"
 else
-    printf "Updating CORTX Deployments to use image %s\n" "${UPGRADE_IMAGE}"
+    RGW_IMAGE="${UPGRADE_IMAGE/cortx-all/cortx-rgw}"
+    printf "Updating CORTX Deployments to use:\n"
+    printf "   %s\n" "${UPGRADE_IMAGE}"
+    printf "   %s\n" "${RGW_IMAGE}"
     while IFS= read -r deployment; do
-        kubectl set image deployment "${deployment}" "*=${UPGRADE_IMAGE}"
+        if [[ "${deployment}" == "cortx-server-"* ]]; then
+            IMAGE="${RGW_IMAGE}"
+        else
+            IMAGE="${UPGRADE_IMAGE}"
+        fi
+        kubectl set image deployment "${deployment}" "*=${IMAGE}"
     done <<< "${cortx_deployments}"
     printf "\n"
 fi


### PR DESCRIPTION
This PR updates upgrade-cortx-cloud.sh to upgrade using the "cortx-rgw" image for cortx-server deployments.

This does not change the interface. The user still specified only the "cortx-all" image.  This implementation assumes that the cortx-all and cortx-rgw images will always be built together, with the same version number, and same url path.