### PR TITLE
CORTX-30781 Add regression test for default vs other namespace

### DIFF
--- a/test/regression/cluster.py
+++ b/test/regression/cluster.py
@@ -56,6 +56,7 @@ class Cluster:
             self.generate_solution_file()
 
         solution = safe_load(open(self.solution_file))
+        self.solution = solution['solution']
         nodes = solution['solution']['nodes']
         self.nodes = [n['name'] for n in nodes.values()]
 
@@ -113,6 +114,13 @@ class Cluster:
         secrets = self.cluster_data.get('secrets')
         if secrets:
             solution['solution']['secrets'] = secrets
+
+        #
+        # Set namespace
+        #
+        namespace = self.cluster_data.get('namespace')
+        if namespace:
+            solution['solution']['namespace'] = namespace
 
         #
         # Set nodeports

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -14,8 +14,9 @@ from utils import Logger, StopWatch
 
 def verify_pods_in_namespace(checker, namespace):
     cmd = ['kubectl', 'get', 'pods', '-n', namespace, '--no-headers']
+    # nosec
     stdout = subprocess.Popen(cmd, stdout=subprocess.PIPE) \
-                       .communicate()[0].decode('utf-8')  # nosec
+                       .communicate()[0].decode('utf-8')
     expected_pods = {
         'cortx-control': 0,
         'cortx-data': 0,

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -2,7 +2,7 @@
 
 import argparse
 import re
-import subprocess
+import subprocess # nosec
 import sys
 
 import yaml
@@ -13,7 +13,7 @@ from utils import Logger, StopWatch
 
 
 def verify_pods_in_namespace(checker, namespace):
-    cmd = 'kubectl get pods -A'.split()
+    cmd = ['kubectl', 'get', 'pods', '-A']
     stdout = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
     expected_pods = {
         'cortx-control': 0,
@@ -76,7 +76,7 @@ def run_deploy_test(cluster, logger, checker, shutdown=False):
 
     # Verify cortx pods running in expected namespace
     namespace = cluster.solution['namespace']
-    cmd = f'kubectl get all -n {namespace}'.split()
+    cmd = ['kubectl', 'get', 'all', '-n', namespace]
     logger.log(subprocess.Popen(cmd, stdout=subprocess.PIPE)
                          .communicate()[0].decode('utf-8'))
     verify_pods_in_namespace(checker, namespace)

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -13,7 +13,7 @@ from utils import Logger, StopWatch
 
 
 def verify_pods_in_namespace(checker, namespace):
-    stdout = subprocess.Popen(['kubectl', 'get', 'pods', '-A'],
+    stdout = subprocess.Popen(['kubectl', 'get', 'pods', '-A'], # nosec
                               stdout=subprocess.PIPE) \
                        .communicate()[0].decode('utf-8')
     expected_pods = {

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -13,8 +13,8 @@ from utils import Logger, StopWatch
 
 
 def verify_pods_in_namespace(checker, namespace):
-    cmd = 'kubectl get pods -A'
-    stdout = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
+    cmd = 'kubectl get pods -A'.split()
+    stdout = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
     expected_pods = {
         'cortx-control': 0,
         'cortx-data': 0,
@@ -76,8 +76,9 @@ def run_deploy_test(cluster, logger, checker, shutdown=False):
 
     # Verify cortx pods running in expected namespace
     namespace = cluster.solution['namespace']
-    logger.log(subprocess.Popen(f'kubectl get all -n {namespace}', shell=True,
-                     stdout=subprocess.PIPE).communicate()[0].decode('utf-8'))
+    cmd = f'kubectl get all -n {namespace}'.split()
+    logger.log(subprocess.Popen(cmd, stdout=subprocess.PIPE)
+                         .communicate()[0].decode('utf-8'))
     verify_pods_in_namespace(checker, namespace)
 
     logger.log('\n\n')

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -15,8 +15,8 @@ from utils import Logger, StopWatch
 def verify_pods_in_namespace(checker, namespace):
     cmd = ['kubectl', 'get', 'pods', '-n', namespace, '--no-headers']
     # nosec
-    stdout = subprocess.Popen(cmd, stdout=subprocess.PIPE) \
-                       .communicate()[0].decode('utf-8')
+    child = subprocess.Popen(cmd, stdout=subprocess.PIPE)  # nosec
+    stdout = child.communicate()[0].decode('utf-8')
     expected_pods = {
         'cortx-control': 0,
         'cortx-data': 0,

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -13,8 +13,9 @@ from utils import Logger, StopWatch
 
 
 def verify_pods_in_namespace(checker, namespace):
-    cmd = ['kubectl', 'get', 'pods', '-A']
-    stdout = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
+    stdout = subprocess.Popen(['kubectl', 'get', 'pods', '-A'],
+                              stdout=subprocess.PIPE) \
+                       .communicate()[0].decode('utf-8')
     expected_pods = {
         'cortx-control': 0,
         'cortx-data': 0,
@@ -76,8 +77,7 @@ def run_deploy_test(cluster, logger, checker, shutdown=False):
 
     # Verify cortx pods running in expected namespace
     namespace = cluster.solution['namespace']
-    # cmd = ['kubectl', 'get', 'all', '-n', namespace]
-    logger.log(subprocess.Popen(['kubectl', 'get', 'all', '-n', namespace],
+    logger.log(subprocess.Popen(['kubectl', 'get', 'all', '-n', namespace], # nosec
                                 stdout=subprocess.PIPE)
                          .communicate()[0].decode('utf-8'))
     verify_pods_in_namespace(checker, namespace)

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -76,8 +76,9 @@ def run_deploy_test(cluster, logger, checker, shutdown=False):
 
     # Verify cortx pods running in expected namespace
     namespace = cluster.solution['namespace']
-    cmd = ['kubectl', 'get', 'all', '-n', namespace]
-    logger.log(subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    # cmd = ['kubectl', 'get', 'all', '-n', namespace]
+    logger.log(subprocess.Popen(['kubectl', 'get', 'all', '-n', namespace],
+                                stdout=subprocess.PIPE)
                          .communicate()[0].decode('utf-8'))
     verify_pods_in_namespace(checker, namespace)
 

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -1,12 +1,44 @@
 #!/usr/bin/python3
 
 import argparse
+import re
+import subprocess
 import sys
+
+import yaml
 
 from checker import Checker
 from cluster import Cluster
 from utils import Logger, StopWatch
 
+
+def verify_pods_in_namespace(checker, namespace):
+    cmd = 'kubectl get pods -A'
+    stdout = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
+    expected_pods = {
+        'cortx-control': 0,
+        'cortx-data': 0,
+        'cortx-ha': 0,
+        'cortx-server': 0
+        }
+
+    for line in stdout.splitlines():
+        ns, podname, _ = line.split(None, 2)
+        if ns != namespace:
+            continue
+        m = re.match(r'(cortx-[\w]+)', podname)
+        if m:
+            if m.group(1) in expected_pods:
+                expected_pods[m.group(1)] += 1
+
+    checker.test(expected_pods['cortx-control'] == 1,
+                 f'Verify one cortx-control pod deployed in namespace {namespace}')
+    checker.test(expected_pods['cortx-ha'] == 1,
+                 f'Verify one cortx-ha pod deployed in namespace {namespace}')
+    checker.test(expected_pods['cortx-data'] >= 1,
+                 f'Verify at least one cortx-data pod deployed in namespace {namespace}')
+    checker.test(expected_pods['cortx-server'] >= 1,
+                 f'Verify at least one cortx-server pod deployed in namespace {namespace}')
 
 def run_deploy_test(cluster, logger, checker, shutdown=False):
 
@@ -40,6 +72,13 @@ def run_deploy_test(cluster, logger, checker, shutdown=False):
     sw.stop()
     checker.test_equal(0, result, 'Run deploy-cortx-cloud.sh')
     logger.log(f'TIMING: Deploy: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
+
+
+    # Verify cortx pods running in expected namespace
+    namespace = cluster.solution['namespace']
+    logger.log(subprocess.Popen(f'kubectl get all -n {namespace}', shell=True,
+                     stdout=subprocess.PIPE).communicate()[0].decode('utf-8'))
+    verify_pods_in_namespace(checker, namespace)
 
     logger.log('\n\n')
     logger.logheader('-'*80)
@@ -81,6 +120,9 @@ def run_deploy_test(cluster, logger, checker, shutdown=False):
         checker.test_equal(0, result, 'Run start-cortx-cloud.sh')
         logger.log(f'TIMING: Status: {sw.elapsed():.0f}s', color=Logger.OKBLUE)
 
+        # Verify cortx pods running in expected namespace
+        verify_pods_in_namespace(checker, namespace)
+
     logger.log('\n\n')
     logger.logheader('-'*80)
     logger.logheader('\n\n')
@@ -99,13 +141,24 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', dest='cluster')
     parser.add_argument('-s', dest='solution')
+    parser.add_argument('--namespace', dest='namespace')
     parser.add_argument('--shutdown', action='store_true')
     parser.add_argument('--logdir', dest='logdir', default='.')
     args = parser.parse_args()
 
+    # Update namespace if specified
+    cluster_file = args.cluster
+    if args.namespace:
+        with open(args.cluster) as f:
+            cluster_data = yaml.safe_load(f)
+        cluster_data['namespace'] = args.namespace
+        cluster_file = f'{args.namespace}.' + args.cluster
+        with open(cluster_file, 'w') as f:
+            yaml.dump(cluster_data, f)
+
     logger = Logger()
     checker = Checker(logger)
-    cluster = Cluster(args.solution, args.cluster)
+    cluster = Cluster(args.solution, cluster_file)
     run_deploy_test(cluster, logger, checker, args.shutdown)
 
     sys.exit(checker.result())

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -2,7 +2,7 @@
 
 import argparse
 import re
-import subprocess # nosec
+import subprocess  # nosec
 import sys
 
 import yaml
@@ -13,9 +13,9 @@ from utils import Logger, StopWatch
 
 
 def verify_pods_in_namespace(checker, namespace):
-    stdout = subprocess.Popen(['kubectl', 'get', 'pods', '-A'], # nosec
-                              stdout=subprocess.PIPE) \
-                       .communicate()[0].decode('utf-8')
+    cmd = ['kubectl', 'get', 'pods', '-n', namespace, '--no-headers']
+    stdout = subprocess.Popen(cmd, stdout=subprocess.PIPE) \
+                       .communicate()[0].decode('utf-8')  # nosec
     expected_pods = {
         'cortx-control': 0,
         'cortx-data': 0,
@@ -24,9 +24,7 @@ def verify_pods_in_namespace(checker, namespace):
         }
 
     for line in stdout.splitlines():
-        ns, podname, _ = line.split(None, 2)
-        if ns != namespace:
-            continue
+        podname, _ = line.split(None, 1)
         m = re.match(r'(cortx-[\w]+)', podname)
         if m:
             if m.group(1) in expected_pods:
@@ -77,7 +75,7 @@ def run_deploy_test(cluster, logger, checker, shutdown=False):
 
     # Verify cortx pods running in expected namespace
     namespace = cluster.solution['namespace']
-    logger.log(subprocess.Popen(['kubectl', 'get', 'all', '-n', namespace], # nosec
+    logger.log(subprocess.Popen(['kubectl', 'get', 'all', '-n', namespace],  # nosec
                                 stdout=subprocess.PIPE)
                          .communicate()[0].decode('utf-8'))
     verify_pods_in_namespace(checker, namespace)

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -153,6 +153,10 @@ if __name__ == "__main__":
             cluster_data = yaml.safe_load(f)
         cluster_data['namespace'] = args.namespace
         cluster_file = f'{args.namespace}.' + args.cluster
+        # Note: This creates a new config file that is
+        # note deleted by this test.  I am ok with that.
+        # I prefer this than deleting a file that I might
+        # want to inspect after the test runs.
         with open(cluster_file, 'w') as f:
             yaml.dump(cluster_data, f)
 

--- a/test/regression/testlists/alltests.yaml
+++ b/test/regression/testlists/alltests.yaml
@@ -5,3 +5,9 @@ test_deploy_basic:
 test_deploy_stub:
   id: TEST-DEPLOY-0002
   cmd: ./test_deploy.py -c {{ cluster }} -s {{ k8_cloud_dir }}/solution_stub.yaml --shutdown
+
+#Deploy into default namespace
+test_deploy_basic_default:
+  id: TEST-DEPLOY-0001
+  cmd: ./test_deploy.py -c {{ cluster }} -s {{ k8_cloud_dir }}/solution.example.yaml --shutdown --namespace=default
+

--- a/test/regression/testlists/deploy_all.yaml
+++ b/test/regression/testlists/deploy_all.yaml
@@ -3,4 +3,5 @@ tests:
 
 testlist:
  - test_deploy_basic
+ - test_deploy_basic_default
  - test_deploy_stub


### PR DESCRIPTION
## Description
This change adds a feature to the regression test `test_deploy.py` to specify a namespace.
When namespace is specified it overrides the namespace specified in the cluster config file.

In addition, a new test that specifies "default" namespace is added (to ensure that deployment
into the default namespace works as expected).

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [x] Code quality improvements to existing code or test additions/updates

## Applicable issues
- This change is related to an issue: CORTX-30781

## How was this tested?
I have run this via ./testrunner.py -c <config> -t testlists/deploy_all.py

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
