### PR TITLE
Relocate Helm repo install to pre-req function

### DIFF
--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -307,6 +307,11 @@ done <<< "$(kubectl get namespaces)"
 ##########################################################
 function deployKubernetesPrereqs()
 {
+    # Add and update Helm repository dependencies
+    helm repo add hashicorp https://helm.releases.hashicorp.com
+    helm repo add bitnami https://charts.bitnami.com/bitnami
+    helm repo update hashicorp bitnami
+
     ## PodSecurityPolicies are Cluster-scoped, so Helm doesn't handle it smoothly
     ## in the same chart as Namespace-scoped objects.
     local podSecurityPolicyName="cortx-baseline"
@@ -365,9 +370,6 @@ function deployRancherProvisioner()
 {
     local image
 
-    # Add the HashiCorp Helm Repository:
-    helm repo add hashicorp https://helm.releases.hashicorp.com
-    helm repo update hashicorp
     if [[ ${storage_class} == "local-path" ]]
     then
         printf "Install Rancher Local Path Provisioner"
@@ -452,10 +454,6 @@ function deployZookeeper()
     printf "######################################################\n"
     printf "# Deploy Zookeeper                                    \n"
     printf "######################################################\n"
-    # Add Zookeeper and Kafka Repository
-    helm repo add bitnami https://charts.bitnami.com/bitnami
-    helm repo update bitnami
-
     image=$(parseSolution 'solution.images.zookeeper')
     image=$(echo "${image}" | cut -f2 -d'>')
     splitDockerImage "${image}"


### PR DESCRIPTION
Signed-off-by: Keith Pine <keith.pine@seagate.com>

## Description
Move Helm Chart repository installation and updating to the "pre-req" function.

While analyzing the deploy script, I noticed that the Hashicorp repo was being
installed in the Rancher local provisioner function, which is confusing and out
of place. Similarly, the Bitnami repo install is in the Zookeeper deployment
function, except there are multiple charts dependent on the install. It makes
more logical sense to move these actions to somewhere else, like the pre-req
function.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues
- This change is related to an issue: CORTX-29961

## CORTX image version requirements
N/A

## How was this tested?
New deployment with repos installed, then a re-deployment.

## Additional information

## Checklist
- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
