### PR TITLE
CORTX-30943: Support specified namespace for cortx-client pods

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-local-pvc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-local-pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.cortxclient.localpathpvc.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: {{ .Values.cortxclient.name }}
   name: {{ .Values.cortxclient.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-svc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-svc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.cortxclient.service.headless.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   publishNotReadyAddresses: true
   clusterIP: None

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/values.yaml
@@ -1,4 +1,3 @@
-namespace: cortx
 cortxclient:
   name: cortx-client
   image: ghcr.io/seagate/centos:7


### PR DESCRIPTION

## Description
This change fully supports deploying cortx-client pods into the namespace specified by solution.yaml.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-29043

## CORTX image version requirements
No new CORTX image version requirements with this change (but as before it does need to be version 725 or later to support other recent changes).

## How was this tested?
I deployed CORTX with "num_clients  = 1" to confirm that it deploys into the specified namespace.


## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
