### PR TITLE
CORTX-30708: Fix shellcheck issues in solution-validation.sh

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,6 @@ jobs:
           # Temporarily ignore these until they are fixed
           ignore_paths: >-
             parse_scripts
-            solution_validation_scripts
 
   solution_yaml:
     name: Solution YAML validation

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -14,6 +14,7 @@ function buildRegexFromSolutionVar()
     # Example:
     # string="solution.storage.cvg1.devices.data.d2.device"
     # regex="solution.storage.cvg[0-9]+.devices.data.d[0-9]+.device"
+    # shellcheck disable=SC2001
     echo "$1" | sed -e 's/\([0-9]\+\)/[0-9]+/g'
 }
 
@@ -96,6 +97,7 @@ for element in "${my_array[@]}"; do
 
     if [[ "${found}" = false && "${element_array[1]}" == "required" ]]; then
         # Find all the number in the string and replace it with "*".
+        # shellcheck disable=SC2001
         temp_regex=$(echo "${element}" | sed -e 's/\([0-9]\+\)/*/g')
         temp_regex_val=$(echo "${temp_regex}" | cut -f1 -d'>')
         result_str="Failed to find '${temp_regex_val}' in the solution file"
@@ -135,6 +137,7 @@ for sol_chk_e in "${solution_chk_cvg_var_list[@]}"; do
 
     if [[ "${found}" = false ]]; then
         # Find all the number in the string and replace it with "*".
+        # shellcheck disable=SC2001
         temp_regex=$(echo "${sol_chk_e}" | sed -e 's/\([0-9]\+\)/*/g')
         temp_regex_val=$(echo "${temp_regex}" | cut -f1 -d'>')
         result_str="Failed to find '${temp_regex_val}' in the solution file"
@@ -184,6 +187,7 @@ for sol_chk_e in "${solution_chk_node[@]}"; do
 
     if [[ "${found}" = false ]]; then
         # Find all the number in the string and replace it with "*".
+        # shellcheck disable=SC2001
         temp_regex=$(echo "${sol_chk_e}" | sed -e 's/\([0-9]\+\)/*/g')
         temp_regex_val=$(echo "${temp_regex}" | cut -f1 -d'>')
         result_str="Failed to find '${temp_regex_val}' in the solution file"

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -10,13 +10,11 @@ function parseSolution()
 
 function buildRegexFromSolutionVar()
 {
-    string=$1
     # Find all the number in the string and replace it with "[0-9]+".
     # Example:
     # string="solution.storage.cvg1.devices.data.d2.device"
     # regex="solution.storage.cvg[0-9]+.devices.data.d[0-9]+.device"
-    local regex=$(echo "$string" | sed -e 's/\([0-9]\+\)/[0-9]+/g')
-    echo "$regex"
+    echo "$1" | sed -e 's/\([0-9]\+\)/[0-9]+/g'
 }
 
 solution_content=$(parseSolution)

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -44,7 +44,8 @@ solution_node_list=[]
 sol_node_count=0
 IFS=";" read -r -a my_array <<< "${solution_content}"
 for element in "${my_array[@]}"; do
-    if [[ "${element}" == *".node"* ]]; then
+    if [[ "${element}" == "solution.nodes.node"* ]]; then
+        # NOTE: this will fail if extra keys are added to nodes
         solution_node_list[${sol_node_count}]=${element}
         sol_node_count=$((sol_node_count+1))
     fi

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -5,7 +5,7 @@ solution_chk_yaml='./solution_validation_scripts/solution-check.yaml'
 
 function parseSolution()
 {
-    ./parse_scripts/parse_yaml.sh ${solution_yaml} $1
+    ./parse_scripts/parse_yaml.sh "${solution_yaml}" "$1"
 }
 
 function buildRegexFromSolutionVar()
@@ -97,7 +97,7 @@ for element in "${my_array[@]}"; do
     if [[ "${found}" = false && "${element_array[1]}" == "required" ]]; then
         # Find all the number in the string and replace it with "*".
         temp_regex=$(echo "${element}" | sed -e 's/\([0-9]\+\)/*/g')
