### PR TITLE
Handle an unset `services.io.count` for the cortx-platform Chart install

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-io-svc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-io-svc.yaml
@@ -1,5 +1,5 @@
 {{- $svc := .Values.services.io -}}
-{{- if gt $svc.count 0 -}}
+{{- if gt (int $svc.count) 0 -}}
 {{- $isLB := eq $svc.type "LoadBalancer" -}}
 {{- $nodePortAllowed := or (eq $svc.type "NodePort") $isLB -}}
 {{- $svcCount := ternary $svc.count 1 $isLB | int -}}


### PR DESCRIPTION
Signed-off-by: Keith Pine <keith.pine@seagate.com>

## Description
Installing the `cortx-platform` Helm Chart fails if the `services.io.count` value is not explicitly set.

```text
Error: INSTALLATION FAILED: template: cortx-platform/templates/cortx-io-svc.yaml:2:7: executing "cortx-platform/templates/cortx-io-svc.yaml" at <gt $svc.count 0>: error calling gt: incompatible types for comparison
```

It's already defaulted to `0` in `values.yaml`, but I have to assume that value coming from the YAML file is conveyed as a string, so the comparison in the template fails as string and int comparisons aren't legal. The command line set works fine (e.g. `--set services.io.count=1`).

This is fixed by casting the value to an int before comparing.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

## CORTX image version requirements
N/A

## How was this tested?
Installed chart manually. This is the command that would be used for a non-default namespace.

```
helm install cortx-ns-foobar cortx-cloud-helm-pkg/cortx-platform --set namespace.create=true --set namespace.name=foobar
```

## Additional information

## Checklist
- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
