### PR TITLE
CORTX-30147: misc Chart-related cleanup

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -105,7 +105,7 @@ helm uninstall cortx
 | cortxcontrol.machineid.value | string | `""` |  |
 | cortxcontrol.service.loadbal.enabled | bool | `true` |  |
 | cortxcontrol.service.loadbal.nodePorts.https | string | `""` |  |
-| cortxcontrol.service.loadbal.ports.https | int | `23256` |  |
+| cortxcontrol.service.loadbal.ports.https | int | `8081` |  |
 | cortxcontrol.service.loadbal.type | string | `"NodePort"` |  |
 | cortxcontrol.sslcfgmap.mountpath | string | `"/etc/cortx/solution/ssl"` |  |
 | cortxdata.blockDevicePaths | list | `[]` |  |
@@ -124,7 +124,6 @@ helm uninstall cortx
 | cortxdata.motr.resources.limits.memory | string | `"2Gi"` |  |
 | cortxdata.motr.resources.requests.cpu | string | `"250m"` |  |
 | cortxdata.motr.resources.requests.memory | string | `"1Gi"` |  |
-| cortxdata.motr.startportnum | int | `29000` |  |
 | cortxdata.nodes | list | `[]` |  |
 | cortxdata.persistentStorage.accessModes[0] | string | `"ReadWriteMany"` |  |
 | cortxdata.persistentStorage.volumeMode | string | `"Block"` |  |

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -71,7 +71,6 @@ helm uninstall cortx
 | configmap.cortxControl.agent.resources.requests.cpu | string | `"250m"` |  |
 | configmap.cortxControl.agent.resources.requests.memory | string | `"128Mi"` |  |
 | configmap.cortxHare.haxClientEndpoints | list | `[]` |  |
-| configmap.cortxHare.haxServerEndpoints | list | `[]` |  |
 | configmap.cortxMotr.clientEndpoints | list | `[]` |  |
 | configmap.cortxMotr.clientInstanceCount | int | `0` |  |
 | configmap.cortxMotr.confd.resources.limits.cpu | string | `"500m"` |  |
@@ -83,7 +82,6 @@ helm uninstall cortx
 | configmap.cortxMotr.motr.resources.limits.memory | string | `"2Gi"` |  |
 | configmap.cortxMotr.motr.resources.requests.cpu | string | `"250m"` |  |
 | configmap.cortxMotr.motr.resources.requests.memory | string | `"1Gi"` |  |
-| configmap.cortxMotr.rgwEndpoints | list | `[]` |  |
 | configmap.cortxSecretName | string | `"cortx-secret"` |  |
 | configmap.cortxSecretValues | object | `{}` |  |
 | configmap.cortxStoragePaths.config | string | `"/etc/cortx"` |  |
@@ -107,7 +105,7 @@ helm uninstall cortx
 | cortxcontrol.machineid.value | string | `""` |  |
 | cortxcontrol.service.loadbal.enabled | bool | `true` |  |
 | cortxcontrol.service.loadbal.nodePorts.https | string | `""` |  |
-| cortxcontrol.service.loadbal.ports.https | int | `8081` |  |
+| cortxcontrol.service.loadbal.ports.https | int | `23256` |  |
 | cortxcontrol.service.loadbal.type | string | `"NodePort"` |  |
 | cortxcontrol.sslcfgmap.mountpath | string | `"/etc/cortx/solution/ssl"` |  |
 | cortxdata.blockDevicePaths | list | `[]` |  |
@@ -205,7 +203,6 @@ helm uninstall cortx
 | platform.podSecurityPolicy.create | bool | `false` |  |
 | platform.rbacRole.create | bool | `true` |  |
 | platform.rbacRoleBinding.create | bool | `true` |  |
-| platform.storage.localBlock.storageClassName | string | `"cortx-local-block-storage"` |  |
 | serviceAccount.annotations | object | `{}` | Custom annotations for the CORTX ServiceAccount |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for CORTX pods |