-        temp_regex_val=$(echo ${temp_regex} | cut -f1 -d'>')
+        temp_regex_val=$(echo "${temp_regex}" | cut -f1 -d'>')
         result_str="Failed to find '${temp_regex_val}' in the solution file"
         result="failed"
     fi
@@ -111,7 +111,7 @@ num_cvg=$(echo "${cvg_name_list}" | awk -F">" '{print NF-1}')
 # Build a list that contains cvg info
 solution_cvg_blk_list=[]
 cvg_blk_list=0
-for index in $(seq 1 ${num_cvg}); do
+for index in $(seq 1 "${num_cvg}"); do
     solution_cvg_blk_list[${cvg_blk_list}]=$(parseSolution "solution.storage.cvg${index}.*")
     cvg_blk_list=$((cvg_blk_list+1))
 done
@@ -136,7 +136,7 @@ for sol_chk_e in "${solution_chk_cvg_var_list[@]}"; do
     if [[ "${found}" = false ]]; then
         # Find all the number in the string and replace it with "*".
         temp_regex=$(echo "${sol_chk_e}" | sed -e 's/\([0-9]\+\)/*/g')
-        temp_regex_val=$(echo ${temp_regex} | cut -f1 -d'>')
+        temp_regex_val=$(echo "${temp_regex}" | cut -f1 -d'>')
         result_str="Failed to find '${temp_regex_val}' in the solution file"
         result="failed"
         break
@@ -148,7 +148,7 @@ checkResult ${result} "${result_str}"
 # Build a list that only contains data device info in cvg
 solution_cvg_blk_data_dev=[]
 cvg_blk_list=0
-for index in $(seq 1 ${num_cvg}); do
+for index in $(seq 1 "${num_cvg}"); do
     solution_cvg_blk_data_dev[${cvg_blk_list}]=$(parseSolution "solution.storage.cvg${index}.devices.data.*")
     cvg_blk_list=$((cvg_blk_list+1))
 done
@@ -185,7 +185,7 @@ for sol_chk_e in "${solution_chk_node[@]}"; do
     if [[ "${found}" = false ]]; then
         # Find all the number in the string and replace it with "*".
         temp_regex=$(echo "${sol_chk_e}" | sed -e 's/\([0-9]\+\)/*/g')
-        temp_regex_val=$(echo ${temp_regex} | cut -f1 -d'>')
+        temp_regex_val=$(echo "${temp_regex}" | cut -f1 -d'>')
         result_str="Failed to find '${temp_regex_val}' in the solution file"
         result="failed"
         break

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -12,7 +12,7 @@ function buildRegexFromSolutionVar()
 {
     string=$1
     # Find all the number in the string and replace it with "[0-9]+".
-    # Example: 
+    # Example:
     # string="solution.storage.cvg1.devices.data.d2.device"
     # regex="solution.storage.cvg[0-9]+.devices.data.d[0-9]+.device"
     local regex=$(echo "$string" | sed -e 's/\([0-9]\+\)/[0-9]+/g')
@@ -57,7 +57,7 @@ IFS=";" read -r -a my_array <<< "$solution_chk_content"
 for element in "${my_array[@]}"; do
     IFS=">" read -r -a element_array <<< "$element"
     found=false
-    
+
     if [[ "$element" == *".node"* ]]; then
         solution_chk_node[$sol_chk_node_count]="$element"
         sol_chk_node_count=$((sol_chk_node_count+1))
@@ -80,7 +80,7 @@ for element in "${my_array[@]}"; do
             && "${element_array[1]}" == "required" ]]; then
         validate_data_size=true
     fi
-    
+
     if [[ "${element_array[0]}" =~ solution.storage.cvg[0-9]+.devices.data.d[0-9]+.device \
             && "${element_array[1]}" == "required" ]]; then
         validate_data_device=true
@@ -215,7 +215,7 @@ done
 # The SNS=(N+K+S) should not exceed the total number of CVGs in the cluster (the number
 # of CVGs in the solution file multiplies by the number of worker nodes in the cluster)
 total_num_cvgs_in_cluster=$(($num_cvgs*$total_num_nodes))
