### PR TITLE
CORTX-30141: Remove CORTX secrets custom template file

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/other/secret-template.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/other/secret-template.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: <<.Values.secret.name>>
-type: Opaque
-stringData:
-<<.Values.secret.content>>


### PR DESCRIPTION
## Description
Remove the custom template file used for creating the CORTX secret, and generate the secret directly with `kubectl create`. This reduces the number of template files to manage, in support of merging the cortx-configmap Chart into the "unified" Chart.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change is related to an issue: CORTX-30141

## How was this tested?
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->

## Additional information
Deployed a cluster and performed S3 I/O for each of these:

- custom passwords in solution.yaml
- auto-generated passwords
- an external secret

Examined the created secret and compared it from previous, no unexpected changes seen.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
