### PR TITLE
CORTX-30708: Fix shellcheck issues in parse scripts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,6 @@ jobs:
         with:
           # Temporarily ignore these until they are fixed
           ignore_paths: >-
-            parse_scripts
             solution_validation_scripts
 
   solution_yaml:

--- a/k8_cortx_cloud/parse_scripts/parse_yaml.sh
+++ b/k8_cortx_cloud/parse_scripts/parse_yaml.sh
@@ -62,6 +62,12 @@ else
         # Get the var and val from the tuple
         VAR=$(echo $VAR_VAL_ELEMENT | cut -f1 -d'>')
         # Check is the filter matches the var
+        #
+        # Ignore SC2053: $2 is a filter which can take wildcard (*)
+        # characters, so this comparison is intentionally relying on glob
+        # pattern matching.
+        #
+        # shellcheck disable=SC2053
         if [[ $VAR == $YAML_PATH_FILTER ]]
         then
             # If the OUTPUT is empty set it otherwise append

--- a/k8_cortx_cloud/parse_scripts/parse_yaml.sh
+++ b/k8_cortx_cloud/parse_scripts/parse_yaml.sh
@@ -25,7 +25,7 @@ function parseYaml
 }
 
 # Check that all of the required parameters have been passed in
-if [ "$INPUT_YAML_FILE" == "" ]
+if [[ -z $INPUT_YAML_FILE ]]
 then
     echo "Invalid input paramters"
     echo "./parse_yaml.sh <input yaml file> [<yaml path filter> OPTIONAL]"
@@ -35,7 +35,7 @@ then
 fi
 
 # Check if the file exists
-if [ ! -f $INPUT_YAML_FILE ]
+if [[ ! -f $INPUT_YAML_FILE ]]
 then
     echo "ERROR: $INPUT_YAML_FILE does not exist"
     exit 1