--- a/charts/cortx/templates/_cluster.yaml.tpl
+++ b/charts/cortx/templates/_cluster.yaml.tpl
@@ -85,10 +85,14 @@ cluster:
     {{- $hostName := printf "%s.%s" $nodeName (include "cortx.data.serviceDomain" $root) }}
     {{- include "storageset.node" (dict "name" $nodeName "hostname" $hostName "id" $hostName "type" "data_node") | nindent 4 }}
     {{- end }}
-    {{- range $nodeName, $node := $storageSet.nodes }}
-    {{- if and $root.Values.cortxserver.enabled $node.serverUuid }}
-    {{- include "storageset.node" (dict "name" $nodeName "hostname" $node.serverUuid "id" $node.serverUuid "type" "server_node") | nindent 4 }}
+    {{- if $root.Values.cortxserver.enabled }}
+    {{- range $i := until (int $root.Values.cortxserver.replicas) }}
+    {{- $nodeName := printf "%s-%d" (include "cortx.server.fullname" $root) $i }}
+    {{- $hostName := printf "%s.%s" $nodeName (include "cortx.server.serviceDomain" $root) }}
+    {{- include "storageset.node" (dict "name" $nodeName "hostname" $hostName "id" $hostName "type" "server_node") | nindent 4 }}
     {{- end }}
+    {{- end }}
+    {{- range $nodeName, $node := $storageSet.nodes }}
     {{- if $node.clientUuid }}
     {{- $clientName := printf "cortx-client-headless-svc-%s" (split "." $nodeName)._0 }}
     {{- include "storageset.node" (dict "name" $clientName "id" $node.clientUuid "type" "client_node") | nindent 4 }}

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -19,7 +19,6 @@
 {{- $serverHostnames = append $serverHostnames (printf "%s-%d.%s" (include "cortx.server.fullname" $) $i (include "cortx.server.serviceDomain" $)) -}}
 {{- end -}}
 {{- end -}}
-{{- $rgwClientPort := 22501 -}}
 cortx:
   external:
     kafka:
@@ -116,7 +115,7 @@ cortx:
       num_instances: 1  # number of instances *per-pod*
       endpoints:
       {{- range $serverHostnames }}
-      - {{ printf "tcp://%s:%d" . $rgwClientPort }}
+      - {{ printf "tcp://%s:%d" . (include "cortx.server.motrClientPort" $ | int) }}
       {{- end }}
     {{- end }}
     - name: motr_client

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -19,7 +19,6 @@
 {{- $serverHostnames = append $serverHostnames (printf "%s-%d.%s" (include "cortx.server.fullname" $) $i (include "cortx.server.serviceDomain" $)) -}}
 {{- end -}}
 {{- end -}}
-{{- $confdPort := 21001 -}}
 {{- $rgwClientPort := 22501 -}}
 cortx:
   external:
@@ -109,7 +108,7 @@ cortx:
     confd:
       endpoints:
       {{- range $dataHostnames }}
-      - {{ printf "tcp://%s:%d" . $confdPort }}
+      - {{ printf "tcp://%s:%d" . (include "cortx.data.confdPort" $ | int) }}
       {{- end }}
     clients:
     {{- if .Values.cortxserver.enabled }}

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -19,7 +19,6 @@
 {{- $serverHostnames = append $serverHostnames (printf "%s-%d.%s" (include "cortx.server.fullname" $) $i (include "cortx.server.serviceDomain" $)) -}}
 {{- end -}}
 {{- end -}}
-{{- $haxPort := 22001 -}}
 {{- $iosPort := 21002 -}}
 {{- $confdPort := 21001 -}}
 {{- $rgwClientPort := 22501 -}}
@@ -92,7 +91,7 @@ cortx:
       endpoints:
       - {{ include "cortx.hare.hax.url" . }}
       {{- range (concat $dataHostnames $serverHostnames) }}