-if [[ "$sns_total" -gt "$total_num_cvgs_in_cluster" ]]; then    
+if [[ "$sns_total" -gt "$total_num_cvgs_in_cluster" ]]; then
     result_str="The sum of SNS ($sns_total) is greater than the total number of CVGs ($total_num_cvgs_in_cluster) in the cluster"
     result="failed"
 fi
@@ -232,7 +232,7 @@ for val in "${dix_val_array[@]}"; do
     dix_total=$((dix_total+val))
 done
 
-if [[ "$dix_total" -gt "$total_num_nodes" ]]; then    
+if [[ "$dix_total" -gt "$total_num_nodes" ]]; then
     result_str="The sum of DIX ($dix_total) is greater than the total number of worker nodes ($total_num_nodes) in the cluster"
     result="failed"
 fi

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -27,7 +27,6 @@ solution_var_list=[]
 count=0
 solution_node_list=[]
 sol_node_count=0
-cur_cvg_name=''
 IFS=";" read -r -a my_array <<< "$solution_content"
 for element in "${my_array[@]}"; do
     if [[ "$element" == *".node"* ]]; then
@@ -198,8 +197,6 @@ if [[ "$result" == "failed" ]]; then
     exit 1
 fi
 
-sum_sns_durability=0
-sum_dix_durability=0
 sns_var_val=$(parseSolution 'solution.common.storage_sets.durability.sns')
 dix_var_val=$(parseSolution 'solution.common.storage_sets.durability.dix')
 sns_val=$(echo "$sns_var_val" | cut -f2 -d'>')

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -5,7 +5,7 @@ solution_chk_yaml='./solution_validation_scripts/solution-check.yaml'
 
 function parseSolution()
 {
-    echo "$(./parse_scripts/parse_yaml.sh $solution_yaml $1)"
+    ./parse_scripts/parse_yaml.sh $solution_yaml $1
 }
 
 function buildRegexFromSolutionVar()

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -5,7 +5,7 @@ solution_chk_yaml='./solution_validation_scripts/solution-check.yaml'
 
 function parseSolution()
 {
-    ./parse_scripts/parse_yaml.sh $solution_yaml $1
+    ./parse_scripts/parse_yaml.sh ${solution_yaml} $1
 }
 
 function buildRegexFromSolutionVar()
@@ -29,20 +29,20 @@ function checkResult()
 }
 
 solution_content=$(parseSolution)
-solution_chk_content=$(./parse_scripts/parse_yaml.sh $solution_chk_yaml)
+solution_chk_content=$(./parse_scripts/parse_yaml.sh ${solution_chk_yaml})
 
 # Build a list that contains all the content in the solution.yaml file
 solution_var_list=[]
 count=0
 solution_node_list=[]
 sol_node_count=0
-IFS=";" read -r -a my_array <<< "$solution_content"
+IFS=";" read -r -a my_array <<< "${solution_content}"
 for element in "${my_array[@]}"; do
-    if [[ "$element" == *".node"* ]]; then
-        solution_node_list[$sol_node_count]=$element
+    if [[ "${element}" == *".node"* ]]; then
+        solution_node_list[${sol_node_count}]=${element}
         sol_node_count=$((sol_node_count+1))
     fi
-    solution_var_list[$count]="$element"
+    solution_var_list[${count}]="${element}"
     count=$((count+1))
 done
 
@@ -61,23 +61,23 @@ validate_data_device=false
 
 # Validate the following in the solution file: namespace, secrets, images, common section,
 # the first cvg in storage, and the first node in nodes.
-IFS=";" read -r -a my_array <<< "$solution_chk_content"
+IFS=";" read -r -a my_array <<< "${solution_chk_content}"
 for element in "${my_array[@]}"; do
-    IFS=">" read -r -a element_array <<< "$element"
+    IFS=">" read -r -a element_array <<< "${element}"
     found=false
 
