### PR TITLE
Remove wait when installing CORTX Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,14 +343,12 @@ The Helm charts work with both "stub" and "CORTX ALL" containers, allowing users
 
 ### Overriding Helm Install  / Wait Timeouts
 
-There is a "wait" after each of the cortx helm charts are deployed.  This wait is guarded by a timeout.  If needed, these timeout values can be overridden by environment variables.
+There is a "wait" after some of the CORTX Helm Charts are deployed.  This wait is guarded by a timeout.  If needed, these timeout values can be overridden by environment variables.
 
 | Environment Variable           | Default Value |
 | ------------------------------ | ------------- |
-| `CORTX_DEPLOY_CONTROL_TIMEOUT` | `300s`        |
 | `CORTX_DEPLOY_DATA_TIMEOUT`    | `300s`        |
 | `CORTX_DEPLOY_SERVER_TIMEOUT`  | `300s`        |
-| `CORTX_DEPLOY_HA_TIMEOUT`      | `120s`        |
 
 ### Crash-looping InitContainers
 

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -577,7 +577,6 @@ function deployCortx()
         -f ${values_file} \
         --namespace "${namespace}" \
         --create-namespace \
-        --wait \
         || exit $?
 
     # Restarting Consul at this time causes havoc. Disabling this for now until


### PR DESCRIPTION
## Description

This change removes the wait when installing the unified CORTX Helm Chart. Previous to this, the installation would fail if the third party dependencies + HA + Control components do not fully deploy within 5 minutes.

The motivation behind this is that the HA and Control wait timeouts were already effectively removed when merging the Control and HA charts into the unified chart (PRs #252 and #261). We don't know what the right timeout value is for all cases; 5 minutes could be too low or too high depending on the configuration. Instead of adding in yet another variable to enforce a timeout, we prefer that users check the state of their deployment after the script has finished. This can be done with the `status-cortx-cloud.sh` script, or individual `kubectl wait` or `kubectl rollout status` commands. 

Timeouts still exist for checking that:

- the third party services are ready
- all CORTX Data deployments are ready
- all CORTX Server deployments are ready

## Breaking change
No. But the aforementioned timeout variables have already been removed, so we should document them as unused now. Those are: `CORTX_DEPLOY_CONTROL_TIMEOUT` and `CORTX_DEPLOY_HA_TIMEOUT`.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## How was this tested?

Deployed a cluster and performed S3 I/O.

## Additional information

Note that there are existing issues logged for initContainers never completing:

- HA deployment: CORTX-31665
- Control deployment: CORTX-31536

As a result, the deployment script will complete successfully, but these services won't be available. This can be verified with the status script. The workaround is to delete the Pods and let them be re-created.

Removing the Helm install timeout actually improves this situation because it allows the full stack to be deployed without failing part way. The failed Pods can be fixed afterwards.

Also note that it seems possible to perform S3 I/O with the default user w/o the control Pod ever coming up. I'm not sure if there's some setup that was partially done beforehand, or if that's expected...

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/keithpine/cortx-k8s/blob/no-wait/README.md)