### PR TITLE
CORTX-32041: configure HAX http endpoint correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,7 @@ This section contains common parameters that affect all CORTX components running
 | `common.motr.num_client_inst`                         | TODO       | `0` |
 | `common.motr.start_port_num`                          | TODO       | `29000` |
 | `common.motr.extra_configuration`                     | _(Optional)_ Extra configuration settings to append to the Motr configuration. The value is a multi-line string included verbatim. | `""` |
-| `common.hax.protocol`                                 | Protocol that is used to communicate with HAX components running across Server and Data Pods.     | `https` |
-| `common.hax.service_name`                             | Service name that is used to communicate with HAX components running across Server and Data Pods. | `cortx-hax-svc` |
+| `common.hax.protocol`                                 | Protocol that is used to communicate with HAX components running across Server and Data Pods.     | `http` |
 | `common.hax.port_num`                                 | Port number that is used to communicate with HAX components running across Server and Data Pods.  | `22003` |
 | `common.external_services.s3.type`                    | Kubernetes Service type for external access to S3 IO                                              | `NodePort` |
 | `common.external_services.s3.count`                   | The number of service instances to create when service type is `LoadBalancer`                     | `1` |

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -75,9 +75,6 @@ helm uninstall cortx
 | configmap.cortxHare.haxClientEndpoints | list | `[]` |  |
 | configmap.cortxHare.haxDataEndpoints | list | `[]` |  |
 | configmap.cortxHare.haxServerEndpoints | list | `[]` |  |
-| configmap.cortxHare.haxService.name | string | `"cortx-hax-svc"` |  |
-| configmap.cortxHare.haxService.port | int | `22003` |  |
-| configmap.cortxHare.haxService.protocol | string | `"https"` |  |
 | configmap.cortxIoService.name | string | `"cortx-io-svc-0"` |  |
 | configmap.cortxIoService.ports.http | string | `""` |  |
 | configmap.cortxIoService.ports.https | string | `""` |  |
@@ -175,9 +172,8 @@ helm uninstall cortx
 | platform.podSecurityPolicy.create | bool | `false` |  |
 | platform.rbacRole.create | bool | `true` |  |
 | platform.rbacRoleBinding.create | bool | `true` |  |
-| platform.services.create | bool | `true` |  |
-| platform.services.hax.name | string | `"cortx-hax-svc"` |  |
 | platform.services.hax.port | int | `22003` |  |
+| platform.services.hax.protocol | string | `"https"` |  |
 | platform.services.hax.type | string | `"ClusterIP"` |  |
 | platform.services.io.count | int | `1` |  |
 | platform.services.io.name | string | `"cortx-io-svc"` |  |

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -75,14 +75,12 @@ cortx:
   {{- end }}
   hare:
     hax:
-      {{- with .Values.configmap.cortxHare }}
-      {{- $endpoints := concat (list (printf "%s://%s:%d" .haxService.protocol .haxService.name (.haxService.port | int))) .haxDataEndpoints .haxClientEndpoints -}}
-      {{- if $.Values.configmap.cortxRgw.enabled }}
-      {{- $endpoints = concat $endpoints .haxServerEndpoints -}}
+      {{- $endpoints := concat (list (include "cortx.hare.hax.url" .)) .Values.configmap.cortxHare.haxDataEndpoints .Values.configmap.cortxHare.haxClientEndpoints -}}
+      {{- if .Values.configmap.cortxRgw.enabled }}
+      {{- $endpoints = concat $endpoints .Values.configmap.cortxHare.haxServerEndpoints -}}
       {{- end }}
       endpoints:
       {{- toYaml (default (list) $endpoints) | nindent 8 }}
-      {{- end }}
     limits:
       services:
       {{- include "config.yaml.service.limits" (dict "name" "hax" "resources" .Values.configmap.cortxHare.hax.resources) | nindent 6 }}

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -88,3 +88,17 @@ Return the name of the HA component
 {{- define "cortx.ha.fullname" -}}
 {{- printf "%s-ha" (include "cortx.fullname" .) -}}
 {{- end -}}
+
+{{/*
+Return the name of the Hare hax component
+*/}}
+{{- define "cortx.hare.hax.fullname" -}}
+{{- printf "%s-hax" (include "cortx.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Create a URL for the Hare hax HTTP endpoint
+*/}}
+{{- define "cortx.hare.hax.url" -}}
+{{- printf "%s://%s:%d" .Values.platform.services.hax.protocol (include "cortx.hare.hax.fullname" .) (.Values.platform.services.hax.port | int) -}}
+{{- end -}}

--- a/charts/cortx/templates/hax/service.yaml
+++ b/charts/cortx/templates/hax/service.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.platform.services.create }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cortx.fullname" . }}-hax
+  name: {{ include "cortx.hare.hax.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "cortx.labels" . | nindent 4 }}
 spec:
@@ -12,6 +11,5 @@ spec:
   ports:
     - name: hax-tcp
       protocol: TCP
-      port: {{ .Values.platform.services.hax.port }}
+      port: {{ .Values.platform.services.hax.port | int }}
       targetPort: hax
-{{- end }}

--- a/charts/cortx/templates/server/service.yaml
+++ b/charts/cortx/templates/server/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.platform.services.create -}}
 {{- $svc := .Values.platform.services.io -}}
 {{- if gt (int $svc.count) 0 -}}
 {{- $isLB := eq $svc.type "LoadBalancer" -}}
