### PR TITLE
CORTX-29537: Fix shellcheck issues in prereq-deploy-cortx-cloud.sh

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,8 +34,6 @@ jobs:
           ignore_paths: >-
             parse_scripts
             solution_validation_scripts
-          ignore_names: >-
-            prereq-deploy-cortx-cloud.sh
 
   solution_yaml:
     name: Solution YAML validation

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -182,6 +182,12 @@ function parseSolution()
             # Get the var and val from the tuple
             VAR=$(echo ${VAR_VAL_ELEMENT} | cut -f1 -d'>')
             # Check is the filter matches the var
+            #
+            # Ignore SC2053: $2 is a filter which can take wildcard (*)
+            # characters, so this comparison is intentionally relying on glob
+            # pattern matching.
+            #
+            # shellcheck disable=SC2053
             if [[ ${VAR} == $2 ]]
             then
                 # If the OUTPUT is empty set it otherwise append

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC2312
+
 SCRIPT=$(readlink -f "$0")
 SCRIPT_NAME=$(basename "${SCRIPT}")
 

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -369,15 +369,11 @@ function symlinkBlockDevices()
     # Wait for all Jobs to complete successfully
     printf "Waiting for 'symlink-block-devices' Jobs to complete successfully...\n"
     sleep 10
-    kubectl wait jobs -l "cortx.io/task=symlink-block-devices" --for="condition=Complete" --timeout=30s
-
     ##  If timeout, wait again
-    if (( $? != 0 )); then
+    if ! kubectl wait jobs -l "cortx.io/task=symlink-block-devices" --for="condition=Complete" --timeout=30s; then
         printf "Timed out waiting for Jobs to complete successfully. Will attempt to wait again...\n"
-        kubectl wait jobs -l "cortx.io/task=symlink-block-devices" --for="condition=Complete" --timeout=30s
-
         ##  If timeout again, fail and exit out of installer with user directives.
-        if (( $? != 0 )); then
+        if ! kubectl wait jobs -l "cortx.io/task=symlink-block-devices" --for="condition=Complete" --timeout=30s; then
             printf "Timed out waiting for Jobs to complete successfully again. Corrective user action should be taken.\n"
             exit 1
         fi

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -327,9 +327,12 @@ function symlinkBlockDevices()
     # Local variables
     local filter
     local device_paths=()
-    local job_template="$(pwd)/cortx-cloud-3rd-party-pkg/templates/job-symlink-block-devices.yaml.template"
+    local job_template
     local template_vars='${NODE_NAME}:${NODE_SHORT_NAME}:${DEVICE_PATHS}:${SYMLINK_PATH_SEPARATOR}:${CORTX_IMAGE}'
-    local job_file="jobs-symlink-block-devices-$(hostname -s).yaml"
+    local job_file
+
+    job_template="$(pwd)/cortx-cloud-3rd-party-pkg/templates/job-symlink-block-devices.yaml.template"
+    job_file="jobs-symlink-block-devices-$(hostname -s).yaml"
 
     # Template replacement variable
     export SYMLINK_PATH_SEPARATOR=${symlink_block_devices_separator}
