### PR TITLE
CORTX-31831: Add Kafka init container to wait for Zookeeper

### DIFF
--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -61,6 +61,11 @@ kafka:
   # -- Overridden min.insync.replicas config for the transaction topic
   transactionStateLogMinIsr: 2
 
+  initContainers:
+  - name: zookeeper-watcher
+    image: ghcr.io/seagate/busybox:latest
+    command: ['sh', '-c', 'until echo "ruok" | timeout 30 nc -w 30 cortx-zookeeper 2181 | grep imok; do sleep 1; done']
+
   # ZooKeeper chart configuration
   # ref: https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/values.yaml
   zookeeper:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -62,7 +62,7 @@ kafka:
   transactionStateLogMinIsr: 2
 
   initContainers:
-  - name: zookeeper-watcher
+  - name: wait-for-zookeeper
     image: ghcr.io/seagate/busybox:latest
     command: ['sh', '-c', 'until echo "ruok" | timeout 30 nc -w 30 cortx-zookeeper 2181 | grep imok; do sleep 1; done']
 


### PR DESCRIPTION

## Description
Use an init container to prevent Kafka containers to start before Zookeeper is ready for them.  This prevents Kafka
from doing a restart right out of the box.  This is does not fix any functional problem (it is ok if the Kafka container
restarts), but it looks nicer and better controlled.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-31831


## CORTX image version requirements
N/A

## How was this tested?
Deployed cluster locally multiple times.  Confirmed no Kafka restarts.

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
