### PR TITLE
CORTX-31118: Remove custom Kafka settings

### DIFF
--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -499,21 +499,6 @@ function deployKafka()
     splitDockerImage "${image}"
     printf "\nRegistry: %s\nRepository: %s\nTag: %s\n" "${registry}" "${repository}" "${tag}"
 
-    local kafka_cfg_log_segment_delete_delay_ms=${KAFKA_CFG_LOG_SEGMENT_DELETE_DELAY_MS:-1000}
-    local kafka_cfg_log_flush_offset_checkpoint_interval_ms=${KAFKA_CFG_LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS:-1000}
-    local kafka_cfg_log_retention_check_interval_ms=${KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS:-1000}
-    local tmp_kafka_envvars_yaml="tmp-kafka.yaml"
-
-    cat > ${tmp_kafka_envvars_yaml} << EOF
-extraEnvVars:
-- name: KAFKA_CFG_LOG_SEGMENT_DELETE_DELAY_MS
-  value: "${kafka_cfg_log_segment_delete_delay_ms}"
-- name: KAFKA_CFG_LOG_FLUSH_OFFSET_CHECKPOINT_INTEL_MS
-  value: "${kafka_cfg_log_flush_offset_checkpoint_interval_ms}"
-- name: KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS
-  value: "${kafka_cfg_log_retention_check_interval_ms}"
-EOF
-
     helm install kafka bitnami/kafka \
         --version 16.2.7 \
         --set zookeeper.enabled=false \
@@ -542,12 +527,9 @@ EOF
         --set serviceAccount.automountServiceAccountToken=false \
         --set containerSecurityContext.enabled=true \
         --set containerSecurityContext.allowPrivilegeEscalation=false \
-        --values ${tmp_kafka_envvars_yaml}  \
         --namespace "${namespace}" \
         --wait \
         || exit $?
-
-    rm ${tmp_kafka_envvars_yaml}
 
     printf "\n\n"
 }


### PR DESCRIPTION
## Description

The deployment script was configuring Kafka with some customized configuration settings. These settings were only used by S3Server, and since we've switched to RGW they are no longer needed and have been removed. The default Kafka settings will apply.

## Breaking change

Generally no, but the deployment script allowed undocumented customization of these settings via environment variables. This customization will not be possible any longer.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-31118
- This change is related to an issue: CORTX-30140

## CORTX image version requirements

N/A

## How was this tested?

Deployed cluster, ran simple S3 I/O. Examined Kafka container definition to confirm settings are no longer applied.

## Additional information

`KAFKA_CFG_LOG_SEGMENT_DELETE_DELAY_MS` was set to `1000` (1 second). Now it will be set to the [default](https://kafka.apache.org/30/documentation.html#brokerconfigs_log.segment.delete.delay.ms) of `60000` (1 minute).

`KAFKA_CFG_LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS` was set to `1000` (1 second). Now it will be set to the [default](https://kafka.apache.org/30/documentation.html#brokerconfigs_log.flush.offset.checkpoint.interval.ms) of `60000` (1 minute). However, the name of the environment variable inside the container was being [set incorrectly](https://github.com/Seagate/cortx-k8s/blob/ff8d0fd0c8c4f14e1fde3f3560cbfcd1b7245b6a/k8_cortx_cloud/deploy-cortx-cloud.sh#L511) as `KAFKA_CFG_LOG_FLUSH_OFFSET_CHECKPOINT_INTEL_MS`. This typo means the config setting was never really applied in the first place.

`KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS` was set to `1000` (1 second). Now it will be set to the [default](https://kafka.apache.org/30/documentation.html#brokerconfigs_log.flush.offset.checkpoint.interval.ms) of `300000` (5 minutes).

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
