### PR TITLE
CORTX-27410 - Updated zookeeper image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ This section contains the CORTX and third-party images used to deploy CORTX on K
 | `images.cortxclient`     | Image registry, repository, & tag for the CORTX Client components                      | `ghcr.io/seagate/cortx-all:2.0.0-{VERSION}` |
 | `images.consul`          | Image registry, repository, & tag for the Consul required service                      | `ghcr.io/seagate/consul:1.10.0`             |
 | `images.kafka`           | Image registry, repository, & tag for the Kafka required service                       | `ghcr.io/seagate/kafka:3.0.0-debian-10-r7`  |
-| `images.zookeeper`       | Image registry, repository, & tag for the Zookeeper required service                   | `ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182` |
+| `images.zookeeper`       | Image registry, repository, & tag for the Zookeeper required service                   | `ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9` |
 | `images.rancher`         | Image registry, repository, & tag for the Rancher Local Path Provisioner container     | `ghcr.io/seagate/local-path-provisioner:v0.0.20` |
 | `images.busybox`         | Image registry, repository, & tag for the utility busybox container                    | `ghcr.io/seagate/busybox:latest`            |
 

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -18,7 +18,7 @@ solution:
     cortxclient: ghcr.io/seagate/cortx-all:2.0.0-689
     consul: ghcr.io/seagate/consul:1.10.0
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
-    zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
+    zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
     busybox: ghcr.io/seagate/busybox:latest
   common:

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -20,7 +20,7 @@ solution:
     cortxclient: ghcr.io/seagate/cortx-all:2.0.0-689
     consul: ghcr.io/seagate/consul:1.10.0
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
-    zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
+    zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
     busybox: ghcr.io/seagate/busybox:latest
   common:

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -18,7 +18,7 @@ solution:
     cortxclient: ghcr.io/seagate/centos:7
     consul: ghcr.io/seagate/consul:1.10.0
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
-    zookeeper: ghcr.io/seagate/zookeeper:3.7.0-debian-10-r182
+    zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9
     rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
     busybox: ghcr.io/seagate/busybox:latest
   common:


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

## Description

This PR moves the specific default container image used for Zookeeper deployments to a more current version _(3.8.0-debian-10-r9)_ that is not affected by the log4j CVEs.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [x] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: [CORTX-27410](https://jts.seagate.com/browse/CORTX-27410)

## How was this tested?
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->
This change was manually deployed multiple times across two different k8s clusters and validated all components started successfully as expected with `hctl status`.

## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->
n/a

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [x] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
