### PR TITLE
simplify deploy/un-deploy cleanup

### DIFF
--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -1047,21 +1047,12 @@ function deployCortxClient()
 
 function cleanup()
 {
-    #################################################################
-    # Delete files that contain disk partitions on the worker nodes
-    # and the node info
-    #################################################################
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-data" -name "secret-*" -delete
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-server" -name "secret-*" -delete
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-ha" -name "secret-*" -delete
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-client" -name "secret-*" -delete
+    # Delete files that contain disk partitions on the worker nodes and the node info
+    # and left-over secret data
+    find "$(pwd)/cortx-cloud-helm-pkg" -type f \( -name 'mnt-blk-*' -o -name 'node-list-*' -o -name secret-info.txt \) -delete
 
-    rm -rf "${cfgmap_path}/auto-gen-secret-${namespace}"
-
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-data-blk-data" -name "mnt-blk-*" -delete
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-data-blk-data" -name "node-list-*" -delete
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-data" -name "mnt-blk-*" -delete
-    find "$(pwd)/cortx-cloud-helm-pkg/cortx-data" -name "node-list-*" -delete
+    # Delete left-over machine IDs and any other auto-gen data
+    rm -rf "${cfgmap_path}"
 }
 
 # Extract storage provisioner path from the "solution.yaml" file

--- a/k8_cortx_cloud/destroy-cortx-cloud.sh
+++ b/k8_cortx_cloud/destroy-cortx-cloud.sh
@@ -270,11 +270,7 @@ function deleteSecrets()
         secret_name=$(echo "${secret_name}" | cut -f2 -d'>')
         kubectl delete secret "${secret_name}" --namespace="${namespace}" --ignore-not-found=true
 
-        find "$(pwd)/cortx-cloud-helm-pkg/cortx-control" -name "secret-*" -delete
-        find "$(pwd)/cortx-cloud-helm-pkg/cortx-data" -name "secret-*" -delete
-        find "$(pwd)/cortx-cloud-helm-pkg/cortx-server" -name "secret-*" -delete
-        find "$(pwd)/cortx-cloud-helm-pkg/cortx-ha" -name "secret-*" -delete
-        find "$(pwd)/cortx-cloud-helm-pkg/cortx-client" -name "secret-*" -delete
+        find "$(pwd)/cortx-cloud-helm-pkg" -name "secret-info.txt" -delete
     fi
 }
 


### PR DESCRIPTION
## Description
This fixes a harmless warning message when running the destroy script, about not finding the (since removed) `cortx-cloud-helm-pkg/cortx-control` chart directory.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change is related to an issue: #252 

## How was this tested?
Deploy and destroy cluster.

## Additional information
Instead of hard-coding a list of directories to delete files from, just search the parent directory. This handles future chart merges. I applied the same logic to the deploy script's cleanup function.

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
