### PR TITLE
CORTX-30684: Upgrade Rancher Local Path Provisioner to v0.0.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Kernel parameter `vm.max_map_count` must be set to a specific minimum level of `
 
 ### Storage Provisioning
 
-[Rancher Local Path Provisioner](https://github.com/rancher/local-path-provisioner) is used to manage dynamic provisioning of local storage for prerequisite services.
+[Rancher Local Path Provisioner](https://github.com/rancher/local-path-provisioner) is used to manage dynamic provisioning of local storage for prerequisite services. v0.0.22 is required when using the provided deployment script.
 
 - The `prereq-deploy-cortx-cloud.sh` script will ensure this directory exists, if you choose to utilize it.
 - This directory prefix is configurable in the `solution.yaml` file via the `solution.common.storage_provisioner_path`, while appending `local-path-provisioner` to it.
@@ -275,7 +275,7 @@ This section contains the CORTX and third-party images used to deploy CORTX on K
 | `images.consul`          | Image registry, repository, & tag for the Consul required service                      | `ghcr.io/seagate/consul:1.11.4`             |
 | `images.kafka`           | Image registry, repository, & tag for the Kafka required service                       | `ghcr.io/seagate/kafka:3.0.0-debian-10-r97`  |
 | `images.zookeeper`       | Image registry, repository, & tag for the Zookeeper required service                   | `ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9` |
-| `images.rancher`         | Image registry, repository, & tag for the Rancher Local Path Provisioner container     | `ghcr.io/seagate/local-path-provisioner:v0.0.20` |
+| `images.rancher`         | Image registry, repository, & tag for the Rancher Local Path Provisioner container     | `ghcr.io/seagate/local-path-provisioner:v0.0.22` |
 | `images.busybox`         | Image registry, repository, & tag for the utility busybox container                    | `ghcr.io/seagate/busybox:latest`            |
 
 ### Common parameters

--- a/k8_cortx_cloud/cortx-cloud-3rd-party-pkg/templates/local-path-storage-template.yaml
+++ b/k8_cortx_cloud/cortx-cloud-3rd-party-pkg/templates/local-path-storage-template.yaml
@@ -101,49 +101,21 @@ metadata:
 data:
   config.json: |-
     {
-      "nodePathMap":[
-        {
-          "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
-          "paths":["<<.Values.rancher.host_path>>"]
-        }
-      ]
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["<<.Values.rancher.host_path>>"]
+            }
+            ]
     }
   setup: |-
     #!/bin/sh
-    while getopts "m:s:p:" opt
-    do
-      case $opt in
-        p)
-        absolutePath=$OPTARG
-        ;;
-        s)
-        sizeInBytes=$OPTARG
-        ;;
-        m)
-        volMode=$OPTARG
-        ;;
-      esac
-    done
-
-    mkdir -m 0777 -p ${absolutePath}
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
   teardown: |-
     #!/bin/sh
-    while getopts "m:s:p:" opt
-    do
-      case $opt in
-        p)
-        absolutePath=$OPTARG
-        ;;
-        s)
-        sizeInBytes=$OPTARG
-        ;;
-        m)
-        volMode=$OPTARG
-        ;;
-      esac
-    done
-
-    rm -rf ${absolutePath}
+    set -eu
+    rm -rf "$VOL_DIR"
   helperPod.yaml: |-
     apiVersion: v1
     kind: Pod

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -19,7 +19,7 @@ solution:
     consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r97
     zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9
-    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
+    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.22
     busybox: ghcr.io/seagate/busybox:latest
   common:
     storage_provisioner_path: /mnt/fs-local-volume
@@ -117,7 +117,7 @@ solution:
               cpu:    250m
             limits:
               memory: 2Gi
-              cpu:    1000m   
+              cpu:    1000m
         confd:
           resources:
             requests:
@@ -139,7 +139,7 @@ solution:
         agent:
           resources:
             requests:
-              memory: 128Mi 
+              memory: 128Mi
               cpu:    250m
             limits:
               memory: 256Mi

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -19,7 +19,7 @@ solution:
     consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r97
     zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9
-    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.20
+    rancher: ghcr.io/seagate/local-path-provisioner:v0.0.22
     busybox: ghcr.io/seagate/busybox:latest
   common:
     storage_provisioner_path: /mnt/fs-local-volume
@@ -117,7 +117,7 @@ solution:
               cpu:    250m
             limits:
               memory: 2Gi
-              cpu:    1000m   
+              cpu:    1000m
         confd:
           resources:
             requests:
@@ -139,7 +139,7 @@ solution:
         agent:
           resources:
             requests:
-              memory: 128Mi 
+              memory: 128Mi
               cpu:    250m
             limits:
               memory: 256Mi


### PR DESCRIPTION
## Description

This version fixes some issues having to do with cleaning up data the PVC/PVs are deleted. It should hopefully fix problems with filesystems getting full on the host.

## Breaking change

Deployments now require the use of the 0.0.22 version of the local provisioner container image. The solution validation script does a rudimentary check to make sure a valid image tag is specified.

Users must update their own solution.yaml files according to the example.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [X] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
- This change fixes an issue: CORTX-30684

## How was this tested?
Deployed and un-deployed. Ran S3 I/O. Shutdown and started the cluster, previous S3 objects are available.

## Additional information

## Checklist

- [X] The change is tested and works locally.
- [X] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