-    if [[ "$element" == *".node"* ]]; then
-        solution_chk_node[$sol_chk_node_count]="$element"
+    if [[ "${element}" == *".node"* ]]; then
+        solution_chk_node[${sol_chk_node_count}]="${element}"
         sol_chk_node_count=$((sol_chk_node_count+1))
     fi
 
-    if [[ "$element" == *".cvg"* ]]; then
-        solution_chk_cvg_var_list[$sol_chk_cvg_count]="$element"
+    if [[ "${element}" == *".cvg"* ]]; then
+        solution_chk_cvg_var_list[${sol_chk_cvg_count}]="${element}"
         sol_chk_cvg_count=$((sol_chk_cvg_count+1))
     fi
 
     for e in "${solution_var_list[@]}"; do
-        IFS=">" read -r -a e_array <<< "$e"
+        IFS=">" read -r -a e_array <<< "${e}"
         if [[ "${element_array[0]}" == "${e_array[0]}" ]]; then
             found=true
             break
@@ -94,11 +94,11 @@ for element in "${my_array[@]}"; do
         validate_data_device=true
     fi
 
-    if [[ "$found" = false && "${element_array[1]}" == "required" ]]; then
+    if [[ "${found}" = false && "${element_array[1]}" == "required" ]]; then
         # Find all the number in the string and replace it with "*".
-        temp_regex=$(echo "$element" | sed -e 's/\([0-9]\+\)/*/g')
-        temp_regex_val=$(echo $temp_regex | cut -f1 -d'>')
-        result_str="Failed to find '$temp_regex_val' in the solution file"
+        temp_regex=$(echo "${element}" | sed -e 's/\([0-9]\+\)/*/g')
+        temp_regex_val=$(echo ${temp_regex} | cut -f1 -d'>')
+        result_str="Failed to find '${temp_regex_val}' in the solution file"
         result="failed"
     fi
 done
@@ -107,37 +107,37 @@ checkResult ${result} "${result_str}"
 
 cvg_name_list=$(parseSolution 'solution.storage.cvg*.name')
 # Get number of '>' show up in 'cvg_name_list' string
-num_cvg=$(echo "$cvg_name_list" | awk -F">" '{print NF-1}')
+num_cvg=$(echo "${cvg_name_list}" | awk -F">" '{print NF-1}')
 # Build a list that contains cvg info
 solution_cvg_blk_list=[]
 cvg_blk_list=0
-for index in $(seq 1 $num_cvg); do
-    solution_cvg_blk_list[$cvg_blk_list]=$(parseSolution "solution.storage.cvg$index.*")
+for index in $(seq 1 ${num_cvg}); do
+    solution_cvg_blk_list[${cvg_blk_list}]=$(parseSolution "solution.storage.cvg${index}.*")
     cvg_blk_list=$((cvg_blk_list+1))
 done
 
 # Validate cvg name, type, metadata device, metadata size exist in the solution file
 num_cvgs="${#solution_cvg_blk_list[@]}"
 for sol_chk_e in "${solution_chk_cvg_var_list[@]}"; do
-    IFS=">" read -r -a sol_chk_array <<< "$sol_chk_e"
+    IFS=">" read -r -a sol_chk_array <<< "${sol_chk_e}"
     regex=$(buildRegexFromSolutionVar "${sol_chk_array[0]}")
     count=0
     for sol_e in "${solution_cvg_blk_list[@]}"; do
-        if [[ "$sol_e" =~ $regex || "${sol_chk_array[1]}" != "required" ]]; then
+        if [[ "${sol_e}" =~ ${regex} || "${sol_chk_array[1]}" != "required" ]]; then
             count=$((count+1))
         fi
     done
 
     found=false
-    if [[ "$num_cvgs" == "$count" || "${sol_chk_array[1]}" != "required" ]]; then
+    if [[ "${num_cvgs}" == "${count}" || "${sol_chk_array[1]}" != "required" ]]; then
         found=true
     fi
 
-    if [[ "$found" = false ]]; then
+    if [[ "${found}" = false ]]; then
         # Find all the number in the string and replace it with "*".
