### PR TITLE
CORTX-30142: Remove machine-id config maps

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/values.yaml
@@ -19,8 +19,6 @@ cortxclient:
     name: cortx-ssl-cert
   machineid:
     mountpath: /etc/cortx/solution/node
-    volmountname: machine-id-config
-    name:  cortx-client-machine-id-cfgmap
     value: ""
   localpathpvc:
     name: cortx-client-fs-local-pvc

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
@@ -29,9 +29,6 @@ spec:
         - name: {{ .Values.cortxcontrol.sslcfgmap.volmountname }}
           configMap:
             name: {{ .Values.cortxcontrol.sslcfgmap.name }}
-        - name: {{ .Values.cortxcontrol.machineid.volmountname }}
-          configMap:
-            name: {{ .Values.cortxcontrol.machineid.name }}
         {{- if .Values.cortxcontrol.machineid.value }}
         - name: machine-id
           downwardAPI:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/values.yaml
@@ -22,8 +22,6 @@ cortxcontrol:
     name: cortx-ssl-cert
   machineid:
     mountpath: /etc/cortx/solution/node
-    volmountname: machine-id-config
-    name:  cortx-control-machine-id-cfgmap
     value: ""
   localpathpvc:
     name: cortx-fs-local-pvc

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
@@ -33,9 +33,6 @@ spec:
         - name: {{ .Values.cortxdata.sslcfgmap.volmountname }}
           configMap:
             name: {{ .Values.cortxdata.sslcfgmap.name }}
-        - name: {{ .Values.cortxdata.machineid.volmountname }}
-          configMap:
-            name: {{ .Values.cortxdata.machineid.name }}
         # Loop through the node list info file which contains the following example:
         # 0 node-1
         # 1 node-2

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/values.yaml
@@ -27,8 +27,6 @@ cortxdata:
     name: cortx-ssl-cert
   machineid:
     mountpath: /etc/cortx/solution/node
-    volmountname: machine-id-config
-    name:  cortx-data-machine-id-cfgmap
     value: ""
   localpathpvc:
     name: cortx-fs-local-pvc

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
@@ -30,9 +30,6 @@ spec:
         - name: {{ .Values.cortxha.sslcfgmap.volmountname }}
           configMap:
             name: {{ .Values.cortxha.sslcfgmap.name }}
-        - name: {{ .Values.cortxha.machineid.volmountname }}
-          configMap:
-            name: {{ .Values.cortxha.machineid.name }}
         {{- if .Values.cortxha.machineid.value }}
         - name: machine-id
           downwardAPI:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/values.yaml
@@ -20,8 +20,6 @@ cortxha:
     name: cortx-ssl-cert
   machineid:
     mountpath: /etc/cortx/solution/node
-    volmountname: machine-id-config
-    name:  cortx-ha-machine-id-cfgmap
     value: ""
   localpathpvc:
     name: cortx-fs-local-pvc

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
@@ -33,9 +33,6 @@ spec:
         - name: {{ .Values.cortxserver.sslcfgmap.volmountname }}
           configMap:
             name: {{ .Values.cortxserver.sslcfgmap.name }}
-        - name: {{ .Values.cortxserver.machineid.volmountname }}
-          configMap:
-            name: {{ .Values.cortxserver.machineid.name }}
         {{- if .Values.cortxserver.machineid.value }}
         - name: machine-id
           downwardAPI:

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/values.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/values.yaml
@@ -27,8 +27,6 @@ cortxserver:
     name: cortx-ssl-cert
   machineid:
     mountpath: /etc/cortx/solution/node
-    volmountname: machine-id-config
-    name:  cortx-server-machine-id-cfgmap
     value: ""
   localpathpvc:
     name: cortx-fs-server-local-pvc

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -649,32 +649,6 @@ function generateMachineIds()
     done
 }
 
-function deployCortxConfigMap()
-{
-    # Create node machine ID config maps
-    for node in "${node_name_list[@]}"; do
-        local auto_gen_path="${cfgmap_path}/auto-gen-${node}-${namespace}"
-        for type in data server client; do
-            local id_path="${auto_gen_path}/${type}/id"
-            if [[ -f ${id_path} ]]; then
-                kubectl create configmap "cortx-${type}-machine-id-cfgmap-${node}-${namespace}" \
-                    --namespace="${namespace}" \
-                    --from-file="${id_path}"
-                fi
-        done
-    done
-
-    # Create control and HA machine ID config maps
-    for type in control ha; do
-        local id_path="${cfgmap_path}/auto-gen-{type}-${namespace}/id"
-        if [[ -f ${id_path} ]]; then
-            kubectl create configmap "cortx-${type}-machine-id-cfgmap-${namespace}" \
-                --namespace="${namespace}" \
-                --from-file="${id_path}"
-        fi
-    done
-}
-
 function pwgen()
 {
     # This function generates a random password that is
@@ -1109,15 +1083,14 @@ num_motr_client=$(extractBlock 'solution.common.motr.num_client_inst')
 deployKubernetesPrereqs
 deployRancherProvisioner
 deployCortxLocalBlockStorage
+deleteStaleAutoGenFolders
+generateMachineIds
 
 ##########################################################
 # Deploy CORTX cloud
 ##########################################################
-deleteStaleAutoGenFolders
-generateMachineIds
 deployCortx
 waitForThirdParty
-deployCortxConfigMap
 deployCortxSecrets
 deployCortxControl
 deployCortxData

--- a/k8_cortx_cloud/destroy-cortx-cloud.sh
+++ b/k8_cortx_cloud/destroy-cortx-cloud.sh
@@ -204,9 +204,10 @@ function deleteCortxPVs()
 
 function deleteCortxConfigmap()
 {
-    printf "########################################################\n"
-    printf "# Delete CORTX Configmap                               #\n"
-    printf "########################################################\n"
+    #
+    # These configmaps are deprecated, and removed for backwards compatibility.
+    #
+
     cfgmap_path="./cortx-cloud-helm-pkg/cortx-configmap"
 
     for node in "${node_name_list[@]}"; do
@@ -379,7 +380,7 @@ deleteCortxControl
 waitForCortxPodsToTerminate
 deleteSecrets
 deleteCortxLocalBlockStorage
-deleteCortxConfigmap
+deleteCortxConfigmap  # deprecated
 
 #############################################################
 # Delete CORTX 3rd party resources


### PR DESCRIPTION
## Description
Machine-ids are passed to containers via other methods using Helm. These individual ConfigMaps that contain the machine IDs have not been used for awhile now, so they can be removed.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues
- This change is related to an issue: CORTX-30142

## How was this tested?
Local deployment, un-deployment, performed S3 I/O, ran helper scripts.

## Additional information

This is some prep-work for the control chart merge, and other future charts merges.

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
