### PR TITLE
CORTX-29435: Fix contact links (issue forms)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report problems and issues with CORTX on Kubernetes
+description: Report problems and issues with CORTX on Kubernetes.
 labels: [bug]
 
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature request
-    url: https://github.com/Seagate/cortx/issues/new
-    about: Want to suggest an idea? Create a feature request at the main CORTX project.
+    url: https://github.com/Seagate/cortx/issues/new/choose
+    about: Want to suggest an idea? Visit the main CORTX project and create a feature request.
   - name: CORTX on Kubernetes Questions and Support
     url: https://github.com/Seagate/cortx-k8s/discussions
     about: Have questions or need support for CORTX on Kubernetes for anything that isn't a bug report? Go ahead and start a new discussion.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature request
+    url: https://github.com/Seagate/cortx/issues/new
+    about: Want to suggest an idea? Create a feature request at the main CORTX project.
+  - name: CORTX on Kubernetes Questions and Support
     url: https://github.com/Seagate/cortx-k8s/discussions
-    about: Want to suggest an idea? Start a new discussion.
-  - name: Community Support
-    url: https://github.com/Seagate/cortx-k8s/discussions
-    about: Ask a question or request general support on the Discussion forum.
+    about: Have questions or need support for CORTX on Kubernetes for anything that isn't a bug report? Go ahead and start a new discussion.
+  - name: CORTX Community Support
+    url: https://cortx.link/slack_invite
+    about: Join us on Slack for general CORTX questions and support.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Ask a question, get support, or suggest new features
+  - name: Feature request
     url: https://github.com/Seagate/cortx-k8s/discussions
+    about: Want to suggest an idea? Start a new discussion.
+  - name: Community Support
+    url: https://github.com/Seagate/cortx-k8s/discussions
+    about: Ask a question or request general support on the Discussion forum.


### PR DESCRIPTION
Signed-off-by: Keith Pine <keith.pine@seagate.com>

## Description
Fix the issue template contact links. Some missing fields appear to make them not render.

Add new links pointing to the main CORTX project for feature requests, Discussions for cortx-k8s support, and Slack for general CORTX community support.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Third-party dependency update
- [X] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)

## Applicable issues
- This change is related to an issue: CORTX-29435

## How was this tested?
Using my fork repo.

![image](https://user-images.githubusercontent.com/76182378/161163781-e0b8be2a-2977-4abb-a394-e7762e1a58c1.png)

## Checklist

- [ ] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
