### PR TITLE
CORTX-31260: increase default resource limits

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/templates/_config.tpl
@@ -51,10 +51,10 @@ cortx:
       - name: rgw
         memory:
           min: 128Mi
-          max: 1Gi
+          max: 2Gi
         cpu:
           min: 250m
-          max: 1000m
+          max: 2000m
     {{- if .Values.cortxRgw.extraConfiguration }}
     {{- tpl .Values.cortxRgw.extraConfiguration . | nindent 4 }}
     {{- end }}
@@ -77,10 +77,10 @@ cortx:
       - name: hax
         memory:
           min: 128Mi
-          max: 1Gi
+          max: 2Gi
         cpu:
           min: 250m
-          max: 500m
+          max: 1000m
   motr:
     interface_family: inet
     transport_type: libfab
@@ -105,17 +105,17 @@ cortx:
       - name: ios
         memory:
           min: 1Gi
-          max: 2Gi
+          max: 3Gi
         cpu:
           min: 250m
-          max: 1000m
+          max: 2000m
       - name: confd
         memory:
           min: 128Mi
-          max: 512Mi
+          max: 1Gi
         cpu:
           min: 250m
-          max: 500m
+          max: 1000m
     {{- if .Values.cortxMotr.extraConfiguration }}
     {{- tpl .Values.cortxMotr.extraConfiguration . | nindent 4 }}
     {{- end }}
@@ -137,10 +137,10 @@ cortx:
       - name: agent
         memory:
           min: 128Mi
-          max: 256Mi
+          max: 500Mi
         cpu:
           min: 250m
-          max: 500m
+          max: 1000m
   {{- end }}
   {{- if .Values.cortxHa.enabled }}
   ha:

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -68,19 +68,19 @@ solution:
           storage: 10Gi
           resources:
             requests:
-              memory: 100Mi
-              cpu: 100m
+              memory: 200Mi
+              cpu: 200m
             limits:
-              memory: 300Mi
-              cpu: 100m
+              memory: 500Mi
+              cpu: 500m
         client:
           resources:
             requests:
-              memory: 100Mi
-              cpu: 100m
+              memory: 200Mi
+              cpu: 200m
             limits:
-              memory: 300Mi
-              cpu: 100m
+              memory: 500Mi
+              cpu: 500m
       zookeeper:
         storage_request_size: 8Gi
         data_log_dir_request_size: 8Gi
@@ -89,8 +89,8 @@ solution:
             memory: 256Mi
             cpu: 250m
           limits:
-            memory: 512Mi
-            cpu: 500m
+            memory: 1Gi
+            cpu: 1000m
       kafka:
         storage_request_size: 8Gi
         resources:
@@ -99,7 +99,7 @@ solution:
             cpu: 250m
           limits:
             memory: 2Gi
-            cpu: 1
+            cpu: 1000m
   storage:
     cvg1:
       name: cvg-01

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -68,19 +68,19 @@ solution:
           storage: 10Gi
           resources:
             requests:
-              memory: 100Mi
-              cpu: 100m
+              memory: 200Mi
+              cpu: 200m
             limits:
-              memory: 300Mi
-              cpu: 100m
+              memory: 500Mi
+              cpu: 500m
         client:
           resources:
             requests:
-              memory: 100Mi
-              cpu: 100m
+              memory: 200Mi
+              cpu: 200m
             limits:
-              memory: 300Mi
-              cpu: 100m
+              memory: 500Mi
+              cpu: 500m
       zookeeper:
         storage_request_size: 9Gi
         data_log_dir_request_size: 9Gi
@@ -89,17 +89,17 @@ solution:
             memory: 256Mi
             cpu: 250m
           limits:
-            memory: 512Mi
-            cpu: 500m
+            memory: 1Gi
+            cpu: 1000m
       kafka:
         storage_request_size: 9Gi
         resources:
           requests:
             memory: 1Gi
-            cpu: 250m
+            cpu: 500m
           limits:
             memory: 2Gi
-            cpu: 1
+            cpu: 1000m
   storage:
     cvg1:
       name: cvg-01


### PR DESCRIPTION
The current default resource limits preventing io in long run.
It is also causing connection reset by peer issue for heavy io load situations.
These limit were defined for normal IO load and to achieve continuous io load
for multiple parallel clients these limits need to be increased.

Signed-off-by: saurabh jain <saurabh.jain2@seagate.com>

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->

## Breaking change
<!--
If this change introduces any breaking changes, describe what it breaks and what action is required
to address it. We prefer deprecating things first before breaking them entirely. If you are unable
to support deprecation in this change, or are actually removing the deprecated the item, please
state so.

You can delete this section if there are no breaking changes.
-->

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [x] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: #
- This change is related to an issue: #

## CORTX image version requirements
<!--
If this change requires specific versions of CORTX that are newer than the currently referenced
images, please list those images and link them to the public CORTX packages page.

- cortx-all images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-all
- cortx-rgw images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-rgw

The referenced images are always defined in the images section of the solution.example.yaml file. If
updated images are required, the example solution YAML file should be updated in this change.

If the currently referenced CORTX container images support this change, you can delete this section
or indicate that.

*NOTE* that we cannot merge any PRs that depend on non-public images!
-->
This change requires the following images:

- `cortx-all:<version>`
- `cortx-rgw:<version>`

## How was this tested?
This changes is tested on a 3 node setup by increasing the resource limits of all the components before the deployment.
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->

## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
