### PR TITLE
CORTX-30792: Cluster IP service for HA Pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ This section contains common parameters that affect all CORTX components running
 | `common.hax.protocol`                                 | Protocol that is used to communicate with HAX components running across Server and Data Pods.     | `https` |
 | `common.hax.service_name`                             | Service name that is used to communicate with HAX components running across Server and Data Pods. | `cortx-hax-svc` |
 | `common.hax.port_num`                                 | Port number that is used to communicate with HAX components running across Server and Data Pods.  | `22003` |
+| `common.ha.protocol`                                  | Protocol that is used to communicate with Ha components running across Ha Pod.  | `http` |
+| `common.ha.service_name`                                  | Service name that is used to communicate with Ha components running across Ha Pod.  | `cortx-ha-svc` |
+| `common.ha.port_num`                                  | Port number that is used to communicate with Ha components running across Ha Pod.  | `23051` |
 | `common.external_services.s3.type`                    | Kubernetes Service type for external access to S3 IO                                              | `NodePort` |
 | `common.external_services.s3.count`                   | The number of service instances to create when service type is `LoadBalancer`                     | `1` |
 | `common.external_services.s3.ports.http`              | Non-secure (http) port number used for S3 IO                                                      | `8000` |

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
@@ -144,6 +144,11 @@ cortx:
   {{- end }}
   {{- if .Values.cortxHa.enabled }}
   ha:
+    service:
+      endpoints:
+      {{- with .Values.cortxHa.haService }}
+        - {{ .protocol }}://{{ .name }}:{{ .port }}
+      {{- end }}
     limits:
       services:
       - name: fault_tolerance

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/values.yaml
@@ -110,6 +110,10 @@ cortxRgw:
 # cortxHA allows configuring CORTX HA settings
 cortxHa:
   enabled: true
+  haService:
+    protocol: http
+    name: cortx-ha-svc
+    port: 23501
 
 #cortxHare allows configuring CORTX HARE settings
 cortxHare:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
@@ -116,6 +116,10 @@ spec:
           env:
             - name: UDS_CLOUD_CONTAINER_NAME
               value: {{ .Values.cortxha.name }}
+          ports:
+          - name: ha
+            containerPort: {{ .Values.cortxdata.ha.port }}
+            protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
         - name: cortx-ha-health-monitor

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
@@ -118,7 +118,7 @@ spec:
               value: {{ .Values.cortxha.name }}
           ports:
           - name: ha
-            containerPort: {{ .Values.cortxdata.ha.port }}
+            containerPort: {{ .Values.cortxha.ha.port }}
             protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/values.yaml
@@ -3,6 +3,8 @@ cortxha:
   image: ghcr.io/seagate/centos:7
   secretinfo: secret-info.txt
   serviceaccountname: cortx-sa
+  ha:
+    port: 23501
   service:
     clusterip:
       name: cortx-ha-clusterip-svc

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-ha-svc.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/templates/cortx-ha-svc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.services.create -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.services.ha.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: {{ .Values.services.ha.type }}
+  selector:
+    cortx.io/service-type: "cortx-ha"
+  ports:
+    - name: cortx-ha-tcp
+      protocol: TCP
+      port: {{ .Values.services.ha.port | int }}
+      targetPort: {{ .Values.services.ha.port | int }}
+
+{{- end }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-platform/values.yaml
@@ -51,6 +51,10 @@ services:
     name: cortx-hax-svc
     type: ClusterIP
     port: 22003
+  ha:
+    name: cortx-ha-svc
+    type: ClusterIP
+    port: 23501
   io:
     name: cortx-io-svc
     type: ClusterIP

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -41,6 +41,10 @@ solution:
       protocol: https
       service_name: cortx-hax-svc
       port_num: 22003
+    ha:
+      protocol: http
+      service_name: cortx-ha-svc
+      port_num: 23501
     storage_sets:
       name: storage-set-1
       durability:


### PR DESCRIPTION
<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
-->
These changes have been done to create a ClusterIP service for the ha pod named cortx-ha-svc which will be listening to the HA pod. 
## Breaking change
<!--
If this change introduces any breaking changes, describe what it breaks and what action is required
to address it. We prefer deprecating things first before breaking them entirely. If you are unable
to support deprecation in this change, or are actually removing the deprecated the item, please
state so.

You can delete this section if there are no breaking changes.
-->

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [x] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: # CORTX-30792
- This change is related to an issue: # CORTX-30792

## CORTX image version requirements
<!--
If this change requires specific versions of CORTX that are newer than the currently referenced
images, please list those images and link them to the public CORTX packages page.

- cortx-all images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-all
- cortx-rgw images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-rgw

The referenced images are always defined in the images section of the solution.example.yaml file. If
updated images are required, the example solution YAML file should be updated in this change.

If the currently referenced CORTX container images support this change, you can delete this section
or indicate that.

*NOTE* that we cannot merge any PRs that depend on non-public images!
-->
This change requires the following images:

- `cortx-all:ghcr.io/seagate/cortx-all:2.0.0-737`
- `cortx-rgw:ghcr.io/seagate/cortx-rgw:2.0.0-737`

## How was this tested?
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->

## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [x] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID CORTX-30792
