### PR TITLE
Bump CORTX images to build 713

### DIFF
--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -11,11 +11,11 @@ solution:
       csm_auth_admin_secret: seagate2
       csm_mgmt_admin_secret: Cortxadmin@123
   images:
-    cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-707
-    cortxdata: ghcr.io/seagate/cortx-all:2.0.0-707
-    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-707
-    cortxha: ghcr.io/seagate/cortx-all:2.0.0-707
-    cortxclient: ghcr.io/seagate/cortx-all:2.0.0-707
+    cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-713
+    cortxdata: ghcr.io/seagate/cortx-all:2.0.0-713
+    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-713
+    cortxha: ghcr.io/seagate/cortx-all:2.0.0-713
+    cortxclient: ghcr.io/seagate/cortx-all:2.0.0-713
     consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
     zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9

--- a/k8_cortx_cloud/solution.yaml
+++ b/k8_cortx_cloud/solution.yaml
@@ -13,11 +13,11 @@ solution:
       csm_auth_admin_secret: seagate2
       csm_mgmt_admin_secret: Cortxadmin@123
   images:
-    cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-707
-    cortxdata: ghcr.io/seagate/cortx-all:2.0.0-707
-    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-707
-    cortxha: ghcr.io/seagate/cortx-all:2.0.0-707
-    cortxclient: ghcr.io/seagate/cortx-all:2.0.0-707
+    cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-713
+    cortxdata: ghcr.io/seagate/cortx-all:2.0.0-713
+    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-713
+    cortxha: ghcr.io/seagate/cortx-all:2.0.0-713
+    cortxclient: ghcr.io/seagate/cortx-all:2.0.0-713
     consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r7
     zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9


### PR DESCRIPTION
Signed-off-by: Keith Pine <keith.pine@seagate.com>

## Description
Bump CORTX images to latest published versions.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [X] Dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
N/A

## CORTX image version requirements
Updated to:

- `cortx-all:2.0.0-713`
- `cortx-rgw:2.0.0-713`

## How was this tested?
Deployment and basic S3 I/O.

## Additional information

## Checklist
- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).