### PR TITLE
temporarily disable Consul serviceaccount patching

### DIFF
--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -578,19 +578,23 @@ function deployCortx()
         --wait \
         || exit $?
 
-    # Patch generated ServiceAccounts to prevent automounting ServiceAccount tokens
-    kubectl patch serviceaccount/cortx-consul-client \
-        -p '{"automountServiceAccountToken": false}' \
-        --namespace "${namespace}"
-    kubectl patch serviceaccount/cortx-consul-server \
-        -p '{"automountServiceAccountToken": false}' \
-        --namespace "${namespace}"
+    # Restarting Consul at this time causes havoc. Disabling this for now until
+    # Consul supports configuring automountServiceAccountToken (a PR is planned
+    # to add support).
 
-    # Rollout a new deployment version of Consul pods to use updated Service Account settings
-    kubectl rollout restart statefulset/cortx-consul-server --namespace "${namespace}"
-    kubectl rollout restart daemonset/cortx-consul-client --namespace "${namespace}"
+    # # Patch generated ServiceAccounts to prevent automounting ServiceAccount tokens
+    # kubectl patch serviceaccount/cortx-consul-client \
+    #     -p '{"automountServiceAccountToken": false}' \
+    #     --namespace "${namespace}"
+    # kubectl patch serviceaccount/cortx-consul-server \
+    #     -p '{"automountServiceAccountToken": false}' \
+    #     --namespace "${namespace}"
 
-    ##TODO This needs to be maintained during upgrades etc...
+    # # Rollout a new deployment version of Consul pods to use updated Service Account settings
+    # kubectl rollout restart statefulset/cortx-consul-server --namespace "${namespace}"
+    # kubectl rollout restart daemonset/cortx-consul-client --namespace "${namespace}"
+
+    # ##TODO This needs to be maintained during upgrades etc...
 }
 
 function waitForThirdParty()


### PR DESCRIPTION
## Description
We patch the Consul service accounts to disable auto-mounting of the Kubernetes service tokens. However, this requires a restart of the controllers, which in turns causes havoc as the consul Pods crash and restart (they eventually settle down).

The proper solution is to submit a PR upstream to allow disabling auto-mounting via Helm value so we can turn this back on. Or, as a last resort we could pull in a local version of the Chart, or use a fork.

## How was this tested?
Deployed and noticed there were no consul Pod restarts.

## Additional information
We could make this a script option, but I didn't quite see a need to enable it at this time. If that's necessary, let me know and I can add this functionality.

## Checklist
- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