@@ -32,6 +31,5 @@ spec:
       nodePort: {{ add $svc.nodePorts.https $i }}
       {{- end }}
 ---
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -195,10 +195,6 @@ configmap:
     haxDataEndpoints: []
     haxServerEndpoints: []
     haxClientEndpoints: []
-    haxService:
-      protocol: https
-      name: cortx-hax-svc
-      port: 22003
     hax:
       resources:
         requests:
@@ -267,10 +263,9 @@ platform:
       podNameLabel: cortx-data
 
   services:
-    create: true
     hax:
-      name: cortx-hax-svc
       type: ClusterIP
+      protocol: https
       port: 22003
     io:
       name: cortx-io-svc

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -158,15 +158,6 @@ buildValues() {
     # shellcheck disable=SC2016
     yq -i eval-all '
         select(fi==0) ref $to | select(fi==1) ref $from
-        | with($to.configmap.cortxHare.haxService;
-            .protocol = $from.solution.common.hax.protocol
-            | .name = $from.solution.common.hax.service_name
-            | .port = $from.solution.common.hax.port_num)
-        | $to' "${values_file}" "${solution_yaml}"
-
-    # shellcheck disable=SC2016
-    yq -i eval-all '
-        select(fi==0) ref $to | select(fi==1) ref $from
         | with($to.configmap.cortxRgw;
             .authAdmin = $from.solution.common.s3.default_iam_users.auth_admin
             | .authUser = $from.solution.common.s3.default_iam_users.auth_user
@@ -286,12 +277,12 @@ buildValues() {
         createPodSecurityPolicy="false"
     fi
 
-    local hax_service_name
     local hax_service_port
+    local hax_service_protocol
     local s3_service_type
     local s3_service_ports_http
     local s3_service_ports_https
-    hax_service_name=$(getSolutionValue 'solution.common.hax.service_name')
+    hax_service_protocol=$(getSolutionValue 'solution.common.hax.protocol')
     hax_service_port=$(getSolutionValue 'solution.common.hax.port_num')
     s3_service_type=$(getSolutionValue 'solution.common.external_services.s3.type')
     s3_service_count=$(getSolutionValue 'solution.common.external_services.s3.count')
@@ -310,7 +301,7 @@ buildValues() {
     yq -i "
         with(.platform; (
             .podSecurityPolicy.create = ${createPodSecurityPolicy}
-            | .services.hax.name = \"${hax_service_name}\"
+            | .services.hax.protocol = \"${hax_service_protocol}\"
             | .services.hax.port = ${hax_service_port}
             | .services.io.type = \"${s3_service_type}\"
             | .services.io.count = ${s3_service_count}

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -39,7 +39,6 @@ solution:
       extra_configuration: ""
     hax:
       protocol: https
-      service_name: cortx-hax-svc
       port_num: 22003
     storage_sets:
       name: storage-set-1
@@ -117,7 +116,7 @@ solution:
               cpu:    250m
             limits:
               memory: 2Gi
-              cpu:    1000m   
+              cpu:    1000m
         confd:
           resources:
             requests:
@@ -139,7 +138,7 @@ solution:
         agent:
           resources:
             requests:
-              memory: 128Mi 
+              memory: 128Mi
               cpu:    250m
             limits:
               memory: 256Mi

--- a/k8_cortx_cloud/solution_stub.yaml
+++ b/k8_cortx_cloud/solution_stub.yaml
@@ -39,7 +39,6 @@ solution:
       extra_configuration: ""
     hax:
       protocol: https
-      service_name: cortx-hax-svc
       port_num: 22003
     storage_sets:
       name: storage-set-1
@@ -117,7 +116,7 @@ solution:
               cpu:    250m
             limits:
               memory: 2Gi
-              cpu:    1000m   
+              cpu:    1000m
         confd:
           resources:
             requests:
@@ -139,7 +138,7 @@ solution:
         agent:
           resources:
             requests:
-              memory: 128Mi 
+              memory: 128Mi
               cpu:    250m
             limits:
               memory: 256Mi

--- a/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
@@ -24,7 +24,6 @@ solution:
       start_port_num: required
     hax:
       protocol: required
-      service_name: required
       port_num: required
     storage_sets:
       name: required


### PR DESCRIPTION
## Description

The cluster.yaml endpoint must be configured using the correct service name.

This was a regression introduced by #245. The name of the hax service was changed but the related ConfigMap endpoint value was not.

## Breaking change

The solution configuration item `common.hax.service_name` has been removed. The name of the service is assigned based on the Helm Release name (`<fullname>-hax`). This should not be breaking in typical usage, but if any user is relying on a custom name, it is no longer set.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [x] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32041
- This change is related to an issue: CORTX-30799

## How was this tested?

Using image version 803. Deployed cluster and examined the ConfigMap and generated cluster.conf file. The hax URL is correct. Issued cURL commands from a container to the service URL and it is successful.

Note that the hax protocol value doesn't seem to be honored. When setting to `http`, even though the cluster.conf is configured this way, the services do not respond. They will continue to respond to `https` only.

## Additional information

Consilidated duplicate Helm Chart values into the singular `platform.services.hax` object.

Removed the `platform.services.create` boolean value. This controls whether the Hax and S3 IO services are created. It's hardcoded to true and we don't allow changing it. I'm not certain whether it's valid to disable the Hax service, so we shouldn't allow it until the values file is cleaned up.

## Checklist

- [x] The change is tested and works locally.
- [x] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-32041_fix-hax-endpoint/README.md)
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-32041_fix-hax-endpoint/charts/cortx/README.md)