@@ -50,7 +50,7 @@ PARSED_OUTPUT=$(echo ${PARSED_OUTPUT//../.})
 OUTPUT=""
 
 # Check if we need to do any filtering
-if [ "$YAML_PATH_FILTER" == "" ]
+if [[ -z $YAML_PATH_FILTER ]]
 then
     OUTPUT=$PARSED_OUTPUT
 else
@@ -65,7 +65,7 @@ else
         if [[ $VAR == $YAML_PATH_FILTER ]]
         then
             # If the OUTPUT is empty set it otherwise append
-            if [ "$OUTPUT" == "" ]
+            if [[ -z $OUTPUT ]]
             then
                 OUTPUT=$VAR_VAL_ELEMENT
             else

--- a/k8_cortx_cloud/parse_scripts/parse_yaml.sh
+++ b/k8_cortx_cloud/parse_scripts/parse_yaml.sh
@@ -18,8 +18,8 @@ function parseYaml
     # shellcheck disable=SC2312
     sed -ne "s|^\(${s}\):|\1|" \
         -e "s|^\(${s}\)\(${w}\)${s}:${s}[\"']\(.*\)[\"']${s}\$|\1${fs}\2${fs}\3|p" \
-        -e "s|^\(${s}\)\(${w}\)${s}:${s}\(.*\)${s}\$|\1${fs}\2${fs}\3|p" ${yaml_file} |
-    awk -F${fs} '{
+        -e "s|^\(${s}\)\(${w}\)${s}:${s}\(.*\)${s}\$|\1${fs}\2${fs}\3|p" "${yaml_file}" |
+    awk -F"${fs}" '{
         indent = length($1)/2;
         vname[indent] = $2;
         for (i in vname) {if (i > indent) {delete vname[i]}}
@@ -46,7 +46,7 @@ then
 fi
 
 # Store the parsed output in a single string
-PARSED_OUTPUT=$(parseYaml ${INPUT_YAML_FILE})
+PARSED_OUTPUT=$(parseYaml "${INPUT_YAML_FILE}")
 # Remove any additional indent '.' characters
 PARSED_OUTPUT=${PARSED_OUTPUT//../.}
 
@@ -64,7 +64,7 @@ else
     for VAR_VAL_ELEMENT in "${PARSED_VAR_VAL_ARRAY[@]}"
     do
         # Get the var and val from the tuple
-        VAR=$(echo ${VAR_VAL_ELEMENT} | cut -f1 -d'>')
+        VAR=$(echo "${VAR_VAL_ELEMENT}" | cut -f1 -d'>')
         # Check is the filter matches the var
         #
         # Ignore SC2053: YAML_PATH_FILTER is a filter which can take wildcard
@@ -86,4 +86,4 @@ else
 fi
 
 # Return the parsed output
-echo ${OUTPUT}
+echo "${OUTPUT}"

--- a/k8_cortx_cloud/parse_scripts/parse_yaml.sh
+++ b/k8_cortx_cloud/parse_scripts/parse_yaml.sh
@@ -8,12 +8,18 @@ YAML_PATH_FILTER=$2
 # and the vals and vals are > separated
 function parseYaml
 {
-    s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+    local -r yaml_file=$1
+    local -r s='[[:space:]]*'
+    local -r w='[a-zA-Z0-9_]*'
+    local fs
+    fs=$(echo @|tr @ '\034')
+    readonly fs
+
     # shellcheck disable=SC2312
-    sed -ne "s|^\($s\):|\1|" \
-        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
-        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
-    awk -F$fs '{
+    sed -ne "s|^\(${s}\):|\1|" \
+        -e "s|^\(${s}\)\(${w}\)${s}:${s}[\"']\(.*\)[\"']${s}\$|\1${fs}\2${fs}\3|p" \
+        -e "s|^\(${s}\)\(${w}\)${s}:${s}\(.*\)${s}\$|\1${fs}\2${fs}\3|p" ${yaml_file} |
+    awk -F${fs} '{
         indent = length($1)/2;
         vname[indent] = $2;
         for (i in vname) {if (i > indent) {delete vname[i]}}
@@ -25,24 +31,22 @@ function parseYaml
 }
 
 # Check that all of the required parameters have been passed in
-if [[ -z $INPUT_YAML_FILE ]]
+if [[ -z ${INPUT_YAML_FILE} ]]
 then
-    echo "Invalid input paramters"
+    echo "Missing required input parameters:"
     echo "./parse_yaml.sh <input yaml file> [<yaml path filter> OPTIONAL]"
-    echo "<input yaml file>             = $INPUT_YAML_FILE"
-    echo "[<yaml path filter> OPTIONAL] = $YAML_PATH_FILTER"
     exit 1
 fi
 
 # Check if the file exists
-if [[ ! -f $INPUT_YAML_FILE ]]
+if [[ ! -f ${INPUT_YAML_FILE} ]]
 then
-    echo "ERROR: $INPUT_YAML_FILE does not exist"
+    echo "ERROR: ${INPUT_YAML_FILE} does not exist"
     exit 1
 fi
 
 # Store the parsed output in a single string
-PARSED_OUTPUT=$(parseYaml $INPUT_YAML_FILE)
+PARSED_OUTPUT=$(parseYaml ${INPUT_YAML_FILE})
 # Remove any additional indent '.' characters
 PARSED_OUTPUT=${PARSED_OUTPUT//../.}
 
@@ -50,36 +54,36 @@ PARSED_OUTPUT=${PARSED_OUTPUT//../.}
 OUTPUT=""
 
 # Check if we need to do any filtering
-if [[ -z $YAML_PATH_FILTER ]]
+if [[ -z ${YAML_PATH_FILTER} ]]
 then
-    OUTPUT=$PARSED_OUTPUT
+    OUTPUT=${PARSED_OUTPUT}
 else
     # Split parsed output into an array of vars and vals
-    IFS=';' read -r -a PARSED_VAR_VAL_ARRAY <<< "$PARSED_OUTPUT"
+    IFS=';' read -r -a PARSED_VAR_VAL_ARRAY <<< "${PARSED_OUTPUT}"
     # Loop the var val tuple array
     for VAR_VAL_ELEMENT in "${PARSED_VAR_VAL_ARRAY[@]}"
     do
         # Get the var and val from the tuple
-        VAR=$(echo $VAR_VAL_ELEMENT | cut -f1 -d'>')
+        VAR=$(echo ${VAR_VAL_ELEMENT} | cut -f1 -d'>')
         # Check is the filter matches the var
         #
-        # Ignore SC2053: $2 is a filter which can take wildcard (*)
-        # characters, so this comparison is intentionally relying on glob
+        # Ignore SC2053: YAML_PATH_FILTER is a filter which can take wildcard
+        # (*) characters, so this comparison is intentionally relying on glob
         # pattern matching.
         #
         # shellcheck disable=SC2053
-        if [[ $VAR == $YAML_PATH_FILTER ]]
+        if [[ ${VAR} == ${YAML_PATH_FILTER} ]]
         then
             # If the OUTPUT is empty set it otherwise append
-            if [[ -z $OUTPUT ]]
+            if [[ -z ${OUTPUT} ]]
             then
-                OUTPUT=$VAR_VAL_ELEMENT
+                OUTPUT=${VAR_VAL_ELEMENT}
             else
-                OUTPUT=$OUTPUT";"$VAR_VAL_ELEMENT
+                OUTPUT=${OUTPUT}";"${VAR_VAL_ELEMENT}
             fi
         fi
     done
 fi
 
 # Return the parsed output
-echo $OUTPUT
+echo ${OUTPUT}

--- a/k8_cortx_cloud/parse_scripts/parse_yaml.sh
+++ b/k8_cortx_cloud/parse_scripts/parse_yaml.sh
@@ -9,6 +9,7 @@ YAML_PATH_FILTER=$2
 function parseYaml
 {
     s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+    # shellcheck disable=SC2312
     sed -ne "s|^\($s\):|\1|" \
         -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
         -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |

--- a/k8_cortx_cloud/parse_scripts/parse_yaml.sh
+++ b/k8_cortx_cloud/parse_scripts/parse_yaml.sh
@@ -44,7 +44,7 @@ fi
 # Store the parsed output in a single string
 PARSED_OUTPUT=$(parseYaml $INPUT_YAML_FILE)
 # Remove any additional indent '.' characters
-PARSED_OUTPUT=$(echo ${PARSED_OUTPUT//../.})
+PARSED_OUTPUT=${PARSED_OUTPUT//../.}
 
 # Star with empty output
 OUTPUT=""

--- a/k8_cortx_cloud/parse_scripts/subst.sh
+++ b/k8_cortx_cloud/parse_scripts/subst.sh
@@ -24,11 +24,11 @@ then
 fi
 
 # Check if the variable to substitute is present in the file
-if ! grep "${TO_SUBST}" ${YAML_FILE_TO_MOD} > /dev/null; then
+if ! grep "${TO_SUBST}" "${YAML_FILE_TO_MOD}" > /dev/null; then
     echo "ERROR: Failed to find ${YAML_PATH} in ${YAML_FILE_TO_MOD} for substitution"
     exit 1
 fi
 
 # Use awk to substitute the variable in the file and check the command was executed successfully
-OUTPUT=$(awk -v var1=${TO_SUBST} -v var2="${REPLACE_WITH}" '{sub(var1,var2)}1' ${YAML_FILE_TO_MOD})
-echo "${OUTPUT}" > ${YAML_FILE_TO_MOD}
+OUTPUT=$(awk -v var1="${TO_SUBST}" -v var2="${REPLACE_WITH}" '{sub(var1,var2)}1' "${YAML_FILE_TO_MOD}")
+echo "${OUTPUT}" > "${YAML_FILE_TO_MOD}"

--- a/k8_cortx_cloud/parse_scripts/subst.sh
+++ b/k8_cortx_cloud/parse_scripts/subst.sh
@@ -27,9 +27,7 @@ then
 fi
 
 # Check if the variable to substitute is present in the file
-grep "$TO_SUBST" $YAML_FILE_TO_MOD > /dev/null
-if [ $? -ne 0 ]
-then
+if ! grep "$TO_SUBST" $YAML_FILE_TO_MOD > /dev/null; then
     echo "ERROR: Failed to find $YAML_PATH in $YAML_FILE_TO_MOD for substitution"
     exit 1
 fi

--- a/k8_cortx_cloud/parse_scripts/subst.sh
+++ b/k8_cortx_cloud/parse_scripts/subst.sh
@@ -6,32 +6,29 @@ YAML_PATH=$2
 REPLACE_WITH=$3
 
 # Check that all of the required parameters have been passed in
-if [[ -z $YAML_FILE_TO_MOD ]] || [[ -z $YAML_PATH ]] || [[ -z $REPLACE_WITH ]]
+if [[ -z ${YAML_FILE_TO_MOD} ]] || [[ -z ${YAML_PATH} ]] || [[ -z ${REPLACE_WITH} ]]
 then
-    echo "Invalid input paramters"
+    echo "Missing required input parameters:"
     echo "./subst.sh <file to modify> <yaml variable path> <replace yaml variable with>"
-    echo "<file to modify>             = $YAML_FILE_TO_MOD"
-    echo "<yaml variable path>         = $YAML_PATH"
-    echo "<replace yaml variable with> = $REPLACE_WITH"
     exit 1
 fi
 
 # Add the additional wrapper to around the yaml path
-TO_SUBST="<<.Values.$YAML_PATH>>"
+TO_SUBST="<<.Values.${YAML_PATH}>>"
 
 # Check if the file exists
-if [[ ! -f $YAML_FILE_TO_MOD ]]
+if [[ ! -f ${YAML_FILE_TO_MOD} ]]
 then
-    echo "ERROR: $YAML_FILE_TO_MOD does not exist"
+    echo "ERROR: ${YAML_FILE_TO_MOD} does not exist"
     exit 1
 fi
 
 # Check if the variable to substitute is present in the file
-if ! grep "$TO_SUBST" $YAML_FILE_TO_MOD > /dev/null; then
-    echo "ERROR: Failed to find $YAML_PATH in $YAML_FILE_TO_MOD for substitution"
+if ! grep "${TO_SUBST}" ${YAML_FILE_TO_MOD} > /dev/null; then
+    echo "ERROR: Failed to find ${YAML_PATH} in ${YAML_FILE_TO_MOD} for substitution"
     exit 1
 fi
 
 # Use awk to substitute the variable in the file and check the command was executed successfully
-OUTPUT=$(awk -v var1=$TO_SUBST -v var2="$REPLACE_WITH" '{sub(var1,var2)}1' $YAML_FILE_TO_MOD)
-echo "${OUTPUT}" > $YAML_FILE_TO_MOD
+OUTPUT=$(awk -v var1=${TO_SUBST} -v var2="${REPLACE_WITH}" '{sub(var1,var2)}1' ${YAML_FILE_TO_MOD})
+echo "${OUTPUT}" > ${YAML_FILE_TO_MOD}

--- a/k8_cortx_cloud/parse_scripts/subst.sh
+++ b/k8_cortx_cloud/parse_scripts/subst.sh
@@ -6,7 +6,7 @@ YAML_PATH=$2
 REPLACE_WITH=$3
 
 # Check that all of the required parameters have been passed in
-if [ "$YAML_FILE_TO_MOD" == "" ] || [ "$YAML_PATH" == "" ] || [ "$REPLACE_WITH" == "" ]
+if [[ -z $YAML_FILE_TO_MOD ]] || [[ -z $YAML_PATH ]] || [[ -z $REPLACE_WITH ]]
 then
     echo "Invalid input paramters"
     echo "./subst.sh <file to modify> <yaml variable path> <replace yaml variable with>"
@@ -20,7 +20,7 @@ fi
 TO_SUBST="<<.Values.$YAML_PATH>>"
 
 # Check if the file exists
-if [ ! -f $YAML_FILE_TO_MOD ]
+if [[ ! -f $YAML_FILE_TO_MOD ]]
 then
     echo "ERROR: $YAML_FILE_TO_MOD does not exist"
     exit 1

--- a/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
@@ -17,7 +17,7 @@ fi
 YQ_YAML_PATH_FILTER=".${YAML_PATH_FILTER}"
 
 # Call the yq command
-EXTRACTED_BLOCK=$(./parse_scripts/yq_linux_amd64 e ${YQ_YAML_PATH_FILTER} ${INPUT_YAML_FILE})
+EXTRACTED_BLOCK=$(./parse_scripts/yq_linux_amd64 e "${YQ_YAML_PATH_FILTER}" "${INPUT_YAML_FILE}")
 
 # Check if we should indent
 if [[ -z ${INDENT} ]]

--- a/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
@@ -6,13 +6,10 @@ YAML_PATH_FILTER=$2
 INDENT=$3
 
 # Check that all of the required parameters have been passed in
-if [ "$INPUT_YAML_FILE" == "" ]
+if [[ -z $INPUT_YAML_FILE ]]
 then
-    echo "Invalid input paramters"
+    echo "Invalid input parameters: <input yaml file> is required"
     echo "./yaml_extract_block.sh <input yaml file> [<yaml path filter> OPTIONAL] [<indent> OPTIONAL]"
-    echo "<input yaml file>             = $INPUT_YAML_FILE"
-    echo "[<yaml path filter> OPTIONAL] = $YAML_PATH_FILTER"
-    echo "[<indent> OPTIONAL]           = $INDENT"
     exit 1
 fi
 
@@ -23,9 +20,9 @@ YQ_YAML_PATH_FILTER=".$YAML_PATH_FILTER"
 EXTRACTED_BLOCK=$(./parse_scripts/yq_linux_amd64 e $YQ_YAML_PATH_FILTER $INPUT_YAML_FILE)
 
 # Check if we should indent
-if [ "$INDENT" == "" ]
+if [[ -z $INDENT ]]
 then
-    # No. Set the outpuit to the extracted block  
+    # No. Set the outpuit to the extracted block
     OUTPUT=$EXTRACTED_BLOCK
 else
     # Yes. Create the whitespace indent pattern
@@ -35,7 +32,7 @@ else
     # Loop the extracted block
     while IFS= read -r LINE; do
         # If the OUTPUT is empty set it otherwise append
-        if [ "$OUTPUT" == "" ]
+        if [[ -z $OUTPUT ]]
         then
             OUTPUT="$INDENT_PATTERN""$LINE"
         else
@@ -43,5 +40,5 @@ else
         fi
     done <<< "$EXTRACTED_BLOCK"
 fi
-    
+
 echo "${OUTPUT}"

--- a/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
@@ -26,6 +26,9 @@ then
     OUTPUT=$EXTRACTED_BLOCK
 else
     # Yes. Create the whitespace indent pattern
+    # (Shellcheck rightly complains, but I don't want to uninentionally break
+    # whatever this is attempting to do.)
+    # shellcheck disable=SC2183
     INDENT_PATTERN=$(printf '%*s' "$INDENT" | tr ' ' " ")
     # Set the output of emtpy
     OUTPUT=""

--- a/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_extract_block.sh
@@ -6,42 +6,42 @@ YAML_PATH_FILTER=$2
 INDENT=$3
 
 # Check that all of the required parameters have been passed in
-if [[ -z $INPUT_YAML_FILE ]]
+if [[ -z ${INPUT_YAML_FILE} ]]
 then
-    echo "Invalid input parameters: <input yaml file> is required"
+    echo "Missing required input parameters:"
     echo "./yaml_extract_block.sh <input yaml file> [<yaml path filter> OPTIONAL] [<indent> OPTIONAL]"
     exit 1
 fi
 
 # Convert the filter
-YQ_YAML_PATH_FILTER=".$YAML_PATH_FILTER"
+YQ_YAML_PATH_FILTER=".${YAML_PATH_FILTER}"
 
 # Call the yq command
-EXTRACTED_BLOCK=$(./parse_scripts/yq_linux_amd64 e $YQ_YAML_PATH_FILTER $INPUT_YAML_FILE)
+EXTRACTED_BLOCK=$(./parse_scripts/yq_linux_amd64 e ${YQ_YAML_PATH_FILTER} ${INPUT_YAML_FILE})
 
 # Check if we should indent
-if [[ -z $INDENT ]]
+if [[ -z ${INDENT} ]]
 then
     # No. Set the outpuit to the extracted block
-    OUTPUT=$EXTRACTED_BLOCK
+    OUTPUT=${EXTRACTED_BLOCK}
 else
     # Yes. Create the whitespace indent pattern
     # (Shellcheck rightly complains, but I don't want to uninentionally break
     # whatever this is attempting to do.)
     # shellcheck disable=SC2183
-    INDENT_PATTERN=$(printf '%*s' "$INDENT" | tr ' ' " ")
+    INDENT_PATTERN=$(printf '%*s' "${INDENT}" | tr ' ' " ")
     # Set the output of emtpy
     OUTPUT=""
     # Loop the extracted block
     while IFS= read -r LINE; do
         # If the OUTPUT is empty set it otherwise append
-        if [[ -z $OUTPUT ]]
+        if [[ -z ${OUTPUT} ]]
         then
-            OUTPUT="$INDENT_PATTERN""$LINE"
+            OUTPUT="${INDENT_PATTERN}""${LINE}"
         else
-            OUTPUT="$OUTPUT"$'\n'"$INDENT_PATTERN""$LINE"
+            OUTPUT="${OUTPUT}"$'\n'"${INDENT_PATTERN}""${LINE}"
         fi
-    done <<< "$EXTRACTED_BLOCK"
+    done <<< "${EXTRACTED_BLOCK}"
 fi
 
 echo "${OUTPUT}"

--- a/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
@@ -21,6 +21,9 @@ then
     OUTPUT=$BLOCK_TO_INSERT
 else
     # Yes. Create the whitespace indent pattern
+    # (Shellcheck rightly complains, but I don't want to uninentionally break
+    # whatever this is attempting to do.)
+    # shellcheck disable=SC2183
     INDENT_PATTERN=$(printf '%*s' "$INDENT" | tr ' ' " ")
     # Set the output of emtpy
     OUTPUT=""

--- a/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
@@ -7,21 +7,17 @@ INDENT=$3
 YAML_PATH=$4
 
 # Check that all of the required parameters have been passed in
-if [ "$OUTPUT_YAML_FILE" == "" ] || [ "$BLOCK_TO_INSERT" == "" ]
+if [[ -z $OUTPUT_YAML_FILE ]] || [[ -z $BLOCK_TO_INSERT ]]
 then
-    echo "Invalid input paramters"
+    echo "Invalid input parameters: <output yaml file> and <block to insert> are required"
     echo "./yaml_insert_block.sh <output yaml file> <block to insert> [<indent> OPTIONAL] [<yaml variable path> OPTIONAL]"
-    echo "<output yaml file>              = $OUTPUT_YAML_FILE"
-    echo "<block to insert>               = $BLOCK_TO_INSERT"
-    echo "[<indent> OPTIONAL]             = $INDENT"
-    echo "[<yaml variable path> OPTIONAL] = $YAML_PATH"
     exit 1
 fi
 
 # Check if we should indent
-if [ "$INDENT" == "" ]
+if [[ -z $INDENT ]]
 then
-    # No. Set the outpuit to the extracted block  
+    # No. Set the outpuit to the extracted block
     OUTPUT=$BLOCK_TO_INSERT
 else
     # Yes. Create the whitespace indent pattern
@@ -31,9 +27,9 @@ else
     # Loop the extracted block
     while IFS= read -r LINE; do
         # If the OUTPUT is empty set it otherwise append
-        if [ "$OUTPUT" == "" ]
+        if [[ -z $OUTPUT ]]
         then
-            if [ "$YAML_PATH" == "" ]
+            if [[ -z $YAML_PATH ]]
             then
                 OUTPUT="$INDENT_PATTERN""$LINE"
             else
@@ -45,7 +41,7 @@ else
     done <<< "$BLOCK_TO_INSERT"
 fi
 
-if [ "$YAML_PATH" == "" ]
+if [[ -z $YAML_PATH ]]
 then
     echo "${OUTPUT}" >> $OUTPUT_YAML_FILE
 else

--- a/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
@@ -7,46 +7,46 @@ INDENT=$3
 YAML_PATH=$4
 
 # Check that all of the required parameters have been passed in
-if [[ -z $OUTPUT_YAML_FILE ]] || [[ -z $BLOCK_TO_INSERT ]]
+if [[ -z ${OUTPUT_YAML_FILE} ]] || [[ -z ${BLOCK_TO_INSERT} ]]
 then
-    echo "Invalid input parameters: <output yaml file> and <block to insert> are required"
+    echo "Missing required input parameters:"
     echo "./yaml_insert_block.sh <output yaml file> <block to insert> [<indent> OPTIONAL] [<yaml variable path> OPTIONAL]"
     exit 1
 fi
 
 # Check if we should indent
-if [[ -z $INDENT ]]
+if [[ -z ${INDENT} ]]
 then
     # No. Set the outpuit to the extracted block
-    OUTPUT=$BLOCK_TO_INSERT
+    OUTPUT=${BLOCK_TO_INSERT}
 else
     # Yes. Create the whitespace indent pattern
     # (Shellcheck rightly complains, but I don't want to uninentionally break
     # whatever this is attempting to do.)
     # shellcheck disable=SC2183
-    INDENT_PATTERN=$(printf '%*s' "$INDENT" | tr ' ' " ")
+    INDENT_PATTERN=$(printf '%*s' "${INDENT}" | tr ' ' " ")
     # Set the output of emtpy
     OUTPUT=""
     # Loop the extracted block
     while IFS= read -r LINE; do
         # If the OUTPUT is empty set it otherwise append
-        if [[ -z $OUTPUT ]]
+        if [[ -z ${OUTPUT} ]]
         then
-            if [[ -z $YAML_PATH ]]
+            if [[ -z ${YAML_PATH} ]]
             then
-                OUTPUT="$INDENT_PATTERN""$LINE"
+                OUTPUT="${INDENT_PATTERN}""${LINE}"
             else
-                 OUTPUT="$LINE"
+                 OUTPUT="${LINE}"
             fi
         else
-            OUTPUT="$OUTPUT"$'\n'"$INDENT_PATTERN""$LINE"
+            OUTPUT="${OUTPUT}"$'\n'"${INDENT_PATTERN}""${LINE}"
         fi
-    done <<< "$BLOCK_TO_INSERT"
+    done <<< "${BLOCK_TO_INSERT}"
 fi
 
-if [[ -z $YAML_PATH ]]
+if [[ -z ${YAML_PATH} ]]
 then
-    echo "${OUTPUT}" >> $OUTPUT_YAML_FILE
+    echo "${OUTPUT}" >> ${OUTPUT_YAML_FILE}
 else
-    ./parse_scripts/subst.sh $OUTPUT_YAML_FILE $YAML_PATH "${OUTPUT}"
+    ./parse_scripts/subst.sh ${OUTPUT_YAML_FILE} ${YAML_PATH} "${OUTPUT}"
 fi

--- a/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_insert_block.sh
@@ -46,7 +46,7 @@ fi
 
 if [[ -z ${YAML_PATH} ]]
 then
-    echo "${OUTPUT}" >> ${OUTPUT_YAML_FILE}
+    echo "${OUTPUT}" >> "${OUTPUT_YAML_FILE}"
 else
-    ./parse_scripts/subst.sh ${OUTPUT_YAML_FILE} ${YAML_PATH} "${OUTPUT}"
+    ./parse_scripts/subst.sh "${OUTPUT_YAML_FILE}" "${YAML_PATH}" "${OUTPUT}"
 fi

--- a/k8_cortx_cloud/parse_scripts/yaml_update_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_update_block.sh
@@ -23,7 +23,7 @@ fi
 # Update the template
 if [[ -n ${TEMPLATE_UPDATE} ]]
 then
-    sed -i "s/<<#>>/${TEMPLATE_UPDATE}/g" ${OUTPUT_FILE}
+    sed -i "s/<<#>>/${TEMPLATE_UPDATE}/g" "${OUTPUT_FILE}"
 fi
 
 # Check if the file exists
@@ -33,7 +33,7 @@ then
     exit 1
 fi
 
-PARSED_OUTPUT=$(./parse_yaml.sh ${INPUT_FILE} ${YAML_PATH_FILTER})
+PARSED_OUTPUT=$(./parse_yaml.sh "${INPUT_FILE}" "${YAML_PATH_FILTER}")
 
 # Split parsed output into an array of vars and vals
 IFS=';' read -r -a PARSED_VAR_VAL_ARRAY <<< "${PARSED_OUTPUT}"
@@ -42,8 +42,8 @@ IFS=';' read -r -a PARSED_VAR_VAL_ARRAY <<< "${PARSED_OUTPUT}"
 for VAR_VAL_ELEMENT in "${PARSED_VAR_VAL_ARRAY[@]}"
 do
     # Get the var and val from the tuple
-    VAR=$(echo ${VAR_VAL_ELEMENT} | cut -f1 -d'>')
-	VAL=$(echo ${VAR_VAL_ELEMENT} | cut -f2 -d'>')
+    VAR=$(echo "${VAR_VAL_ELEMENT}" | cut -f1 -d'>')
+	VAL=$(echo "${VAR_VAL_ELEMENT}" | cut -f2 -d'>')
     # Call the substitution script the update the output file
-    ./subst.sh ${OUTPUT_FILE} ${VAR} ${VAL}
+    ./subst.sh "${OUTPUT_FILE}" "${VAR}" "${VAL}"
 done

--- a/k8_cortx_cloud/parse_scripts/yaml_update_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_update_block.sh
@@ -6,44 +6,44 @@ YAML_PATH_FILTER=$3
 TEMPLATE_UPDATE=$4
 
 # Check that all of the required parameters have been passed in
-if [[ -z $INPUT_FILE ]] || [[ -z $OUTPUT_FILE ]]
+if [[ -z ${INPUT_FILE} ]] || [[ -z ${OUTPUT_FILE} ]]
 then
-    echo "Invalid input parameters: <input file> and <output file> are required"
+    echo "Missing required input parameters:"
     echo "./yaml_update_block.sh <input file> <output file> [<yaml path filter> OPTIONAL] [<template update> OPTIONAL]"
     exit 1
 fi
 
 # Check if the file exists
-if [[ ! -f $INPUT_FILE ]]
+if [[ ! -f ${INPUT_FILE} ]]
 then
-    echo "ERROR: input file $INPUT_FILE does not exist"
+    echo "ERROR: input file ${INPUT_FILE} does not exist"
     exit 1
 fi
 
 # Update the template
-if [[ -n $TEMPLATE_UPDATE ]]
+if [[ -n ${TEMPLATE_UPDATE} ]]
 then
-    sed -i "s/<<#>>/$TEMPLATE_UPDATE/g" $OUTPUT_FILE
+    sed -i "s/<<#>>/${TEMPLATE_UPDATE}/g" ${OUTPUT_FILE}
 fi
 
 # Check if the file exists
-if [[ ! -f $OUTPUT_FILE ]]
+if [[ ! -f ${OUTPUT_FILE} ]]
 then
-    echo "ERROR: output file $OUTPUT_FILE does not exist"
+    echo "ERROR: output file ${OUTPUT_FILE} does not exist"
     exit 1
 fi
 
-PARSED_OUTPUT=$(./parse_yaml.sh $INPUT_FILE $YAML_PATH_FILTER)
+PARSED_OUTPUT=$(./parse_yaml.sh ${INPUT_FILE} ${YAML_PATH_FILTER})
 
 # Split parsed output into an array of vars and vals
-IFS=';' read -r -a PARSED_VAR_VAL_ARRAY <<< "$PARSED_OUTPUT"
+IFS=';' read -r -a PARSED_VAR_VAL_ARRAY <<< "${PARSED_OUTPUT}"
 
 # Loop the var val tuple array
 for VAR_VAL_ELEMENT in "${PARSED_VAR_VAL_ARRAY[@]}"
 do
     # Get the var and val from the tuple
-    VAR=$(echo $VAR_VAL_ELEMENT | cut -f1 -d'>')
-	VAL=$(echo $VAR_VAL_ELEMENT | cut -f2 -d'>')
+    VAR=$(echo ${VAR_VAL_ELEMENT} | cut -f1 -d'>')
+	VAL=$(echo ${VAR_VAL_ELEMENT} | cut -f2 -d'>')
     # Call the substitution script the update the output file
-    ./subst.sh $OUTPUT_FILE $VAR $VAL
+    ./subst.sh ${OUTPUT_FILE} ${VAR} ${VAL}
 done

--- a/k8_cortx_cloud/parse_scripts/yaml_update_block.sh
+++ b/k8_cortx_cloud/parse_scripts/yaml_update_block.sh
@@ -6,32 +6,28 @@ YAML_PATH_FILTER=$3
 TEMPLATE_UPDATE=$4
 
 # Check that all of the required parameters have been passed in
-if [ "$INPUT_FILE" == "" ] || [ "$OUTPUT_FILE" == "" ]
+if [[ -z $INPUT_FILE ]] || [[ -z $OUTPUT_FILE ]]
 then
-    echo "Invalid input paramters"
+    echo "Invalid input parameters: <input file> and <output file> are required"
     echo "./yaml_update_block.sh <input file> <output file> [<yaml path filter> OPTIONAL] [<template update> OPTIONAL]"
-    echo "<input file>                  = $INPUT_FILE"
-    echo "<output file>                 = $OUTPUT_FILE"
-    echo "[<yaml path filter> OPTIONAL] = $YAML_PATH_FILTER"
-    ehco "[<template update> OPTIONAL]  = $TEMPLATE_UPDATE"
     exit 1
 fi
 
 # Check if the file exists
-if [ ! -f $INPUT_FILE ]
+if [[ ! -f $INPUT_FILE ]]
 then
     echo "ERROR: input file $INPUT_FILE does not exist"
     exit 1
 fi
 
-# Udpate he template
-if [ "$TEMPLATE_UPDATE" != "" ]
+# Update the template
+if [[ -n $TEMPLATE_UPDATE ]]
 then
     sed -i "s/<<#>>/$TEMPLATE_UPDATE/g" $OUTPUT_FILE
 fi
 
 # Check if the file exists
-if [ ! -f $OUTPUT_FILE ]
+if [[ ! -f $OUTPUT_FILE ]]
 then
     echo "ERROR: output file $OUTPUT_FILE does not exist"
     exit 1


### PR DESCRIPTION
## Description
Fix shellcheck checks for all scripts in the `parse` directory:

- Double quote to prevent globbing and word splitting. [SC2086]
- Prefer putting braces around variable references even when not strictly required. [SC2250]
- This format string has 2 variables, but is passed 1 arguments. [SC2183]
- Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'. [SC2116]
- Quote the right-hand side of == in [[ ]] to prevent glob matching. [SC2053]
- Prefer [[ ]] over [ ] for tests in Bash/Ksh. [SC2292]
- Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore). [SC2312]
- Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?. [SC2181]

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-30708
- This change is related to: PR #212 

## CORTX image version requirements
N/A

## How was this tested?
Ran all scripts (deploy, destroy, logs, etc.) with success.

## Additional information
This has a merge conflict with PR #212 . Whichever is merged last should remove the entire ignores section of the Github action.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
