### PR TITLE
CORTX-31012:  Include timestamp in Core dump filename.

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-cm-nodeconfig.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-cm-nodeconfig.yaml
@@ -16,5 +16,6 @@ data:
         printf "[WARNING] Detected kernel parameter 'vm.max_map_count' setting (%s) is lower than the desired setting for optimal system performance (%s).\n" "${OBSERVED_MAX_MAP_COUNT}" "${DESIRED_MAX_MAP_COUNT}"
         printf "Setting 'vm.max_map_count' via 'sysctl' command.\n"
         sysctl -w vm.max_map_count=$DESIRED_MAX_MAP_COUNT >> /etc/sysctl.d/k8s.conf
+        sysctl -w kernel.core_pattern=core.%t >> /etc/sysctl.d/k8s.conf
         sleep 60
     fi

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -220,6 +220,8 @@ function increaseResources()
 {
     # Increase Resources
     sysctl -w vm.max_map_count=30000000;
+    # Add timestamp in core file name
+    sysctl -w kernel.core_pattern = core.%t
 }
 
 function prepCortxDeployment()

--- a/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/prereq-deploy-cortx-cloud.sh
@@ -221,7 +221,7 @@ function increaseResources()
     # Increase Resources
     sysctl -w vm.max_map_count=30000000;
     # Add timestamp in core file name
-    sysctl -w kernel.core_pattern = core.%t
+    sysctl -w kernel.core_pattern=core.%t
 }
 
 function prepCortxDeployment()


### PR DESCRIPTION
Signed-off-by: Papan Kumar Singh <papan.kumarsingh@seagate.com>

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->
To avoid same core file name when m0d start with the same pid,
add timestamp in core file name.
Currently core file name is core.<pid>,
Change it to core.<timestamp>.<pid>
## Breaking change
<!--
If this change introduces any breaking changes, describe what it breaks and what action is required
to address it. We prefer deprecating things first before breaking them entirely. If you are unable
to support deprecation in this change, or are actually removing the deprecated the item, please
state so.

You can delete this section if there are no breaking changes.
-->

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: #CORTX-31012
- This change is related to an issue: #

## CORTX image version requirements
<!--
If this change requires specific versions of CORTX that are newer than the currently referenced
images, please list those images and link them to the public CORTX packages page.

- cortx-all images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-all
- cortx-rgw images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-rgw

The referenced images are always defined in the images section of the solution.example.yaml file. If
updated images are required, the example solution YAML file should be updated in this change.

If the currently referenced CORTX container images support this change, you can delete this section
or indicate that.

*NOTE* that we cannot merge any PRs that depend on non-public images!
-->
This change requires the following images:

- `cortx-all:<version>`
- `cortx-rgw:<version>`

## How was this tested?
[root@cortx-data-headless-svc-ssc-vm-rhev4-2614 ~]# sysctl -a | grep core
kernel.core_pattern = core.%t

[root@cortx-data-headless-svc-ssc-vm-rhev4-2614 m0d-0x7200000000000001:0x5a]# pwd
/etc/cortx/motr/m0d-0x7200000000000001:0x5a
[root@cortx-data-headless-svc-ssc-vm-rhev4-2614 m0d-0x7200000000000001:0x5a]# ls
core.1651139893.104  db  db-log  stobs

<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->

## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
