### PR TITLE
CORTX-29634: Update Consul image version to 1.11.4

### DIFF
--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -16,7 +16,7 @@ solution:
     cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-689
     cortxha: ghcr.io/seagate/cortx-all:2.0.0-689
     cortxclient: ghcr.io/seagate/cortx-all:2.0.0-689
-    consul: ghcr.io/seagate/consul:1.10.0
+    consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
     zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -18,7 +18,7 @@ solution:
     cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-689
     cortxha: ghcr.io/seagate/cortx-all:2.0.0-689
     cortxclient: ghcr.io/seagate/cortx-all:2.0.0-689
-    consul: ghcr.io/seagate/consul:1.10.0
+    consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
     zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -16,7 +16,7 @@ solution:
     cortxserver: ghcr.io/seagate/centos:7
     cortxha: ghcr.io/seagate/centos:7
     cortxclient: ghcr.io/seagate/centos:7
-    consul: ghcr.io/seagate/consul:1.10.0
+    consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
     zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20


### PR DESCRIPTION
Update Consul image as specified in solution.example.yaml to 1.11.4.

ghcr.io/seagate has been previously updated to contain this image.

I have verified that CORTX deploys with this new image.