### PR TITLE
CORTX-31239: Support variable timeout values in deploy-cortx-cloud.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,11 +333,12 @@ The Helm charts work with both "stub" and "CORTX ALL" containers, allowing users
 
 There is a "wait" after each of the cortx helm charts are deployed.  This wait is guarded by a timeout.  If needed, these timeout values can be overridden by environment variables.
 
-| Environment Variable | Default Value |
-| CORTX_DEPLOY_CONTROL_TIMEOUT | 300s |
-| CORTX_DEPLOY_DATA_TIMEOUT    | 300s |
-| CORTX_DEPLOY_SERVER_TIMEOUT  | 300s |
-| CORTX_DEPLOY_HA_TIMEOUT      | 300s |
+| Environment Variable           | Default Value |
+| ------------------------------ | ------------- |
+| `CORTX_DEPLOY_CONTROL_TIMEOUT` | `300s`        |
+| `CORTX_DEPLOY_DATA_TIMEOUT`    | `300s`        |
+| `CORTX_DEPLOY_SERVER_TIMEOUT`  | `300s`        |
+| `CORTX_DEPLOY_HA_TIMEOUT`      | `120s`        |
 
 This value is passed directly to `kubectl wait --timeout=${TIMEOUT}`
 

--- a/README.md
+++ b/README.md
@@ -340,8 +340,6 @@ There is a "wait" after each of the cortx helm charts are deployed.  This wait i
 | `CORTX_DEPLOY_SERVER_TIMEOUT`  | `300s`        |
 | `CORTX_DEPLOY_HA_TIMEOUT`      | `120s`        |
 
-This value is passed directly to `kubectl wait --timeout=${TIMEOUT}`
-
 ### Crash-looping InitContainers
 
 During CORTX deployments, there are edge cases where the InitContainers of a CORTX pod will fail into a CrashLoopBackoff state and it becomes difficult to capture the internal logs that provide necessary context for such error conditions. This command can be used to spin up a debugging container instance that has access to those same logs.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,18 @@ This section contains information about all the worker nodes used to deploy CORT
 
 The Helm charts work with both "stub" and "CORTX ALL" containers, allowing users to deploy both placeholder Kubernetes artifacts and functioning CORTX deployments using the same code base. If you are encountering issues deploying CORTX on Kubernetes, you can utilize the stub container method by setting the necessary component in `solution.yaml` to use an image of `ghcr.io/seagate/centos:7` instead of a CORTX-based image. This will deploy the same Kubernetes structure, expect the container entrypoints will be set to `sleep 3650d` to allow for deployment progression and user inspection of the overall deployment.
 
+### Overriding Helm Install  / Wait Timeouts
+
+There is a "wait" after each of the cortx helm charts are deployed.  This wait is guarded by a timeout.  If needed, these timeout values can be overridden by environment variables.
+
+| Environment Variable | Default Value |
+| CORTX_DEPLOY_CONTROL_TIMEOUT | 300s |
+| CORTX_DEPLOY_DATA_TIMEOUT    | 300s |
+| CORTX_DEPLOY_SERVER_TIMEOUT  | 300s |
+| CORTX_DEPLOY_HA_TIMEOUT      | 300s |
+
+This value is passed directly to `kubectl wait --timeout=${TIMEOUT}`
+
 ### Crash-looping InitContainers
 
 During CORTX deployments, there are edge cases where the InitContainers of a CORTX pod will fail into a CrashLoopBackoff state and it becomes difficult to capture the internal logs that provide necessary context for such error conditions. This command can be used to spin up a debugging container instance that has access to those same logs.

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -971,7 +971,7 @@ function deployCortxControl()
         || exit $?
 
     printf "\nWait for CORTX Control to be ready"
-    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_CONTROL_TIMEOUT:-300s} \
+    if ! waitForAllDeploymentsAvailable "${CORTX_DEPLOY_CONTROL_TIMEOUT:-300s}" \
                                         "CORTX Control" "${namespace}" \
                                         deployment/cortx-control; then
         echo "Failed.  Exiting script."
@@ -1029,7 +1029,7 @@ function deployCortxData()
     for i in "${!node_selector_list[@]}"; do
         deployments+=("deployment/cortx-data-${node_name_list[i]}")
     done
-    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_DATA_TIMEOUT:-300s} \
+    if ! waitForAllDeploymentsAvailable "${CORTX_DEPLOY_DATA_TIMEOUT:-300s}" \
                                         "CORTX Data" "${namespace}" \
                                         "${deployments[@]}"; then
         echo "Failed.  Exiting script."