-      - {{ printf "tcp://%s:%d" . $haxPort }}
+      - {{ printf "tcp://%s:%d" . (include "cortx.hare.hax.tcpPort" $ | int) }}
       {{- end }}
       {{- if .Values.configmap.cortxHare.haxClientEndpoints }}
       {{- toYaml .Values.configmap.cortxHare.haxClientEndpoints | nindent 6 }}

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -135,7 +135,7 @@ cortx:
   csm:
     agent:
       endpoints:
-      - https://:23256
+      - {{ printf "https://:%d" (include "cortx.control.agentPort" . | int) }}
     auth_admin: authadmin
     auth_secret: csm_auth_admin_secret
     email_address: cortx@seagate.com # Optional

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -65,8 +65,8 @@ cortx:
       - {{ printf "https://%s-0:%d" (include "cortx.server.fullname" .) (.Values.cortxserver.service.ports.https | int) }}
     service:
       endpoints:
-      - http://:22751
-      - https://:23001
+      - {{ printf "http://:%d" (include "cortx.server.rgwHttpPort" . | int) }}
+      - {{ printf "https://:%d" (include "cortx.server.rgwHttpsPort" . | int) }}
     io_max_units: 8
     max_start_timeout: {{ .Values.cortxserver.maxStartTimeout | int }}
     service_instances: 1

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -19,7 +19,6 @@
 {{- $serverHostnames = append $serverHostnames (printf "%s-%d.%s" (include "cortx.server.fullname" $) $i (include "cortx.server.serviceDomain" $)) -}}
 {{- end -}}
 {{- end -}}
-{{- $iosPort := 21002 -}}
 {{- $confdPort := 21001 -}}
 {{- $rgwClientPort := 22501 -}}
 cortx:
@@ -105,7 +104,7 @@ cortx:
     ios:
       endpoints:
       {{- range $dataHostnames }}
-      - {{ printf "tcp://%s:%d" . $iosPort }}
+      - {{ printf "tcp://%s:%d" . (include "cortx.data.iosPort" $ | int) }}
       {{- end }}
     confd:
       endpoints:

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -104,6 +104,13 @@ Create a URL for the Hare hax HTTP endpoint
 {{- end -}}
 
 {{/*
+Return the Hare hax TCP endpoint port
+*/}}
+{{- define "cortx.hare.hax.tcpPort" -}}
+22001
+{{- end -}}
+
+{{/*
 Return the name of the Server component
 */}}
 {{- define "cortx.server.fullname" -}}

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -125,6 +125,13 @@ Return the name of the Server service domain
 {{- end -}}
 
 {{/*
+Return the RGW Motr-client endpoint port
+*/}}
+{{- define "cortx.server.motrClientPort" -}}
+22501
+{{- end -}}
+
+{{/*
 Return the name of the Data component
 */}}
 {{- define "cortx.data.fullname" -}}

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -83,6 +83,13 @@ Return the name of the Control component
 {{- end -}}
 
 {{/*
+Return the Control Agent endpoint port
+*/}}
+{{- define "cortx.control.agentPort" -}}
+23256
+{{- end -}}
+
+{{/*
 Return the name of the HA component
 */}}
 {{- define "cortx.ha.fullname" -}}

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -137,3 +137,10 @@ Return the name of the Data service domain
 {{- define "cortx.data.serviceDomain" -}}
 {{- printf "%s-headless.%s.svc.%s" (include "cortx.data.fullname" .) .Release.Namespace .Values.clusterDomain -}}
 {{- end -}}
+
+{{/*
+Return the Motr IOS endpoint port
+*/}}
+{{- define "cortx.data.iosPort" -}}
+21002
+{{- end -}}

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -144,3 +144,10 @@ Return the Motr IOS endpoint port
 {{- define "cortx.data.iosPort" -}}
 21002
 {{- end -}}