-        temp_regex=$(echo "$sol_chk_e" | sed -e 's/\([0-9]\+\)/*/g')
-        temp_regex_val=$(echo $temp_regex | cut -f1 -d'>')
-        result_str="Failed to find '$temp_regex_val' in the solution file"
+        temp_regex=$(echo "${sol_chk_e}" | sed -e 's/\([0-9]\+\)/*/g')
+        temp_regex_val=$(echo ${temp_regex} | cut -f1 -d'>')
+        result_str="Failed to find '${temp_regex_val}' in the solution file"
         result="failed"
         break
     fi
@@ -148,8 +148,8 @@ checkResult ${result} "${result_str}"
 # Build a list that only contains data device info in cvg
 solution_cvg_blk_data_dev=[]
 cvg_blk_list=0
-for index in $(seq 1 $num_cvg); do
-    solution_cvg_blk_data_dev[$cvg_blk_list]=$(parseSolution "solution.storage.cvg$index.devices.data.*")
+for index in $(seq 1 ${num_cvg}); do
+    solution_cvg_blk_data_dev[${cvg_blk_list}]=$(parseSolution "solution.storage.cvg${index}.devices.data.*")
     cvg_blk_list=$((cvg_blk_list+1))
 done
 
@@ -157,12 +157,12 @@ done
 # data.dX.device and the number of data.dX.size are equal
 for sol_chk_e in "${solution_cvg_blk_data_dev[@]}"; do
     # Get a number of data devices
-    num_data_dev=$(echo "$sol_chk_e" | awk -F".device>" '{print NF-1}')
-    num_data_size=$(echo "$sol_chk_e" | awk -F".size>" '{print NF-1}')
-    if [[ "$num_data_dev" -lt "$num_data_size" && "$validate_data_device" = true ]]; then
+    num_data_dev=$(echo "${sol_chk_e}" | awk -F".device>" '{print NF-1}')
+    num_data_size=$(echo "${sol_chk_e}" | awk -F".size>" '{print NF-1}')
+    if [[ "${num_data_dev}" -lt "${num_data_size}" && "${validate_data_device}" = true ]]; then
         result_str="Missing data device info in 'solution.storage.cvg*.devices.data.d*'"
         result="failed"
-    elif [[ "$num_data_dev" -gt "$num_data_size" && "$validate_data_size" = true ]]; then
+    elif [[ "${num_data_dev}" -gt "${num_data_size}" && "${validate_data_size}" = true ]]; then
         result_str="Missing data size info in 'solution.storage.cvg*.devices.data.d*'"
         result="failed"
     fi
@@ -174,19 +174,19 @@ total_num_nodes="${#solution_node_list[@]}"
 # Validate node names in the solution file
 for sol_chk_e in "${solution_chk_node[@]}"; do
     found=false
-    IFS=">" read -r -a sol_chk_array <<< "$sol_chk_e"
+    IFS=">" read -r -a sol_chk_array <<< "${sol_chk_e}"
     regex=$(buildRegexFromSolutionVar "${sol_chk_array[0]}")
     for element in "${solution_node_list[@]}"; do
-        if [[ "$element" =~ $regex || "${sol_chk_array[1]}" != "required" ]]; then
+        if [[ "${element}" =~ ${regex} || "${sol_chk_array[1]}" != "required" ]]; then
             found=true
         fi
     done
 
-    if [[ "$found" = false ]]; then
+    if [[ "${found}" = false ]]; then
         # Find all the number in the string and replace it with "*".
-        temp_regex=$(echo "$sol_chk_e" | sed -e 's/\([0-9]\+\)/*/g')
-        temp_regex_val=$(echo $temp_regex | cut -f1 -d'>')
-        result_str="Failed to find '$temp_regex_val' in the solution file"
+        temp_regex=$(echo "${sol_chk_e}" | sed -e 's/\([0-9]\+\)/*/g')
+        temp_regex_val=$(echo ${temp_regex} | cut -f1 -d'>')
+        result_str="Failed to find '${temp_regex_val}' in the solution file"
         result="failed"
         break
     fi
