### PR TITLE
CORTX-30140: Zookeeper managed as cortx Helm Chart dependency

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -70,7 +70,10 @@ helm uninstall cortx
 | kafka.serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | kafka.serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for Kafka pods |
 | kafka.transactionStateLogMinIsr | int | `2` | Overridden min.insync.replicas config for the transaction topic |
-| kafka.zookeeper.enabled | bool | `false` | Enable installation of the Zookeeper chart |
+| kafka.zookeeper.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Zookeeper containers |
+| kafka.zookeeper.enabled | bool | `true` | Enable installation of the Zookeeper chart |
+| kafka.zookeeper.serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
+| kafka.zookeeper.serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for Zookeeper pods |
 | serviceAccount.annotations | object | `{}` | Custom annotations for the CORTX ServiceAccount |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for CORTX pods |

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -53,4 +53,12 @@ kafka:
   # ref: https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/values.yaml
   zookeeper:
     # -- Enable installation of the Zookeeper chart
-    enabled: false
+    enabled: true
+    serviceAccount:
+      # -- Enable the creation of a ServiceAccount for Zookeeper pods
+      create: true
+      # -- Allow auto mounting of the service account token
+      automountServiceAccountToken: false
+    containerSecurityContext:
+      # -- Allow extra privileges in Zookeeper containers
+      allowPrivilegeEscalation: false

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -387,6 +387,13 @@ function deployCortx()
     local kafka_registry="${registry}"
     local kafka_repository="${repository}"
 
+    local zookeeper_image
+    zookeeper_image=$(parseSolution 'solution.images.zookeeper' | cut -f2 -d'>')
+    splitDockerImage "${zookeeper_image}"
+    local zookeeper_tag="${tag}"
+    local zookeeper_registry="${registry}"
+    local zookeeper_repository="${repository}"
+
     helm install cortx ../charts/cortx \
         --set global.storageClass=${storage_class} \
         --set consul.server.image="${consul_image}" \
@@ -406,7 +413,6 @@ function deployCortx()
         --set kafka.image.registry="${kafka_registry}" \
         --set kafka.image.repository="${kafka_repository}" \
         --set kafka.replicaCount="${num_kafka_replicas}" \
-        --set kafka.externalZookeeper.servers="zookeeper" \
         --set kafka.defaultReplicationFactor="${num_kafka_replicas}" \
         --set kafka.offsetsTopicReplicationFactor="${num_kafka_replicas}" \
         --set kafka.transactionStateLogReplicationFactor="${num_kafka_replicas}" \
@@ -415,6 +421,16 @@ function deployCortx()
         --set kafka.resources.limits.memory="$(extractBlock 'solution.common.resource_allocation.kafka.resources.limits.memory')" \
         --set kafka.resources.limits.cpu="$(extractBlock 'solution.common.resource_allocation.kafka.resources.limits.cpu')" \
         --set kafka.persistence.size="$(extractBlock 'solution.common.resource_allocation.kafka.storage_request_size')" \
+        --set kafka.zookeeper.image.tag="${zookeeper_tag}" \
+        --set kafka.zookeeper.image.registry="${zookeeper_registry}" \
+        --set kafka.zookeeper.image.repository="${zookeeper_repository}" \
+        --set kafka.zookeeper.replicaCount="${num_kafka_replicas}" \
+        --set kafka.zookeeper.resources.requests.memory="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.requests.memory')" \
+        --set kafka.zookeeper.resources.requests.cpu="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.requests.cpu')" \
+        --set kafka.zookeeper.resources.limits.memory="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.limits.memory')" \
+        --set kafka.zookeeper.resources.limits.cpu="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.limits.cpu')" \
+        --set kafka.zookeeper.persistence.size="$(extractBlock 'solution.common.resource_allocation.zookeeper.storage_request_size')" \
+        --set kafka.zookeeper.persistence.dataLogDir.size="$(extractBlock 'solution.common.resource_allocation.zookeeper.data_log_dir_request_size')" \
         --namespace "${namespace}" \
         --wait \
         || exit $?
@@ -432,7 +448,6 @@ function deployCortx()
     kubectl rollout restart daemonset/cortx-consul-client --namespace "${namespace}"
 
     ##TODO This needs to be maintained during upgrades etc...
-
 }
 
 function splitDockerImage()
@@ -448,62 +463,6 @@ function splitDockerImage()
     tag="${tag_arr[1]}"
 }
 
