### PR TITLE
CORTX-29952: Apply Memory and CPU limits to motr containers

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
@@ -184,6 +184,13 @@ spec:
             protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
+          resources:
+            limits:
+              cpu: {{ .Values.cortxdata.resources.hax.limits.cpu }}
+              memory: {{ .Values.cortxdata.resources.hax.limits.memory }}
+            requests:
+              cpu: {{ .Values.cortxdata.resources.hax.requests.cpu }}
+              memory: {{ .Values.cortxdata.resources.hax.requests.memory }}
         - name: cortx-motr-confd
           image: {{ .Values.cortxdata.image }}
           imagePullPolicy: IfNotPresent
@@ -236,6 +243,13 @@ spec:
           - containerPort: {{ printf "%d" (add .Values.cortxdata.motr.numiosinst .Values.cortxdata.motr.startportnum) }}
           securityContext:
             allowPrivilegeEscalation: false
+          resources:
+            limits:
+              cpu: {{ .Values.cortxdata.resources.confd.limits.cpu }}
+              memory: {{ .Values.cortxdata.resources.confd.limits.memory }}
+            requests:
+              cpu: {{ .Values.cortxdata.resources.confd.requests.cpu }}
+              memory: {{ .Values.cortxdata.resources.confd.requests.memory }}
         {{- range $i := until (.Values.cortxdata.motr.numiosinst|int) }}
         - name: {{ printf "cortx-motr-io-%03d" (add 1 $i) }}
           image: {{ $.Values.cortxdata.image }}
@@ -291,6 +305,13 @@ spec:
           - containerPort: {{ printf "%d" (add $i $.Values.cortxdata.motr.startportnum) }}
           securityContext:
             allowPrivilegeEscalation: false
+          resources:
+            limits:
+              cpu: {{ $.Values.cortxdata.resources.ios.limits.cpu }}
+              memory: {{ $.Values.cortxdata.resources.ios.limits.memory }}
+            requests:
+              cpu: {{ $.Values.cortxdata.resources.ios.requests.cpu }}
+              memory: {{ $.Values.cortxdata.resources.ios.requests.memory }}
         {{- end }}
       nodeSelector:
         kubernetes.io/hostname: {{ .Values.cortxdata.nodeselector }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
@@ -34,3 +34,25 @@ cortxdata:
     name: cortx-fs-local-pvc
     mountpath: /etc/cortx # This is the mount path in the container
     requeststoragesize: 1Gi
+  resources:
+    hax:
+      limits:
+        cpu:
+        memory:
+      requests:
+        cpu:
+        memory:
+    confd:
+      limits:
+        cpu:
+        memory:
+      requests:
+        cpu:
+        memory:
+    ios:
+      limits:
+        cpu:
+        memory:
+      requests:
+        cpu:
+        memory:


### PR DESCRIPTION
	- For motr ios containers cpu and memory limits are
	  calculated dynamic with available resources.
	- For motr confd, hax containers cpu and memory limits
	  are applied statically as it is expected to work
	  in any setup with those limits.

Signed-off-by: Vinoth.V <vinoth.v@seagate.com>

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->

## Breaking change
<!--
If this change introduces any breaking changes, describe what it breaks and what action is required
to address it. We prefer deprecating things first before breaking them entirely. If you are unable
to support deprecation in this change, or are actually removing the deprecated the item, please
state so.

You can delete this section if there are no breaking changes.
-->

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: #
- This change is related to an issue: #

## CORTX image version requirements
<!--
If this change requires specific versions of CORTX that are newer than the currently referenced
images, please list those images and link them to the public CORTX packages page.

- cortx-all images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-all
- cortx-rgw images are published at https://github.com/Seagate/cortx/pkgs/container/cortx-rgw

The referenced images are always defined in the images section of the solution.example.yaml file. If
updated images are required, the example solution YAML file should be updated in this change.

If the currently referenced CORTX container images support this change, you can delete this section
or indicate that.

*NOTE* that we cannot merge any PRs that depend on non-public images!
-->
This change requires the following images:

- `cortx-all:<version>`
- `cortx-rgw:<version>`

## How was this tested?
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->

## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [ ] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [ ] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