@@ -196,12 +196,12 @@ checkResult ${result} "${result_str}"
 
 sns_var_val=$(parseSolution 'solution.common.storage_sets.durability.sns')
 dix_var_val=$(parseSolution 'solution.common.storage_sets.durability.dix')
-sns_val=$(echo "$sns_var_val" | cut -f2 -d'>')
-dix_val=$(echo "$dix_var_val" | cut -f2 -d'>')
+sns_val=$(echo "${sns_var_val}" | cut -f2 -d'>')
+dix_val=$(echo "${dix_var_val}" | cut -f2 -d'>')
 
 # Validate SNS
 sns_total=0
-IFS="+" read -r -a sns_val_array <<< "$sns_val"
+IFS="+" read -r -a sns_val_array <<< "${sns_val}"
 for val in "${sns_val_array[@]}"; do
     sns_total=$((sns_total+val))
 done
@@ -209,8 +209,8 @@ done
 # The SNS=(N+K+S) should not exceed the total number of CVGs in the cluster (the number
 # of CVGs in the solution file multiplies by the number of worker nodes in the cluster)
 total_num_cvgs_in_cluster=$(( num_cvgs * total_num_nodes ))
-if [[ "$sns_total" -gt "$total_num_cvgs_in_cluster" ]]; then
-    result_str="The sum of SNS ($sns_total) is greater than the total number of CVGs ($total_num_cvgs_in_cluster) in the cluster"
+if [[ "${sns_total}" -gt "${total_num_cvgs_in_cluster}" ]]; then
+    result_str="The sum of SNS (${sns_total}) is greater than the total number of CVGs (${total_num_cvgs_in_cluster}) in the cluster"
     result="failed"
 fi
 
@@ -218,13 +218,13 @@ checkResult ${result} "${result_str}"
 
 # Validate DIX
 dix_total=0
-IFS="+" read -r -a dix_val_array <<< "$dix_val"
+IFS="+" read -r -a dix_val_array <<< "${dix_val}"
 for val in "${dix_val_array[@]}"; do
     dix_total=$((dix_total+val))
 done
 
-if [[ "$dix_total" -gt "$total_num_nodes" ]]; then
-    result_str="The sum of DIX ($dix_total) is greater than the total number of worker nodes ($total_num_nodes) in the cluster"
+if [[ "${dix_total}" -gt "${total_num_nodes}" ]]; then
+    result_str="The sum of DIX (${dix_total}) is greater than the total number of worker nodes (${total_num_nodes}) in the cluster"
     result="failed"
 fi
 

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -17,6 +17,17 @@ function buildRegexFromSolutionVar()
     echo "$1" | sed -e 's/\([0-9]\+\)/[0-9]+/g'
 }
 
+function checkResult()
+{
+    local result=$1
+    local result_str=$2
+
+    if [[ ${result} == "failed" ]]; then
+        printf "%s\nValidate solution file result: %s\n" "${result_str}" "${result}"
+        exit 1
+    fi
+}
+
 solution_content=$(parseSolution)
 solution_chk_content=$(./parse_scripts/parse_yaml.sh $solution_chk_yaml)
 
@@ -92,10 +103,7 @@ for element in "${my_array[@]}"; do
     fi
 done
 
-if [[ "$result" == "failed" ]]; then
-    printf "$result_str\nValidate solution file result: $result\n"
-    exit 1
-fi
+checkResult ${result} "${result_str}"
 
 cvg_name_list=$(parseSolution 'solution.storage.cvg*.name')
 # Get number of '>' show up in 'cvg_name_list' string
@@ -135,10 +143,7 @@ for sol_chk_e in "${solution_chk_cvg_var_list[@]}"; do
     fi
 done
 
-if [[ "$result" == "failed" ]]; then
-    printf "$result_str\nValidate solution file result: $result\n"
-    exit 1
-fi
+checkResult ${result} "${result_str}"
 
 # Build a list that only contains data device info in cvg
 solution_cvg_blk_data_dev=[]
