### PR TITLE
Restore HA/Control deployment waits, optimize install

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,16 +341,17 @@ This section contains information about all the worker nodes used to deploy CORT
 
 The Helm charts work with both "stub" and "CORTX ALL" containers, allowing users to deploy both placeholder Kubernetes artifacts and functioning CORTX deployments using the same code base. If you are encountering issues deploying CORTX on Kubernetes, you can utilize the stub container method by setting the necessary component in `solution.yaml` to use an image of `ghcr.io/seagate/centos:7` instead of a CORTX-based image. This will deploy the same Kubernetes structure, expect the container entrypoints will be set to `sleep 3650d` to allow for deployment progression and user inspection of the overall deployment.
 
-### Overriding Helm Install  / Wait Timeouts
+### Overriding Cluster Install Wait Timeouts
 
-There is a "wait" after each of the cortx helm charts are deployed.  This wait is guarded by a timeout.  If needed, these timeout values can be overridden by environment variables.
+After the CORTX Kubernetes resources are created, the deployment script will wait for those resources to finish installing and reach a ready state. This wait is guarded by a set of timeout values which can be overridden using environment variables. The values are duration strings, such as `"30s"` or `"10m"`.
 
-| Environment Variable           | Default Value |
-| ------------------------------ | ------------- |
-| `CORTX_DEPLOY_CONTROL_TIMEOUT` | `300s`        |
-| `CORTX_DEPLOY_DATA_TIMEOUT`    | `300s`        |
-| `CORTX_DEPLOY_SERVER_TIMEOUT`  | `300s`        |
-| `CORTX_DEPLOY_HA_TIMEOUT`      | `120s`        |
+| Environment Variable           | Description        | Default Value |
+| ------------------------------ | ------------------ | ------------- |
+| `CORTX_DEPLOY_CLIENT_TIMEOUT`  | Client Deployment  | `5m` (5 min)  |
+| `CORTX_DEPLOY_CONTROL_TIMEOUT` | Control Deployment | `5m` (5 min)  |
+| `CORTX_DEPLOY_DATA_TIMEOUT`    | Data Deployment    | `5m` (5 min)  |
+| `CORTX_DEPLOY_HA_TIMEOUT`      | HA Deployment      | `2m` (2 min)  |
+| `CORTX_DEPLOY_SERVER_TIMEOUT`  | Server Deployment  | `5m` (5 min)  |
 
 ### Crash-looping InitContainers
 


### PR DESCRIPTION
## Description

Change how Charts are installed and resources waited for.

### Restore lost Control and HA waits

After the Control and HA Charts were merged into the unified Chart, the ability to wait on these resources was lost, making `CORTX_DEPLOY_CONTROL_TIMEOUT` and `CORTX_DEPLOY_HA_TIMEOUT` in-effective. This code was restored and these deployments are waited on again.

### CORTX Chart install

The `--wait` argument has been removed from the `helm install` command. Previously, if the Chart fails to install with the default wait timeout, then the deployment script fails completely. This leaves the cluster in a half-installed state. Second, the default timeout is 5 minutes, but we don't know for sure how long it should take. Rather, just let install without waiting and either let the user determine if it's complete, or let our other checks handle it. This gives the user the ability to make an corrective actions later.

### Data / Server / Client Chart installs

Instead of installing these serially, which takes a good amount of time, they are now installed in parallel. Based on testing, there doesn't appear to be any dependency on these deployments. 

### Parallel waits

The deployment flow has been modified to wait for all CORTX deployments _after_ all of the charts have been installed, and does each check in parallel. Previously these were done serially, after each Chart install. This helps reduce the total time of the deployment and provides feedback as deployments become ready.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## How was this tested?

Deployed a cluster and performed S3 I/O.

Set a timeout low for a deployment and observed it was reported as an error. Checked cluster after and it was working, as expected.

## Additional information

### Example output

Here's the new output with a timeout.

```text
Waiting for all CORTX Deployments to become Ready..........
Deployment CORTX Control available after 9 seconds
..................................
Deployment CORTX Client available after 43 seconds
.......................
Deployment CORTX Data available after 66 seconds
......................
Deployment CORTX Server available after 89 seconds
........................................................................................................................................................
ERROR: Deployment CORTX HA timed out after 241 seconds

-----------------------------------------------------------

!!! ERROR: The CORTX cluster installation failed. There was a timeout waiting for one or more deployments.

The S3 data service is accessible through the cortx-io-svc-0 service.
   Default IAM access key: sgiamadmin
   Default IAM secret key is accessible via:
       kubectl get secrets/cortx-secret --namespace cortx \
                  --template={{.data.s3_auth_admin_secret}} | base64 -d

The CORTX control service is accessible through the cortx-control-loadbal-svc service.
   Default control username: cortxadmin
   Default control password is accessible via:
       kubectl get secrets/cortx-secret --namespace cortx \
                  --template={{.data.csm_mgmt_admin_secret}} | base64 -d

-----------------------------------------------------------
```

### Related issues

Note that there are existing issues logged for initContainers never completing:

- HA deployment: CORTX-31665
- Control deployment: CORTX-31536

As a result, the deployment script will install everything, but report these deployments as having timed out, and the services won't be available. This can be verified with the status script. The workaround is to delete the Pods and let them be re-created. The benefit of this change is the ability to correct the cluster state w/o a complete tear-down, as everything has been installed.

Also note that it seems possible to perform S3 I/O with the default user w/o the control Pod ever coming up. I'm not sure if there's some setup that was partially done beforehand, or if that's expected...

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/keithpine/cortx-k8s/blob/optimize-wait/README.md)