### PR TITLE
CORTX-30684: change retain policy to Delete for local-path storage

### DIFF
--- a/k8_cortx_cloud/cortx-cloud-3rd-party-pkg/templates/local-path-storage-template.yaml
+++ b/k8_cortx_cloud/cortx-cloud-3rd-party-pkg/templates/local-path-storage-template.yaml
@@ -90,7 +90,7 @@ metadata:
   name: local-path
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Retain
+reclaimPolicy: Delete
 
 ---
 kind: ConfigMap

--- a/k8_cortx_cloud/destroy-cortx-cloud.sh
+++ b/k8_cortx_cloud/destroy-cortx-cloud.sh
@@ -198,7 +198,7 @@ function deleteCortxPVs()
         if [[ "${force_delete}" == "--force" || "${force_delete}" == "-f" ]]; then
             kubectl patch pv "${persistent_volume}" -p '{"metadata":{"finalizers":null}}'
         fi
-        kubectl delete pv "${persistent_volume}"
+        kubectl delete pv "${persistent_volume}" --ignore-not-found
     done < <(kubectl get pv --no-headers | grep -E "${pv_filter}" | cut -f1 -d" ")
 }
 
@@ -313,7 +313,7 @@ function delete3rdPartyPVCs()
             kubectl patch pvc --namespace "${namespace}" "${volume_claim}" \
                       -p '{"metadata":{"finalizers":null}}'
         fi
-        kubectl delete pvc --namespace "${namespace}" "${volume_claim}"
+        kubectl delete pvc --namespace "${namespace}" "${volume_claim}" --ignore-not-found
     done < <(kubectl get pvc --no-headers --namespace="${namespace}" | grep -E "${pvc_filter}" | cut -f1 -d " ")
 }
 
@@ -327,7 +327,7 @@ function delete3rdPartyPVs()
         if [[ "${force_delete}" == "--force" || "${force_delete}" == "-f" ]]; then
             kubectl patch pv "${persistent_volume}" -p '{"metadata":{"finalizers":null}}'
         fi
-        kubectl delete pv "${persistent_volume}"
+        kubectl delete pv "${persistent_volume}" --ignore-not-found
     done < <(kubectl get pv --no-headers | grep -E "${pvc_filter}" | cut -f1 -d " ")
 }
 

--- a/k8_cortx_cloud/destroy-cortx-cloud.sh
+++ b/k8_cortx_cloud/destroy-cortx-cloud.sh
@@ -187,21 +187,6 @@ function deleteCortxLocalBlockStorage()
     uninstallHelmChart "cortx-data-blk-data-${namespace}" "${namespace}"
 }
 
-function deleteCortxPVs()
-{
-    printf "########################################################\n"
-    printf "# Delete CORTX Persistent Volumes                      #\n"
-    printf "########################################################\n"
-    local -r pv_filter="^${namespace}/cortx-data-fs-local-pvc|^${namespace}/cortx-control-fs-local-pvc"
-    while IFS= read -r persistent_volume; do
-        printf "Removing %s\n" "${persistent_volume}"
-        if [[ "${force_delete}" == "--force" || "${force_delete}" == "-f" ]]; then
-            kubectl patch pv "${persistent_volume}" -p '{"metadata":{"finalizers":null}}'
-        fi
-        kubectl delete pv "${persistent_volume}" --ignore-not-found
-    done < <(kubectl get pv --no-headers | grep -E "${pv_filter}" | cut -f1 -d" ")
-}
-
 function deleteCortxConfigmap()
 {
     #
@@ -317,20 +302,6 @@ function delete3rdPartyPVCs()
     done < <(kubectl get pvc --no-headers --namespace="${namespace}" | grep -E "${pvc_filter}" | cut -f1 -d " ")
 }
 
-function delete3rdPartyPVs()
-{
-    printf "########################################################\n"
-    printf "# Delete Persistent Volumes                            #\n"
-    printf "########################################################\n"
-    while IFS= read -r persistent_volume; do
-        printf "Removing %s\n" "${persistent_volume}"
-        if [[ "${force_delete}" == "--force" || "${force_delete}" == "-f" ]]; then
-            kubectl patch pv "${persistent_volume}" -p '{"metadata":{"finalizers":null}}'
-        fi
-        kubectl delete pv "${persistent_volume}" --ignore-not-found
-    done < <(kubectl get pv --no-headers | grep -E "${pvc_filter}" | cut -f1 -d " ")
-}
-
 function deleteKubernetesPrereqs()
 {
     # This chart has been removed, this is for backwards compatibility.
@@ -390,6 +361,5 @@ uninstallHelmChart cortx "${namespace}"
 # Clean up
 #############################################################
 delete3rdPartyPVCs
-delete3rdPartyPVs
 deleteKubernetesPrereqs
 deleteNodeDataFiles


### PR DESCRIPTION
## Description
Change the `reclaimPolicy` of the local path StorageClass to `Delete`, from `Retain`. Note that Delete is the [default](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) policy for dynamic provisioner storage class that doesn't specify any policy, and also the [default](https://github.com/rancher/local-path-provisioner/blob/47ea46952b27e8f60863316af24cc886090326c2/deploy/local-path-storage.yaml#L93) for the Local Path Provisioner.

Using a Retain policy means the cluster administrator needs to manually clean-up the backing data for k8s volumes, after a user deletes their PVCs and PVs. In development usage the local node partitions can easily run out of space without active management, causing deployments to fail. In comparison, if the policy is Delete, the provisioner will automatically remove the backing data on the nodes when the PVCs are deleted (and PVs are unbound). This is the behavior that makes sense as a default for users of the deployment scripts.

It is no longer necessary to manually remove PVs since the provisioner does this itself, in fact doing this at the same time causes the provisioner to be unable to removing the node data.

## Breaking change
It's useful for users to be aware of this change to the default behavior. Running the destroy script will now result in all data being removed from the cluster nodes (although, that is really the intent).

The `destroy-cortx-cloud.sh` script no longer manually removes 3rd party PVs. This means running the script against a cluster where the PV reclaim policies are `Retain`, the PVs will not be removed. Users should manually delete the PVs and data on the cluster nodes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change address an issue: CORTX-30684
- This change is related to an issue: CORTX-31536

In debugging 31356 I wanted to ensure that no left over Pod data was influencing repeat runs. Switching to the Delete reclaim policy makes sure the left-over data is automatically cleaned up.

## How was this tested?

Deploy and destroy. I see all node data removed after the destroy.

Saved files into S3 bucket, confirmed after stopping and starting the cluster (stop/start scripts) the data is still accessible.

## Additional information

If users prefer to keep the Retain policy, PVs can be modified after they are created. https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/

Note that future plans include allowing the use of any StorageClass, not just our specific local-path provisioner. In that case, users are free to define the StorageClass any way they prefer, and clean-up PVs and data as required.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
