### PR TITLE
Bump CORTX images to build 744

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -7,3 +7,4 @@ chart-dirs:
 excluded-charts:
 chart-repos:
 validate-chart-schema: false
+check-version-increment: false

--- a/charts/cortx/Chart.yaml
+++ b/charts/cortx/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.0-735
+appVersion: 2.0.0-744
 description: CORTX is a distributed object storage system designed for great efficiency, massive capacity, and high HDD-utilization.
 home: https://github.com/Seagate/cortx-k8s/tree/integration/charts/cortx
 icon: https://raw.githubusercontent.com/Seagate/cortx/main/doc/assets/CORTX-Logo-GRN_400x400.jpg

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -1,6 +1,6 @@
 # cortx
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-735](https://img.shields.io/badge/AppVersion-2.0.0--735-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-744](https://img.shields.io/badge/AppVersion-2.0.0--744-informational?style=flat-square)
 
 CORTX is a distributed object storage system designed for great efficiency, massive capacity, and high HDD-utilization.
 

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -11,11 +11,11 @@ solution:
       csm_auth_admin_secret: null
       csm_mgmt_admin_secret: null
   images:
-    cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-735
-    cortxdata: ghcr.io/seagate/cortx-all:2.0.0-735
-    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-735
-    cortxha: ghcr.io/seagate/cortx-all:2.0.0-735
-    cortxclient: ghcr.io/seagate/cortx-all:2.0.0-735
+    cortxcontrol: ghcr.io/seagate/cortx-all:2.0.0-744
+    cortxdata: ghcr.io/seagate/cortx-all:2.0.0-744
+    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-744
+    cortxha: ghcr.io/seagate/cortx-all:2.0.0-744
+    cortxclient: ghcr.io/seagate/cortx-all:2.0.0-744
     consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r97
     zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9


### PR DESCRIPTION
## Description
Update the CORTX images in the example solution file to build 744. This is the most-recent announced release (as of 4/28/22, previous announcement being 731).

Although not being used yet, the CORTX Helm Chart's `appVersion` was updated to match this.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
- This change is related to an issue: [CORTX-30893](https://jts.seagate.com/browse/CORTX-30893)

## CORTX image version requirements
<!--
If this change requires specific versions of CORTX that are newer than the currently referenced
images, please list those images and link them to the public CORTX packages page.

- cortx-all images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-all
- cortx-rgw images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-rgw

The referenced images are always defined in the images section of the solution.example.yaml file. If
updated images are required, the example solution YAML file should be updated in this change.

If the currently referenced CORTX container images support this change, you can delete this section
or indicate that.

*NOTE* that we cannot merge any PRs that depend on non-public images!
-->
This change requires the following images:

- [`cortx-all:744`](https://github.com/Seagate/cortx/pkgs/container/cortx-all/20895717?tag=2.0.0-744)
- [`cortx-rgw:744`](https://github.com/Seagate/cortx/pkgs/container/cortx-rgw/20895773?tag=2.0.0-744)

## How was this tested?
Deployed locally with a 2-node cluster. Performed simple I/O.

## Additional information
I am unable to deploy with the current image, 735. Upgrading to 744 fixes this. In the 744 changelog for cortx-hare there is listed this change:

> `e405edf|Thu Apr 21 10:11:24 2022 -0600|utils: motr process is reported as offline if its in starting|Mandar Sawant|`

That is the PR that fixes CORTX-30893, which is the same problem I was seeing.

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/version-bump/charts/cortx/README.md)