### PR TITLE
CORTX-29672: Remove unused s3 server settings

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-networkpolicy.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-networkpolicy.yaml
@@ -34,32 +34,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Values.networkPolicy.namePrefix }}cortx-s3
-  labels:
-    source-pod: cortx-data
-    target-pod: cortx-data
-    target-container: cortx-s3
-  namespace: {{ .Values.namespace.name }}
-spec:
-  podSelector:
-    matchLabels:
-      name: {{ .Values.networkPolicy.cortxData.podNameLabel }}
-  ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          name: {{ .Values.networkPolicy.cortxData.podNameLabel }}
-    ports:
-      - protocol: TCP
-        port: 28051
-      - protocol: TCP
-        port: 28052
-
----
-
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
   name: {{ .Values.networkPolicy.namePrefix }}cortx-motr-ios
   labels:
     source-pod: cortx-data
@@ -103,7 +77,7 @@ spec:
           app: {{ .Values.networkPolicy.cortxControl.podAppLabel }}
     ports:
       - protocol: TCP
-        port: 28049 
+        port: 28049
 
 ---
 
@@ -133,9 +107,9 @@ spec:
       - protocol: TCP
         port: 3002
       - protocol: TCP
-        port: 3003      
+        port: 3003
       - protocol: TCP
-        port: 4001      
+        port: 4001
       - protocol: TCP
         port: 4002
 
@@ -166,13 +140,13 @@ spec:
       - protocol: UDP
         port: 8301
       - protocol: TCP
-        port: 8302      
+        port: 8302
       - protocol: UDP
-        port: 8302    
+        port: 8302
       - protocol: TCP
         port: 8500
       - protocol: TCP
-        port: 8600  
+        port: 8600
       - protocol: UDP
         port: 8600
 

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/values.yaml
@@ -5,8 +5,6 @@ cortxserver:
   nodeselector: node-1
   secretinfo: secret-info.txt
   serviceaccountname: cortx-sa
-  s3:
-    startportnum: 28051
   hax:
     port: 22003
   service:

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -1079,7 +1079,6 @@ function deployCortxServer()
     printf "########################################################\n"
     local cortxserver_image
     local hax_port
-    local s3_start_port_num
     local s3_service_type
     local s3_service_ports_http
     local s3_service_ports_https
@@ -1087,7 +1086,6 @@ function deployCortxServer()
     s3_service_type=$(getSolutionValue 'solution.common.external_services.s3.type')
     s3_service_ports_http=$(getSolutionValue 'solution.common.external_services.s3.ports.http')
     s3_service_ports_https=$(getSolutionValue 'solution.common.external_services.s3.ports.https')
-    s3_start_port_num="$(getSolutionValue 'solution.common.s3.start_port_num')"
     hax_port="$(getSolutionValue 'solution.common.hax.port_num')"
 
     num_nodes=0
@@ -1118,7 +1116,6 @@ function deployCortxServer()
             --set cortxserver.localpathpvc.name="cortx-server-fs-local-pvc-${node_name}" \
             --set cortxserver.localpathpvc.mountpath="${local_storage}" \
             --set cortxserver.localpathpvc.requeststoragesize="1Gi" \
-            --set cortxserver.s3.startportnum="${s3_start_port_num}" \
             --set cortxserver.hax.port="${hax_port}" \
             --set cortxserver.secretinfo="secret-info.txt" \
             --set cortxserver.serviceaccountname="${serviceAccountName}" \

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -33,7 +33,6 @@ solution:
         auth_admin: "sgiamadmin"
         auth_user: "user_name"
         #auth_secret defined above in solution.secrets.content.s3_auth_admin_secret
-      start_port_num: 28051
       max_start_timeout: 240
       extra_configuration: ""
     motr:

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -35,7 +35,6 @@ solution:
         auth_admin: "sgiamadmin"
         auth_user: "user_name"
         #auth_secret defined above in solution.secrets.content.s3_auth_admin_secret
-      start_port_num: 28051
       max_start_timeout: 240
       extra_configuration: ""
     motr:

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -32,7 +32,6 @@ solution:
       default_iam_users:
         auth_admin: "sgiamadmin"
         auth_user: "user_name"
-      start_port_num: 28051
       max_start_timeout: 240
       extra_configuration: ""
     motr:

--- a/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
@@ -21,7 +21,6 @@ solution:
       default_iam_users:
         auth_admin: required
         auth_user: required
-      start_port_num: required
     motr:
       num_client_inst: required
       start_port_num: required


### PR DESCRIPTION
Port number 28051 is the S3 Authserver HTTPs port. This is no longer in use with the switch to RGW.

Signed-off-by: Keith Pine <keith.pine@seagate.com>