-function deployZookeeper()
-{
-    local image
-
-    printf "######################################################\n"
-    printf "# Deploy Zookeeper                                    \n"
-    printf "######################################################\n"
-    image=$(parseSolution 'solution.images.zookeeper')
-    image=$(echo "${image}" | cut -f2 -d'>')
-    splitDockerImage "${image}"
-    printf "\nRegistry: %s\nRepository: %s\nTag: %s\n" "${registry}" "${repository}" "${tag}"
-
-    helm install zookeeper bitnami/zookeeper \
-        --version 9.1.0 \
-        --set image.tag="${tag}" \
-        --set image.registry="${registry}" \
-        --set image.repository="${repository}" \
-        --set replicaCount="${num_kafka_replicas}" \
-        --set global.storageClass=${storage_class} \
-        --set resources.requests.memory="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.requests.memory')" \
-        --set resources.requests.cpu="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.requests.cpu')" \
-        --set resources.limits.memory="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.limits.memory')" \
-        --set resources.limits.cpu="$(extractBlock 'solution.common.resource_allocation.zookeeper.resources.limits.cpu')" \
-        --set persistence.size="$(extractBlock 'solution.common.resource_allocation.zookeeper.storage_request_size')" \
-        --set persistence.dataLogDir.size="$(extractBlock 'solution.common.resource_allocation.zookeeper.data_log_dir_request_size')" \
-        --set serviceAccount.create=true \
-        --set serviceAccount.name="cortx-zookeeper" \
-        --set serviceAccount.automountServiceAccountToken=false \
-        --set containerSecurityContext.allowPrivilegeEscalation=false \
-        --namespace "${namespace}" \
-        --wait \
-        || exit $?
-
-    printf "\nWait for Zookeeper to be ready before starting kafka"
-    while true; do
-        count=0
-        while IFS= read -r line; do
-            IFS=" " read -r -a pod_status <<< "${line}"
-            IFS="/" read -r -a ready_status <<< "${pod_status[2]}"
-            if [[ "${pod_status[3]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
-                count=$((count+1))
-                break
-            fi
-        done <<< "$(kubectl get pods -A | grep 'zookeeper')"
-
-        if [[ ${count} -eq 0 ]]; then
-            break
-        else
-            printf "."
-        fi
-        sleep 1s
-    done
-    printf "\n\n"
-    sleep 2s
-}
-
 function waitForThirdParty()
 {
     printf "\nWait for CORTX 3rd party to be ready"
@@ -516,7 +475,7 @@ function waitForThirdParty()
                 count=$((count+1))
                 break
             fi
-        done <<< "$(kubectl get pods --namespace="${namespace}" --no-headers | grep '^cortx-consul\|^cortx-kafka\|zookeeper')"
+        done <<< "$(kubectl get pods --namespace="${namespace}" --no-headers | grep '^cortx-consul\|^cortx-kafka\|^cortx-zookeeper')"
 
         if [[ ${count} -eq 0 ]]; then
             break
@@ -1239,7 +1198,6 @@ if [[ "${num_worker_nodes}" -gt "${max_kafka_inst}" ]]; then
 fi
 
 deployRancherProvisioner
-deployZookeeper
 deployCortx
 waitForThirdParty
 

--- a/k8_cortx_cloud/destroy-cortx-cloud.sh
+++ b/k8_cortx_cloud/destroy-cortx-cloud.sh
@@ -246,14 +246,6 @@ function deleteCortxConfigmap()
 #############################################################
 # Destroy CORTX 3rd party functions
 #############################################################
-function deleteZookeeper()
-{
-    printf "########################################################\n"
-    printf "# Delete Zookeeper                                     #\n"
-    printf "########################################################\n"
-    uninstallHelmChart zookeeper "${namespace}"
-}
-
 function deleteOpenLdap()
 {
     ## Backwards compatibility check
@@ -295,6 +287,9 @@ function deleteDeprecated()
     deleteOpenLdap
     uninstallHelmChart consul "${namespace}"
     uninstallHelmChart kafka "${namespace}"
+    uninstallHelmChart zookeeper "${namespace}"
+
+    waitFor3rdPartyToTerminate
 }
 
 function waitFor3rdPartyToTerminate()
@@ -306,7 +301,7 @@ function waitFor3rdPartyToTerminate()
         while IFS= read -r line; do
             count=$(( count + 1 ))
         done < <(kubectl get pods --namespace "${namespace}" --no-headers | \
-                  grep -e zookeeper -e openldap -e '^consul' -e '^kafka')
+                  grep -e '^zookeeper' -e openldap -e '^consul' -e '^kafka')
 
         (( count == 0 )) && break || printf "."
         sleep 1s
@@ -395,9 +390,7 @@ deleteCortxConfigmap
 #############################################################
 # Delete CORTX 3rd party resources
 #############################################################
-deleteZookeeper
 deleteDeprecated
-waitFor3rdPartyToTerminate
 
 # Delete remaining CORTX Cloud resources
 uninstallHelmChart cortx "${namespace}"


### PR DESCRIPTION
## Description
Add Zookeeper as a dependency to the new CORTX chart. In this case, Zookeeper is already a dependency of Kafka, so we let the Kafka chart manage it. Follow up to PRs #230 and #233.

## Breaking change

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-30140

## CORTX image version requirements

## How was this tested?
Deployed a new release using this PR. Performed basic I/O.

Tested backwards compatibility by deploying a release prior to this PR. Then ran all of the updated utility scripts against that deployment (although, see Additional information).

## Additional information

The status-cortx-cloud.sh script will report a failure for Zookeeper Cluster IP services when running against an earlier deployment, since the names of the services have changed. I don't consider this a breaking change, since the status script should reflect what is expected based on how it is supposed to be deployed with the current version.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-30140_subcharts-zookeeper/charts/cortx/README.md)