+
+{{/*
+Return the Motr confd endpoint port
+*/}}
+{{- define "cortx.data.confdPort" -}}
+21001
+{{- end -}}

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -125,6 +125,20 @@ Return the name of the Server service domain
 {{- end -}}
 
 {{/*
+Return the RGW HTTP endpoint port
+*/}}
+{{- define "cortx.server.rgwHttpPort" -}}
+22751
+{{- end -}}
+
+{{/*
+Return the RGW HTTPS endpoint port
+*/}}
+{{- define "cortx.server.rgwHttpsPort" -}}
+23001
+{{- end -}}
+
+{{/*
 Return the RGW Motr-client endpoint port
 */}}
 {{- define "cortx.server.motrClientPort" -}}

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -122,7 +122,7 @@ spec:
                 fieldPath: metadata.name
           ports:
             - name: control-https
-              containerPort: 23256
+              containerPort: {{ include "cortx.control.agentPort" . | int }}
               protocol: TCP
           {{- if .Values.cortxcontrol.agent.resources }}
           resources: {{- toYaml .Values.cortxcontrol.agent.resources | nindent 12 }}

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -122,7 +122,7 @@ spec:
                 fieldPath: metadata.name
           ports:
             - name: control-https
-              containerPort: 8081
+              containerPort: 23256
               protocol: TCP
           {{- if .Values.cortxcontrol.agent.resources }}
           resources: {{- toYaml .Values.cortxcontrol.agent.resources | nindent 12 }}

--- a/charts/cortx/templates/data/service-headless.yaml
+++ b/charts/cortx/templates/data/service-headless.yaml
@@ -29,7 +29,7 @@ spec:
       port: {{ include "cortx.data.confdPort" $ | int }}
       targetPort: motr-confd-tcp
     {{- range $i := until (.Values.cortxdata.motr.numiosinst | int) }}
-    {{- $portName := printf "motr-ios-%03d-tcp" (add 1 $i) }}
+    {{- $portName := printf "ios-%d-tcp" (add 1 $i) }}
     - name: {{ $portName }}
       protocol: TCP
       port: {{ printf "%d" (add $i (include "cortx.data.iosPort" $) | int) }}

--- a/charts/cortx/templates/data/service-headless.yaml
+++ b/charts/cortx/templates/data/service-headless.yaml
@@ -22,7 +22,7 @@ spec:
       targetPort: hax-http
     - name: hax-tcp
       protocol: TCP
-      port: 22001
+      port: {{ include "cortx.hare.hax.tcpPort" . | int }}
       targetPort: hax-tcp
     - name: cortx-motr-confd-tcp
       protocol: TCP

--- a/charts/cortx/templates/data/service-headless.yaml
+++ b/charts/cortx/templates/data/service-headless.yaml
@@ -24,10 +24,10 @@ spec:
       protocol: TCP
       port: {{ include "cortx.hare.hax.tcpPort" . | int }}
       targetPort: hax-tcp
-    - name: cortx-motr-confd-tcp
+    - name: motr-confd-tcp
       protocol: TCP
-      port: {{ printf "%d" (add .Values.cortxdata.motr.numiosinst .Values.cortxdata.motr.startportnum) }}
-      targetPort: {{ printf "%d" (add .Values.cortxdata.motr.numiosinst .Values.cortxdata.motr.startportnum) }}
+      port: {{ include "cortx.data.confdPort" $ | int }}
+      targetPort: motr-confd-tcp
     {{- range $i := until (.Values.cortxdata.motr.numiosinst | int) }}
     {{- $portName := printf "motr-ios-%03d-tcp" (add 1 $i) }}
     - name: {{ $portName }}

--- a/charts/cortx/templates/data/service-headless.yaml
+++ b/charts/cortx/templates/data/service-headless.yaml
@@ -28,9 +28,10 @@ spec:
       protocol: TCP
       port: {{ printf "%d" (add .Values.cortxdata.motr.numiosinst .Values.cortxdata.motr.startportnum) }}
       targetPort: {{ printf "%d" (add .Values.cortxdata.motr.numiosinst .Values.cortxdata.motr.startportnum) }}