@@ -1101,7 +1101,7 @@ function deployCortxServer()
     for i in "${!node_selector_list[@]}"; do
         deployments+=("deployment/cortx-server-${node_name_list[i]}")
     done
-    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_SERVER_TIMEOUT:-300s} \
+    if ! waitForAllDeploymentsAvailable "${CORTX_DEPLOY_SERVER_TIMEOUT:-300s}" \
                                         "CORTX Server" "${namespace}" \
                                         "${deployments[@]}"; then
         echo "Failed.  Exiting script."
@@ -1150,7 +1150,7 @@ function deployCortxHa()
         || exit $?
 
     printf "\nWait for CORTX HA to be ready"
-    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_HA_TIMEOUT:-120s} \
+    if ! waitForAllDeploymentsAvailable "${CORTX_DEPLOY_HA_TIMEOUT:-120s}" \
                                         "CORTX HA" "${namespace}" \
                                         deployment/cortx-ha; then
         echo "Failed.  Exiting script."

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -971,7 +971,9 @@ function deployCortxControl()
         || exit $?
 
     printf "\nWait for CORTX Control to be ready"
-    if ! waitForAllDeploymentsAvailable 300s "CORTX Control" "${namespace}" deployment/cortx-control; then
+    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_CONTROL_TIMEOUT:-300s} \
+                                        "CORTX Control" "${namespace}" \
+                                        deployment/cortx-control; then
         echo "Failed.  Exiting script."
         exit 1
     fi
@@ -1027,7 +1029,9 @@ function deployCortxData()
     for i in "${!node_selector_list[@]}"; do
         deployments+=("deployment/cortx-data-${node_name_list[i]}")
     done
-    if ! waitForAllDeploymentsAvailable 300s "CORTX Data" "${namespace}" "${deployments[@]}"; then
+    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_DATA_TIMEOUT:-300s} \
+                                        "CORTX Data" "${namespace}" \
+                                        "${deployments[@]}"; then
         echo "Failed.  Exiting script."
         exit 1
     fi
@@ -1097,7 +1101,9 @@ function deployCortxServer()
     for i in "${!node_selector_list[@]}"; do
         deployments+=("deployment/cortx-server-${node_name_list[i]}")
     done
-    if ! waitForAllDeploymentsAvailable 300s "CORTX Server" "${namespace}" "${deployments[@]}"; then
+    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_SERVER_TIMEOUT:-300s} \
+                                        "CORTX Server" "${namespace}" \
+                                        "${deployments[@]}"; then
         echo "Failed.  Exiting script."
         exit 1
     fi
@@ -1144,7 +1150,9 @@ function deployCortxHa()
         || exit $?
 
     printf "\nWait for CORTX HA to be ready"
-    if ! waitForAllDeploymentsAvailable 120s "CORTX HA" "${namespace}" deployment/cortx-ha; then
+    if ! waitForAllDeploymentsAvailable ${CORTX_DEPLOY_HA_TIMEOUT:-120s} \
+                                        "CORTX HA" "${namespace}" \
+                                        deployment/cortx-ha; then
         echo "Failed.  Exiting script."
         exit 1
     fi


### PR DESCRIPTION
<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
There is a "wait" after each of the cortx helm charts are deployed.  This wait is guarded by a timeout. Prior to this change the timeout values were hard-coded.

With this change in environment variable can override the timeout value.  The supported environment variables are:

* CORTX_DEPLOY_CONTROL_TIMEOUT (default 300s)
* CORTX_DEPLOY_DATA_TIMEOUT (default 300s)
* CORTX_DEPLOY_SERVER_TIMEOUT (default 300s)
* CORTX_DEPLOY_HA_TIMEOUT (default 120s)

This value is passed directly to `kubectl wait --timeout=${TIMEOUT}`

This is being added so that CORTX developers can work around the previously hard-coded timeouts as needed.


## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [x] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-31239

## How was this tested?
Tested locally:
* Set short timeouts for `CORTX_DEPLOY_CONTROL_TIMEOUT` and `CORTX_DEPLOY_HA_TIMEOUT` and verified that they took effect
* Ran with standard timeouts to verify no change

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/walterlopatka/cortx-k8s/blob/CORTX-31239_adjustable_deploy_timeouts/README.md)