### PR TITLE
CORTX-29537: Fix shellcheck issues in generate-cvg-yaml.sh

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,6 @@ jobs:
             parse_scripts
             solution_validation_scripts
           ignore_names: >-
-            generate-cvg-yaml.sh
             prereq-deploy-cortx-cloud.sh
             upgrade-cortx-cloud.sh
 

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -123,7 +123,7 @@ get_options() {
       DEVICE_PATHS_FILE="${2-}"
       shift
       ;;
-    -?*) 
+    -?*)
       error "Unknown option: $1"
       exit
       ;;
@@ -248,7 +248,7 @@ for cvg_instance in $(seq $NUM_CVGS); do
     _CVG_NAME="0$cvg_instance"
   fi
 
-  printf "      name: cvg-%s\n" $_CVG_NAME >> $_YAML_BODY 
+  printf "      name: cvg-%s\n" $_CVG_NAME >> $_YAML_BODY
   printf "      type: ios\n" >> $_YAML_BODY
   printf "      devices:\n" >> $_YAML_BODY
 
@@ -266,7 +266,7 @@ for cvg_instance in $(seq $NUM_CVGS); do
     ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
 
     printf "            size: %s\n" $SIZE_DATA_DRIVE >> $_YAML_BODY
-  done 
+  done
 done
 
 ## Generate Node stanza

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -28,7 +28,7 @@ _YAML_BODY="./tmp-yaml-body.yaml"
 
 # print error message [ execute command ] and exit [ with defined status ]
 error() {
-    echo "${_SCRIPT_NAME}: $1" > /dev/stderr
+    echo "${_SCRIPT_NAME}: $1" >&2
     (( $# > 2)) && eval "$2" && exit "$3"
     (( $# > 1 )) && exit "$2"
     exit 1
@@ -36,12 +36,12 @@ error() {
 
 # print log message
 log() {
-    echo "${_SCRIPT_NAME}: $1" > /dev/stderr
+    echo "${_SCRIPT_NAME}: $1" >&2
 }
 
 # print debug message if script called with verbose mode
 debug() {
-    [[ ${_VERBOSE} == 1 ]] && echo "${_SCRIPT_NAME}: $1" > /dev/stderr
+    [[ ${_VERBOSE} == 1 ]] && echo "${_SCRIPT_NAME}: $1" >&2
 }
 
 usage() {

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -240,14 +240,12 @@ fi
   ## GENERATE STORAGE->CVG STANZA
   _DEVICE_OFFSET=0
   printf "  storage:\n"
-  for cvg_instance in $(seq ${NUM_CVGS}); do
-    printf "    cvg%s:\n" ${cvg_instance}
+  for ((cvg_instance = 1 ; cvg_instance <= ${NUM_CVGS} ; cvg_instance++)); do
+    printf "    cvg%s:\n" "${cvg_instance}"
 
     ## Front-pad cvg-name with leading zeroes
-    _CVG_NAME=${cvg_instance}
-    if [[ "${_CVG_NAME}" -lt "10" ]]; then
-      _CVG_NAME="0${cvg_instance}"
-    fi
+    padding="00"
+    _CVG_NAME="${padding:${#cvg_instance}:${#padding}}${cvg_instance}"
 
     printf "      name: cvg-%s\n" ${_CVG_NAME}
     printf "      type: ios\n"
@@ -255,26 +253,24 @@ fi
 
     ##TODO (1.2) Determine if we currently can use multiple metadata drives
     printf "        metadata:\n"
-    printf "          device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]}
+    printf "          device: %s\n" "${DEVICE_PATHS[${_DEVICE_OFFSET}]}"
     ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
-
-    printf "          size: %s\n" ${SIZE_METADATA_DRIVE}
-
+    printf "          size: %s\n" "${SIZE_METADATA_DRIVE}"
     printf "        data:\n"
-    for data_instance in $(seq 1 ${NUM_DATA_DRIVES}); do
-      printf "          d%s:\n" ${data_instance}
-      printf "            device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]}
+    for ((data_instance = 1 ; data_instance <= ${NUM_DATA_DRIVES} ; data_instance++)); do
+      printf "          d%s:\n" "${data_instance}"
+      printf "            device: %s\n" "${DEVICE_PATHS[${_DEVICE_OFFSET}]}"
       ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
 
-      printf "            size: %s\n" ${SIZE_DATA_DRIVE}
+      printf "            size: %s\n" "${SIZE_DATA_DRIVE}"
     done
   done
 
   ## Generate Node stanza
   printf "  nodes:\n"
-  for node_instance in $(seq ${#NODE_LIST[@]}); do
-    printf "    node%s:\n" ${node_instance}
-    printf "      name: %s\n" ${NODE_LIST[${node_instance}-1]}
+  for ((node_instance = 1 ; node_instance <= ${#NODE_LIST[@]} ; node_instance++)); do
+    printf "    node%d:\n" "${node_instance}"
+    printf "      name: %s\n" "${NODE_LIST[${node_instance}-1]}"
   done
 } > ${_YAML_BODY}
 

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -234,46 +234,48 @@ if [[ "${#DEVICE_PATHS[@]}" == "0" ]]; then
   error "Parsed DEVICE_PATHS_FILE contents is empty" 1
 fi
 
-printf "solution:\n" > ${_YAML_BODY}
+{
+  printf "solution:\n"
 
-## GENERATE STORAGE->CVG STANZA
-_DEVICE_OFFSET=0
-printf "  storage:\n" >> ${_YAML_BODY}
-for cvg_instance in $(seq ${NUM_CVGS}); do
-  printf "    cvg%s:\n" ${cvg_instance} >> ${_YAML_BODY}
+  ## GENERATE STORAGE->CVG STANZA
+  _DEVICE_OFFSET=0
+  printf "  storage:\n"
+  for cvg_instance in $(seq ${NUM_CVGS}); do
+    printf "    cvg%s:\n" ${cvg_instance}
 
-  ## Front-pad cvg-name with leading zeroes
-  _CVG_NAME=${cvg_instance}
-  if [[ "${_CVG_NAME}" -lt "10" ]]; then
-    _CVG_NAME="0${cvg_instance}"
-  fi
+    ## Front-pad cvg-name with leading zeroes
+    _CVG_NAME=${cvg_instance}
+    if [[ "${_CVG_NAME}" -lt "10" ]]; then
+      _CVG_NAME="0${cvg_instance}"
+    fi
 
-  printf "      name: cvg-%s\n" ${_CVG_NAME} >> ${_YAML_BODY}
-  printf "      type: ios\n" >> ${_YAML_BODY}
-  printf "      devices:\n" >> ${_YAML_BODY}
+    printf "      name: cvg-%s\n" ${_CVG_NAME}
+    printf "      type: ios\n"
+    printf "      devices:\n"
 
-  ##TODO (1.2) Determine if we currently can use multiple metadata drives
-  printf "        metadata:\n" >> ${_YAML_BODY}
-  printf "          device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]} >> ${_YAML_BODY}
-  ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
-
-  printf "          size: %s\n" ${SIZE_METADATA_DRIVE} >> ${_YAML_BODY}
-
-  printf "        data:\n" >> ${_YAML_BODY}
-  for data_instance in $(seq 1 ${NUM_DATA_DRIVES}); do
-    printf "          d%s:\n" ${data_instance} >> ${_YAML_BODY}
-    printf "            device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]} >> ${_YAML_BODY}
+    ##TODO (1.2) Determine if we currently can use multiple metadata drives
+    printf "        metadata:\n"
+    printf "          device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]}
     ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
 
-    printf "            size: %s\n" ${SIZE_DATA_DRIVE} >> ${_YAML_BODY}
-  done
-done
+    printf "          size: %s\n" ${SIZE_METADATA_DRIVE}
 
-## Generate Node stanza
-printf "  nodes:\n" >> ${_YAML_BODY}
-for node_instance in $(seq ${#NODE_LIST[@]}); do
-  printf "    node%s:\n" ${node_instance} >> ${_YAML_BODY}
-  printf "      name: %s\n" ${NODE_LIST[${node_instance}-1]} >> ${_YAML_BODY}
-done
+    printf "        data:\n"
+    for data_instance in $(seq 1 ${NUM_DATA_DRIVES}); do
+      printf "          d%s:\n" ${data_instance}
+      printf "            device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]}
+      ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
+
+      printf "            size: %s\n" ${SIZE_DATA_DRIVE}
+    done
+  done
+
+  ## Generate Node stanza
+  printf "  nodes:\n"
+  for node_instance in $(seq ${#NODE_LIST[@]}); do
+    printf "    node%s:\n" ${node_instance}
+    printf "      name: %s\n" ${NODE_LIST[${node_instance}-1]}
+  done
+} > ${_YAML_BODY}
 
 yq ea 'del(select(fi==0) | .solution.storage) | del(select(fi==0) | .solution.nodes) | select(fi==0) * select(fi==1)' ${SOLUTION_YAML} ${_YAML_BODY}

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -190,7 +190,7 @@ if [[ ! -f "${NODE_LIST_FILE}" ]]; then
 fi
 
 ## Check for proper existence of required DEVICE_PATHS_FILE parameter
-debug "|    DEVICE_PATHS_FILE=\"${NODE_LIST_FILE}\""
+debug "|    DEVICE_PATHS_FILE=\"${DEVICE_PATHS_FILE}\""
 if [[ "${DEVICE_PATHS_FILE}" == "UNSET" ]]; then
   error "DEVICE_PATHS_FILE is a required parameter and is unset." 1
 fi

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -205,13 +205,13 @@ if [[ "${YQ_AVAILABLE}" == "" ]]; then
   error "'yq' is required for this script to run successfully. Visit github.com/mikefarah/yq for details." 1
 fi
 
-## Parse nodes
+## Parse nodes - line delimited
 debug " -- PARSED PARAMETERS"
 debug "|"
 debug "|    NODE_LIST_FILE:"
 NODE_LIST=()
 while IFS= read -r line; do
-    NODE_LIST+=(${line})
+    NODE_LIST+=("${line}")
     debug "|      ${line}"
 done < "${NODE_LIST_FILE}"
 
@@ -220,12 +220,12 @@ if [[ "${#NODE_LIST[@]}" == "0" ]]; then
   error "Parsed NODE_LIST_FILE contents is empty" 1
 fi
 
-## Parse devices
+## Parse devices - line delimited
 DEVICE_PATHS=()
 debug "|"
 debug "|    DEVICE_PATHS_FILE:"
 while IFS= read -r line; do
-    DEVICE_PATHS+=(${line})
+    DEVICE_PATHS+=("${line}")
     debug "|      ${line}"
 done < "${DEVICE_PATHS_FILE}"
 

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -240,7 +240,7 @@ fi
   ## GENERATE STORAGE->CVG STANZA
   _DEVICE_OFFSET=0
   printf "  storage:\n"
-  for ((cvg_instance = 1 ; cvg_instance <= ${NUM_CVGS} ; cvg_instance++)); do
+  for ((cvg_instance = 1 ; cvg_instance <= NUM_CVGS ; cvg_instance++)); do
     printf "    cvg%s:\n" "${cvg_instance}"
 
     ## Front-pad cvg-name with leading zeroes
@@ -257,7 +257,7 @@ fi
     ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
     printf "          size: %s\n" "${SIZE_METADATA_DRIVE}"
     printf "        data:\n"
-    for ((data_instance = 1 ; data_instance <= ${NUM_DATA_DRIVES} ; data_instance++)); do
+    for ((data_instance = 1 ; data_instance <= NUM_DATA_DRIVES ; data_instance++)); do
       printf "          d%s:\n" "${data_instance}"
       printf "            device: %s\n" "${DEVICE_PATHS[${_DEVICE_OFFSET}]}"
       ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
@@ -274,4 +274,4 @@ fi
   done
 } > ${_YAML_BODY}
 
-yq ea 'del(select(fi==0) | .solution.storage) | del(select(fi==0) | .solution.nodes) | select(fi==0) * select(fi==1)' ${SOLUTION_YAML} ${_YAML_BODY}
+yq ea 'del(select(fi==0) | .solution.storage) | del(select(fi==0) | .solution.nodes) | select(fi==0) * select(fi==1)' "${SOLUTION_YAML}" ${_YAML_BODY}

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -41,7 +41,7 @@ log() {
 
 # print debug message if script called with verbose mode
 debug() {
-    [[ $_VERBOSE == 1 ]] && echo "${_SCRIPT_NAME}: $1" > /dev/stderr
+    [[ ${_VERBOSE} == 1 ]] && echo "${_SCRIPT_NAME}: $1" > /dev/stderr
 }
 
 usage() {
@@ -146,29 +146,29 @@ init() {
    # OPTIONS:
    debug " -- OPTIONS"
    debug "|"
-   # $NUM_CVGS : Number of desired CVGs in the generated cluster
-   debug "|   NUM_CVGS=$NUM_CVGS"
-   # $NUM_DATA_DRIVES : Number of desired data drives per CVG
-   debug "|   NUM_DATA_DRIVES=$NUM_DATA_DRIVES"
-   # $SIZE_DATA_DRIVE : Desired size of each data drive
-   debug "|   SIZE_DATA_DRIVE=$SIZE_DATA_DRIVE"
-   # $NUM_METADATA_DRIVES : Number of desired metadata drives per CVG
-   debug "|   NUM_METADATA_DRIVES=$NUM_METADATA_DRIVES"
-   # $SIZE_METADATA_DRIVE : Desired size of each metadata drive
-   debug "|   SIZE_METADATA_DRIVE=$SIZE_METADATA_DRIVE"
-   # $SOLUTION_YAML : The path to the solution.yaml file to be used as a template
-   debug "|   SOLUTION_YAML=$SOLUTION_YAML"
-   # $NODE_LIST_FILE : The path to the file to use for a list of nodes
-   debug "|   NODE_LIST_FILE=$NODE_LIST_FILE"
-   # $DEVICE_PATHS_FILE : The path to the file to use for a list of device paths
-   debug "|   DEVICE_PATHS_FILE=$DEVICE_PATHS_FILE"
+   # NUM_CVGS : Number of desired CVGs in the generated cluster
+   debug "|   NUM_CVGS=${NUM_CVGS}"
+   # NUM_DATA_DRIVES : Number of desired data drives per CVG
+   debug "|   NUM_DATA_DRIVES=${NUM_DATA_DRIVES}"
+   # SIZE_DATA_DRIVE : Desired size of each data drive
+   debug "|   SIZE_DATA_DRIVE=${SIZE_DATA_DRIVE}"
+   # NUM_METADATA_DRIVES : Number of desired metadata drives per CVG
+   debug "|   NUM_METADATA_DRIVES=${NUM_METADATA_DRIVES}"
+   # SIZE_METADATA_DRIVE : Desired size of each metadata drive
+   debug "|   SIZE_METADATA_DRIVE=${SIZE_METADATA_DRIVE}"
+   # SOLUTION_YAML : The path to the solution.yaml file to be used as a template
+   debug "|   SOLUTION_YAML=${SOLUTION_YAML}"
+   # NODE_LIST_FILE : The path to the file to use for a list of nodes
+   debug "|   NODE_LIST_FILE=${NODE_LIST_FILE}"
+   # DEVICE_PATHS_FILE : The path to the file to use for a list of device paths
+   debug "|   DEVICE_PATHS_FILE=${DEVICE_PATHS_FILE}"
    debug "|"
 
    # FLAGS:
    debug " -- FLAGS"
    debug "|"
-   # $_VERBOSE : Enable verbose mode
-   debug "|   _VERBOSE=$_VERBOSE"
+   # _VERBOSE : Enable verbose mode
+   debug "|   _VERBOSE=${_VERBOSE}"
    debug "|"
 }
 
@@ -211,9 +211,9 @@ debug "|"
 debug "|    NODE_LIST_FILE:"
 NODE_LIST=()
 while IFS= read -r line; do
-    NODE_LIST+=($line)
-    debug "|      $line"
-done < "$NODE_LIST_FILE"
+    NODE_LIST+=(${line})
+    debug "|      ${line}"
+done < "${NODE_LIST_FILE}"
 
 ## Check for empty node list
 if [[ "${#NODE_LIST[@]}" == "0" ]]; then
@@ -225,55 +225,55 @@ DEVICE_PATHS=()
 debug "|"
 debug "|    DEVICE_PATHS_FILE:"
 while IFS= read -r line; do
-    DEVICE_PATHS+=($line)
-    debug "|      $line"
-done < "$DEVICE_PATHS_FILE"
+    DEVICE_PATHS+=(${line})
+    debug "|      ${line}"
+done < "${DEVICE_PATHS_FILE}"
 
 ## Check for empty device path list
 if [[ "${#DEVICE_PATHS[@]}" == "0" ]]; then
   error "Parsed DEVICE_PATHS_FILE contents is empty" 1
 fi
 
-printf "solution:\n" > $_YAML_BODY
+printf "solution:\n" > ${_YAML_BODY}
 
 ## GENERATE STORAGE->CVG STANZA
 _DEVICE_OFFSET=0
-printf "  storage:\n" >> $_YAML_BODY
-for cvg_instance in $(seq $NUM_CVGS); do
-  printf "    cvg%s:\n" $cvg_instance >> $_YAML_BODY
+printf "  storage:\n" >> ${_YAML_BODY}
+for cvg_instance in $(seq ${NUM_CVGS}); do
+  printf "    cvg%s:\n" ${cvg_instance} >> ${_YAML_BODY}
 
   ## Front-pad cvg-name with leading zeroes
-  _CVG_NAME=$cvg_instance
-  if [[ "$_CVG_NAME" -lt "10" ]]; then
-    _CVG_NAME="0$cvg_instance"
+  _CVG_NAME=${cvg_instance}
+  if [[ "${_CVG_NAME}" -lt "10" ]]; then
+    _CVG_NAME="0${cvg_instance}"
   fi
 
-  printf "      name: cvg-%s\n" $_CVG_NAME >> $_YAML_BODY
-  printf "      type: ios\n" >> $_YAML_BODY
-  printf "      devices:\n" >> $_YAML_BODY
+  printf "      name: cvg-%s\n" ${_CVG_NAME} >> ${_YAML_BODY}
+  printf "      type: ios\n" >> ${_YAML_BODY}
+  printf "      devices:\n" >> ${_YAML_BODY}
 
   ##TODO (1.2) Determine if we currently can use multiple metadata drives
-  printf "        metadata:\n" >> $_YAML_BODY
-  printf "          device: %s\n" ${DEVICE_PATHS[$_DEVICE_OFFSET]} >> $_YAML_BODY
+  printf "        metadata:\n" >> ${_YAML_BODY}
+  printf "          device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]} >> ${_YAML_BODY}
   ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
 
-  printf "          size: %s\n" $SIZE_METADATA_DRIVE >> $_YAML_BODY
+  printf "          size: %s\n" ${SIZE_METADATA_DRIVE} >> ${_YAML_BODY}
 
-  printf "        data:\n" >> $_YAML_BODY
-  for data_instance in $(seq 1 $NUM_DATA_DRIVES); do
-    printf "          d%s:\n" $data_instance >> $_YAML_BODY
-    printf "            device: %s\n" ${DEVICE_PATHS[$_DEVICE_OFFSET]} >> $_YAML_BODY
+  printf "        data:\n" >> ${_YAML_BODY}
+  for data_instance in $(seq 1 ${NUM_DATA_DRIVES}); do
+    printf "          d%s:\n" ${data_instance} >> ${_YAML_BODY}
+    printf "            device: %s\n" ${DEVICE_PATHS[${_DEVICE_OFFSET}]} >> ${_YAML_BODY}
     ((_DEVICE_OFFSET=_DEVICE_OFFSET+1))
 
-    printf "            size: %s\n" $SIZE_DATA_DRIVE >> $_YAML_BODY
+    printf "            size: %s\n" ${SIZE_DATA_DRIVE} >> ${_YAML_BODY}
   done
 done
 
 ## Generate Node stanza
-printf "  nodes:\n" >> $_YAML_BODY
+printf "  nodes:\n" >> ${_YAML_BODY}
 for node_instance in $(seq ${#NODE_LIST[@]}); do
-  printf "    node%s:\n" $node_instance >> $_YAML_BODY
-  printf "      name: %s\n" ${NODE_LIST[$node_instance-1]} >> $_YAML_BODY
+  printf "    node%s:\n" ${node_instance} >> ${_YAML_BODY}
+  printf "      name: %s\n" ${NODE_LIST[${node_instance}-1]} >> ${_YAML_BODY}
 done
 
 yq ea 'del(select(fi==0) | .solution.storage) | del(select(fi==0) | .solution.nodes) | select(fi==0) * select(fi==1)' ${SOLUTION_YAML} ${_YAML_BODY}

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -29,8 +29,8 @@ _YAML_BODY="./tmp-yaml-body.yaml"
 # print error message [ execute command ] and exit [ with defined status ]
 error() {
     echo "${_SCRIPT_NAME}: $1" > /dev/stderr
-    [ $# -gt 2 ] && eval "$2" && exit "$3"
-    [ $# -gt 1 ] && exit "$2"
+    (( $# > 2)) && eval "$2" && exit "$3"
+    (( $# > 1 )) && exit "$2"
     exit 1
 }
 
@@ -41,7 +41,7 @@ log() {
 
 # print debug message if script called with verbose mode
 debug() {
-    [ "$_VERBOSE" ] && echo "${_SCRIPT_NAME}: $1" > /dev/stderr
+    [[ $_VERBOSE == 1 ]] && echo "${_SCRIPT_NAME}: $1" > /dev/stderr
 }
 
 usage() {

--- a/k8_cortx_cloud/generate-cvg-yaml.sh
+++ b/k8_cortx_cloud/generate-cvg-yaml.sh
@@ -213,7 +213,7 @@ NODE_LIST=()
 while IFS= read -r line; do
     NODE_LIST+=($line)
     debug "|      $line"
-done <<< "$(cat $NODE_LIST_FILE)"
+done < "$NODE_LIST_FILE"
 
 ## Check for empty node list
 if [[ "${#NODE_LIST[@]}" == "0" ]]; then
@@ -227,7 +227,7 @@ debug "|    DEVICE_PATHS_FILE:"
 while IFS= read -r line; do
     DEVICE_PATHS+=($line)
     debug "|      $line"
-done <<< "$(cat $DEVICE_PATHS_FILE)"
+done < "$DEVICE_PATHS_FILE"
 
 ## Check for empty device path list
 if [[ "${#DEVICE_PATHS[@]}" == "0" ]]; then


### PR DESCRIPTION
## Description

- Fix all shellcheck errors, warnings and notes:
  - Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore). [SC2312]
  - Prefer [[ ]] over [ ] for tests in Bash/Ksh. [SC2292]
  - Prefer putting braces around variable references even when not strictly required. [SC2250]
  - Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a. [SC2206]
  - Consider using { cmd1; cmd2; } >> file instead of individual redirects. [SC2129]
  - Double quote to prevent globbing and word splitting. [SC2086]
- Fix verbose logging redirect to file
- Fix debug message for `DEVICE_PATHS_FILE`
- Re-enable GitHub lint action for the script.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues
- This change fixes an issue: CORTX-29537

## CORTX image version requirements
None

## How was this tested?
Ran script before and after change with identical parameters and solution file. Diffed the two and there were no differences.

## Additional information
Each shellcheck error was fixed in a single commit. Each commit can be reviewed separately to see the changes.

## Checklist
- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