-    {{- range $i := until (.Values.cortxdata.motr.numiosinst|int) }}
-    - name: {{ printf "cortx-motr-ios-%03d-tcp" (add 1 $i) }}
+    {{- range $i := until (.Values.cortxdata.motr.numiosinst | int) }}
+    {{- $portName := printf "motr-ios-%03d-tcp" (add 1 $i) }}
+    - name: {{ $portName }}
       protocol: TCP
-      port: {{ printf "%d" (add $i $.Values.cortxdata.motr.startportnum) }}
-      targetPort: {{ printf "%d" (add $i $.Values.cortxdata.motr.startportnum) }}
+      port: {{ printf "%d" (add $i (include "cortx.data.iosPort" $) | int) }}
+      targetPort: {{ $portName }}
     {{- end }}

--- a/charts/cortx/templates/data/service-headless.yaml
+++ b/charts/cortx/templates/data/service-headless.yaml
@@ -24,10 +24,10 @@ spec:
       protocol: TCP
       port: {{ include "cortx.hare.hax.tcpPort" . | int }}
       targetPort: hax-tcp
-    - name: motr-confd-tcp
+    - name: confd-tcp
       protocol: TCP
       port: {{ include "cortx.data.confdPort" $ | int }}
-      targetPort: motr-confd-tcp
+      targetPort: confd-tcp
     {{- range $i := until (.Values.cortxdata.motr.numiosinst | int) }}
     {{- $portName := printf "ios-%d-tcp" (add 1 $i) }}
     - name: {{ $portName }}

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -210,7 +210,8 @@ spec:
             - name: data
               mountPath: {{ $.Values.cortxdata.localpathpvc.mountpath }}
           ports:
-          - containerPort: {{ printf "%d" (add $i $.Values.cortxdata.motr.startportnum) }}
+          - name: {{ printf "motr-ios-%03d-tcp" (add 1 $i) }}
+            containerPort: {{ printf "%d" (add $i (include "cortx.data.iosPort" $) | int) }}
           {{- if $.Values.cortxdata.motr.resources }}
           resources: {{- toYaml $.Values.cortxdata.motr.resources | nindent 12 }}
           {{- end }}

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -167,7 +167,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           ports:
-          - name: motr-confd-tcp
+          - name: confd-tcp
             containerPort: {{ include "cortx.data.confdPort" $ | int }}
           {{- if .Values.cortxdata.confd.resources }}
           resources: {{- toYaml .Values.cortxdata.confd.resources | nindent 12 }}

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -126,7 +126,7 @@ spec:
             containerPort: {{ .Values.hare.hax.ports.http.port | int }}
             protocol: TCP
           - name: hax-tcp
-            containerPort: 22001
+            containerPort: {{ include "cortx.hare.hax.tcpPort" . | int }}
             protocol: TCP
           {{- if .Values.hare.hax.resources }}
           resources: {{- toYaml .Values.hare.hax.resources | nindent 12 }}

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -211,7 +211,7 @@ spec:
             - name: data
               mountPath: {{ $.Values.cortxdata.localpathpvc.mountpath }}
           ports:
-          - name: {{ printf "motr-ios-%03d-tcp" (add 1 $i) }}
+          - name: {{ printf "ios-%d-tcp" (add 1 $i) }}
             containerPort: {{ printf "%d" (add $i (include "cortx.data.iosPort" $) | int) }}
           {{- if $.Values.cortxdata.motr.resources }}
           resources: {{- toYaml $.Values.cortxdata.motr.resources | nindent 12 }}

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -167,7 +167,8 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           ports:
-          - containerPort: {{ printf "%d" (add .Values.cortxdata.motr.numiosinst .Values.cortxdata.motr.startportnum) }}
+          - name: motr-confd-tcp
+            containerPort: {{ include "cortx.data.confdPort" $ | int }}
           {{- if .Values.cortxdata.confd.resources }}
           resources: {{- toYaml .Values.cortxdata.confd.resources | nindent 12 }}
           {{- end }}

--- a/charts/cortx/templates/server/statefulset.yaml
+++ b/charts/cortx/templates/server/statefulset.yaml
@@ -140,7 +140,7 @@ spec:
             containerPort: {{ .Values.hare.hax.ports.http.port | int }}
             protocol: TCP
           - name: hax-tcp
