### PR TITLE
CORTX-31408: Add NODE_NAME and POD_NAME to runtime env vars in each Pod

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-client/templates/cortx-client-pod.yaml
@@ -82,6 +82,14 @@ spec:
         env:
           - name: MACHINE_ID
             value: {{ printf "%s" .Values.cortxclient.machineid.value | quote }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
       containers:
         {{- range $i := until (.Values.cortxclient.motr.numclientinst|int) }}
         - name: {{ printf "cortx-motr-client-%03d" (add 1 $i) }}
@@ -109,10 +117,16 @@ spec:
             - name: local-path-pv
               mountPath: {{ $.Values.cortxclient.localpathpvc.mountpath }}
           env:
-            - name: UDS_CLOUD_CONTAINER_NAME
-              value: {{ $.Values.cortxclient.name }}
             - name: CLIENT_INDEX
               value: {{ printf "%d" (add 1 $i) | quote }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             allowPrivilegeEscalation: false
         {{- end }}
@@ -141,7 +155,13 @@ spec:
             - name: local-path-pv
               mountPath: {{ .Values.cortxclient.localpathpvc.mountpath }}
           env:
-            - name: UDS_CLOUD_CONTAINER_NAME
-              value: {{ .Values.cortxclient.name }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-control/templates/cortx-control-pod.yaml
@@ -83,6 +83,14 @@ spec:
         env:
           - name: MACHINE_ID
             value: {{ printf "%s" .Values.cortxcontrol.machineid.value | quote }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         ports:
         - containerPort: 5050
       containers:
@@ -109,6 +117,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxcontrol.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           ports:
           - containerPort: 8081
           {{- if .Values.cortxcontrol.agent.resources }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data/templates/cortx-data-pod.yaml
@@ -135,6 +135,14 @@ spec:
         env:
           - name: MACHINE_ID
             value: {{ printf "%s" .Values.cortxdata.machineid.value | quote }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         ports:
         - containerPort: 5050
       - name: node-config
@@ -172,6 +180,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxdata.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           ports:
           - name: hax
             containerPort: {{ .Values.cortxdata.hax.port }}
@@ -226,6 +243,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxdata.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           ports:
           - containerPort: {{ printf "%d" (add .Values.cortxdata.motr.numiosinst .Values.cortxdata.motr.startportnum) }}
           {{- if .Values.cortxdata.confd.resources }}
@@ -240,6 +266,14 @@ spec:
           env:
             - name: IO_INDEX
               value: {{ printf "%d" (add 1 $i) | quote }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-ha/templates/cortx-ha-pod.yaml
@@ -84,6 +84,14 @@ spec:
         env:
           - name: MACHINE_ID
             value: {{ printf "%s" .Values.cortxha.machineid.value | quote }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         ports:
         - containerPort: 5050
       containers:
@@ -110,6 +118,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           {{- if .Values.cortxha.fault_tolerance.resources }}
           resources: {{- toYaml .Values.cortxha.fault_tolerance.resources | nindent 12 }}
           {{- end }}
@@ -138,6 +155,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           {{- if .Values.cortxha.health_monitor.resources }}
           resources: {{- toYaml .Values.cortxha.health_monitor.resources | nindent 12 }}
           {{- end }}
@@ -166,6 +192,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           {{- if .Values.cortxha.k8s_monitor.resources }}
           resources: {{- toYaml .Values.cortxha.k8s_monitor.resources | nindent 12 }}
           {{- end }}

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-server/templates/cortx-server-pod.yaml
@@ -87,6 +87,14 @@ spec:
         env:
           - name: MACHINE_ID
             value: {{ printf "%s" .Values.cortxserver.machineid.value | quote }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         ports:
         - containerPort: 5050
       containers:
@@ -113,6 +121,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxserver.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           ports:
           - name: rgw-http
             containerPort: 22751
@@ -148,6 +165,15 @@ spec:
             {{- end }}
             - name: local-path-pv
               mountPath: {{ .Values.cortxserver.localpathpvc.mountpath }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           ports:
           - name: hax
             containerPort: {{ .Values.cortxserver.hax.port | int }}


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->

This change will inject the Pod's name and the name of the Kubernetes worker node that it is running on as environment variables into all containers in the Pod. This is required for future changes to Provisioner work inside the initContainers but can also be leveraged by additional components running in long-running Pods as well. 

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [x] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: # CORTX-31408
- This change is related to an issue: #


## How was this tested?
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->
Tested and verified locally through deployments on two distinct Kubernetes clusters.

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