@@ -163,10 +168,7 @@ for sol_chk_e in "${solution_cvg_blk_data_dev[@]}"; do
     fi
 done
 
-if [[ "$result" == "failed" ]]; then
-    printf "$result_str\nValidate solution file result: $result\n"
-    exit 1
-fi
+checkResult ${result} "${result_str}"
 
 total_num_nodes="${#solution_node_list[@]}"
 # Validate node names in the solution file
@@ -190,10 +192,7 @@ for sol_chk_e in "${solution_chk_node[@]}"; do
     fi
 done
 
-if [[ "$result" == "failed" ]]; then
-    printf "$result_str\nValidate solution file result: $result\n"
-    exit 1
-fi
+checkResult ${result} "${result_str}"
 
 sns_var_val=$(parseSolution 'solution.common.storage_sets.durability.sns')
 dix_var_val=$(parseSolution 'solution.common.storage_sets.durability.dix')
@@ -215,10 +214,7 @@ if [[ "$sns_total" -gt "$total_num_cvgs_in_cluster" ]]; then
     result="failed"
 fi
 
-if [[ "$result" == "failed" ]]; then
-    printf "$result_str\nValidate solution file result: $result\n"
-    exit 1
-fi
+checkResult ${result} "${result_str}"
 
 # Validate DIX
 dix_total=0
@@ -232,4 +228,4 @@ if [[ "$dix_total" -gt "$total_num_nodes" ]]; then
     result="failed"
 fi
 
-printf "$result_str\nValidate solution file result: $result\n"
+checkResult ${result} "${result_str}"

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -29,6 +29,11 @@ function checkResult()
     fi
 }
 
+if [[ ! -f ${solution_yaml} ]]; then
+    echo "ERROR: ${solution_yaml} does not exist"
+    exit 1
+fi
+
 solution_content=$(parseSolution)
 solution_chk_content=$(./parse_scripts/parse_yaml.sh ${solution_chk_yaml})
 

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -214,7 +214,7 @@ done
 
 # The SNS=(N+K+S) should not exceed the total number of CVGs in the cluster (the number
 # of CVGs in the solution file multiplies by the number of worker nodes in the cluster)
-total_num_cvgs_in_cluster=$(($num_cvgs*$total_num_nodes))
+total_num_cvgs_in_cluster=$(( num_cvgs * total_num_nodes ))
 if [[ "$sns_total" -gt "$total_num_cvgs_in_cluster" ]]; then
     result_str="The sum of SNS ($sns_total) is greater than the total number of CVGs ($total_num_cvgs_in_cluster) in the cluster"
     result="failed"


### PR DESCRIPTION
## Description

Fix shellcheck checks:
- See if you can use ${variable//search/replace} instead. [SC2001]
- Double quote to prevent globbing and word splitting. [SC2086]
- Prefer putting braces around variable references even when not strictly required. [SC2250]
- Don't use variables in the printf format string. Use printf '..%s..' "$foo". [SC2059]
- Useless echo? Instead of 'echo $(cmd)', just use 'cmd'. [SC2005]
- Declare and assign separately to avoid masking return values. [SC2155]
- <X> appears unused. Verify use (or export if used externally). [SC2034]
- $/${} is unnecessary on arithmetic variables. [SC2004]

Other:
- Remove trailing whitespace
- Check if solution file exists, return an error if not
- Fix SNS validation check that was wrong due to node count miscalculation

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-30708

## CORTX image version requirements

N/A

## How was this tested?
Ran solution check locally, with expected passing file and various error conditions.

During testing, discovered that the CVG count was not working properly due to an incorrect node count calculation.

## Additional information

Each shellcheck error was fixed in a single commit. Each commit can be reviewed separately to see the changes.

As mentioned, the node counting code is pretty fragile. It will fail for the same reason if, in the future, new keys are added to the nodes entries. Fixing that requires a bit more work and is not done in this PR.

I disabled the checks in each location for SC2001. It's not very easy to try and make Bash pattern globs to replace regular expression, and thus not worth the effort.

## Checklist
- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