-            containerPort: 22001
+            containerPort: {{ include "cortx.hare.hax.tcpPort" . | int }}
             protocol: TCP
           {{- if .Values.hare.hax.resources }}
           resources: {{- toYaml .Values.hare.hax.resources | nindent 12 }}

--- a/charts/cortx/templates/server/statefulset.yaml
+++ b/charts/cortx/templates/server/statefulset.yaml
@@ -104,6 +104,9 @@ spec:
           - name: rgw-https
             containerPort: 23001
             protocol: TCP
+          - name: motr-client
+            containerPort: {{ include "cortx.server.motrClientPort" . | int }}
+            protocol: TCP
           resources: {{- toYaml .Values.cortxserver.rgw.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/cortx/templates/server/statefulset.yaml
+++ b/charts/cortx/templates/server/statefulset.yaml
@@ -99,10 +99,10 @@ spec:
                 fieldPath: metadata.name
           ports:
           - name: rgw-http
-            containerPort: 22751
+            containerPort: {{ include "cortx.server.rgwHttpPort" . | int }}
             protocol: TCP
           - name: rgw-https
-            containerPort: 23001
+            containerPort: {{ include "cortx.server.rgwHttpsPort" . | int }}
             protocol: TCP
           - name: motr-client
             containerPort: {{ include "cortx.server.motrClientPort" . | int }}

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -251,7 +251,7 @@ cortxcontrol:
       enabled: true
       type: NodePort
       ports:
-        https: 23256
+        https: 8081
       nodePorts:
         https: ""
   cfgmap:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -369,7 +369,6 @@ cortxdata:
     accessModes:
     - ReadWriteMany
   motr:
-    startportnum: 29000
     numiosinst: 1
     resources:
       requests:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -176,14 +176,12 @@ configmap:
 
   # cortxHare allows configuring CORTX HARE settings
   cortxHare:
-    haxServerEndpoints: []
     haxClientEndpoints: []
 
   # cortxMotr allows configuring CORTX MOTR settings
   cortxMotr:
     clientInstanceCount: 0
     clientEndpoints: []
-    rgwEndpoints: []
     # An optional multi-line string that contains extra Motr configuration
     # settings. The string may contain template expressions, and is appended to
     # the end of the computed configuration.
@@ -234,10 +232,6 @@ platform:
     cortxData:
       podNameLabel: cortx-data
 
-  storage:
-    localBlock:
-      storageClassName: "cortx-local-block-storage"
-
 ##
 ## Imported values from cortx-control Helm Chart. These will be changed.
 ##
@@ -257,7 +251,7 @@ cortxcontrol:
       enabled: true
       type: NodePort
       ports:
-        https: 8081
+        https: 23256
       nodePorts:
         https: ""
   cfgmap:

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -53,7 +53,7 @@ solution:
       control:
         type: NodePort
         ports:
-          https: 8081
+          https: 23256
         nodePorts:
           https: null
     resource_allocation:

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -53,7 +53,7 @@ solution:
       control:
         type: NodePort
         ports:
-          https: 23256
+          https: 8081
         nodePorts:
           https: null
     resource_allocation:


### PR DESCRIPTION
## Description

Various Helm Chart improvements.

- Remove generation of Server endpoints from deploy script. This is done in the Helm templates now.
- Update all port definitions:
  - Port numbers to match the current [sample file](https://github.com/Seagate/cortx-prvsnr/blob/1c0926ec0171eddf761bdaae13c91a4f336c288b/conf/solution/config.yaml.sample) and [Ports page](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/791216223/CORTX+Security+Ports+needed+by+CORTX+services).
  - Use templates to define the numbers in a single location
  - Add names to all containerPorts, and use in related services
- Simplify local block storage class naming

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-30147

## How was this tested?

Deploy/destroy cluster, run util scripts, S3 I/O, CSM API requests.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-30147_endpoint-cleanup/charts/cortx/README.md)