@@ -348,7 +351,8 @@ function symlinkBlockDevices()
         device_paths+=(${device_path#*>})
     done
     # Template replacement variable
-    export DEVICE_PATHS=$(join_array "," "${device_paths[@]}")
+    DEVICE_PATHS=$(join_array "," "${device_paths[@]}")
+    export DEVICE_PATHS
 
     # Prepare local templated Job definition
     rm -f ${job_file}

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -348,7 +348,7 @@ function symlinkBlockDevices()
     IFS=';' read -r -a device_array <<< "${device_output}"
     for device_path in "${device_array[@]}"
     do
-        device_paths+=(${device_path#*>})
+        device_paths+=("${device_path#*>}")
     done
     # Template replacement variable
     DEVICE_PATHS=$(join_array "," "${device_paths[@]}")

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -88,7 +88,7 @@ if [[ "${disk}" == *".yaml"* ]]; then
 fi
 
 # Check if the file exists
-if [ ! -f ${solution_yaml} ]
+if [[ ! -f ${solution_yaml} ]]
 then
     echo "ERROR: ${solution_yaml} does not exist"
     exit 1
@@ -144,7 +144,7 @@ function parseYaml
 function parseSolution()
 {
     # Check that all of the required parameters have been passed in
-    if [ "$1" == "" ]
+    if [[ $1 == "" ]]
     then
         echo "ERROR: Invalid input parameters"
         echo "Input YAML file is an empty string"
@@ -154,7 +154,7 @@ function parseSolution()
     fi
 
     # Check if the file exists
-    if [ ! -f $1 ]
+    if [[ ! -f $1 ]]
     then
         echo "ERROR: $1 does not exist"
         usage
@@ -170,7 +170,7 @@ function parseSolution()
     OUTPUT=""
 
     # Check if we need to do any filtering
-    if [ "$2" == "" ]
+    if [[ $2 == "" ]]
     then
         OUTPUT=${PARSED_OUTPUT}
     else
@@ -185,7 +185,7 @@ function parseSolution()
             if [[ ${VAR} == $2 ]]
             then
                 # If the OUTPUT is empty set it otherwise append
-                if [ "${OUTPUT}" == "" ]
+                if [[ ${OUTPUT} == "" ]]
                 then
                     OUTPUT=${VAR_VAL_ELEMENT}
                 else

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -328,8 +328,11 @@ function symlinkBlockDevices()
     local filter
     local device_paths=()
     local job_template
-    local template_vars='${NODE_NAME}:${NODE_SHORT_NAME}:${DEVICE_PATHS}:${SYMLINK_PATH_SEPARATOR}:${CORTX_IMAGE}'
     local job_file
+
+    # We don't want these expanded right now
+    # shellcheck disable=SC2016
+    local template_vars='${NODE_NAME}:${NODE_SHORT_NAME}:${DEVICE_PATHS}:${SYMLINK_PATH_SEPARATOR}:${CORTX_IMAGE}'
 
     job_template="$(pwd)/cortx-cloud-3rd-party-pkg/templates/job-symlink-block-devices.yaml.template"
     job_file="jobs-symlink-block-devices-$(hostname -s).yaml"

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -164,7 +164,7 @@ function parseSolution()
     # Store the parsed output in a single string
     PARSED_OUTPUT=$(parseYaml $1)
     # Remove any additional indent '.' characters
-    PARSED_OUTPUT=$(echo ${PARSED_OUTPUT//../.})
+    PARSED_OUTPUT=${PARSED_OUTPUT//../.}
 
     # Star with empty output
     OUTPUT=""

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 SCRIPT=$(readlink -f "$0")
-DIR=$(dirname "${SCRIPT}")
 SCRIPT_NAME=$(basename "${SCRIPT}")
 
 # Script defaults
@@ -313,7 +312,6 @@ function symlinkBlockDevices()
 
     # Local variables
     local filter
-    local node_list=()
     local device_paths=()
     local job_template="$(pwd)/cortx-cloud-3rd-party-pkg/templates/job-symlink-block-devices.yaml.template"
     local template_vars='${NODE_NAME}:${NODE_SHORT_NAME}:${DEVICE_PATHS}:${SYMLINK_PATH_SEPARATOR}:${CORTX_IMAGE}'


### PR DESCRIPTION
<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->
* Fix all shellcheck errors, warnings and notes:
  * Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a. [SC2206]
  * Double quote to prevent globbing and word splitting. [SC2086]
  * Declare and assign separately to avoid masking return values. [SC2155]
  * Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore). [SC2312]
  * Quote the right-hand side of == in [[ ]] to prevent glob matching. [SC2053]
  * Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'. [SC2116]
  * Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?. [SC2181]
  * Prefer [[ ]] over [ ] for tests in Bash/Ksh. [SC2292]
  * Prefer putting braces around variable references even when not strictly required. [SC2250]
  * <X> appears unused. Verify use (or export if used externally). [SC2034]
* Re-enable GitHub lint action for the script.

## Breaking change
<!--
If this change introduces any breaking changes, describe what it breaks and what action is required
to address it. We prefer deprecating things first before breaking them entirely. If you are unable
to support deprecation in this change, or are actually removing the deprecated the item, please
state so.

You can delete this section if there are no breaking changes.
-->

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-29537

## CORTX image version requirements
None

## How was this tested?
Ran script to do both the persistent mount and symlink generation. Actions were successful.

Captured bash script execution (`bash -x`) from original and new script and diffed the output. The only differences were syntax related (e.g. `[` vs `[[`), otherwise execution was identical.

Diffed before and after `jobs-symlink-block-devices-*.yaml` output, files were the same.

## Additional information
Each shellcheck error was fixed in a single commit. Each commit can be reviewed separately to see the changes.

## Checklist
- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
