### PR TITLE
CORTX-32320: Update docs for upgrade to clarify how images are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,36 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
 
 > :information_source: As the CORTX on Kubernetes architecture is evolving, the upgrade path for CORTX on Kubernetes is evolving as well. As a workaround until more foundational upgrade capabilities exist, the following steps are available to manually upgrade your CORTX on Kubernetes environment to a more recent release.
 
-1. Deploy CORTX on Kubernetes according to the [Deploying CORTX on Kubernetes](#deploying-cortx-on-kubernetes) steps above.
+This upgrade process updates all containers in all CORTX pods to the new specified image.
 
-2. Run the upgrade script to patch the CORTX on Kubernetes deployments using an updated image _(:information_source: You will want to update the `TARGET_IMAGE` variable below to your desired image tag)_. The script will stop all CORTX Pods, update the Deployments and StatefulSets, and then re-start the Pods.
+To upgrade a previously deployed CORTX cluster, run the `upgrade-cortx-cloud.sh` script to patch the CORTX on Kubernetes deployments using an updated image _(:information_source: You will want to update the `TARGET_IMAGE` variable below to your desired image tag)_. The script will stop all CORTX Pods, update the Deployments and StatefulSets, and then re-start the Pods.
+
+Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image ghcr.io/seagate/cortx-data:2.0.0-790 is specified, the:
+* ghcr.io/seagate/cortx-data:2.0.0-834 will be applied to the cortx-data containers
+* ghcr.io/seagate/cortx-rgw:2.0.0-834 will be applied to the cortx-server containers
+* ghcr.io/seagate/cortx-control:2.0.0-834 will be applied to the cortx-control and cortx-ha containers
+
 
    ```bash
-   TARGET_IMAGE="ghcr.io/seagate/cortx-data:2.0.0-790"
+   TARGET_IMAGE="ghcr.io/seagate/cortx-data:2.0.0-834"
    ./upgrade-cortx-cloud.sh -s solution.yaml -i $TARGET_IMAGE
    ```
+
+To update the image for a specific CORTX deployment or statefulset use `kubectl set image`:
+```bash
+# Update image on all containers in a cortx-data statefulset
+kubectl set image --namespace=${NAMESPACE} statefulset cortx-data '*=ghcr.io/seagate/cortx-data:2.0.0-834'
+
+# Update image on all containers in a cortx-server statefulset
+kubectl set image --namespace=${NAMESPACE} statefulset cortx-server '*=ghcr.io/seagate/cortx-rgw:2.0.0-834'
+
+# Update image on all containers in a cortx-control deployment
+kubectl set image --namespace=${NAMESPACE} deployment cortx-control '*=ghcr.io/seagate/cortx-control:2.0.0-834'
+
+# Update image on all containers in a cortx-ha deployment
+kubectl set image --namespace=${NAMESPACE} deployment cortx-ha '*=ghcr.io/seagate/cortx-control:2.0.0-834'
+```
+
 
 ### Using CORTX on Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To upgrade a previously deployed CORTX cluster, run the `upgrade-cortx-cloud.sh`
 
 Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image ghcr.io/seagate/cortx-data:2.0.0-834 is specified, then:
 
-- ghcr.io/seagate/cortx-data:2.0.0-834 will be applied to the cortx-data containers
+- ghcr.io/seagate/cortx-data:2.0.0-834 will be applied to the cortx-data and cortx-client containers
 - ghcr.io/seagate/cortx-rgw:2.0.0-834 will be applied to the cortx-server containers
 - ghcr.io/seagate/cortx-control:2.0.0-834 will be applied to the cortx-control and cortx-ha containers
 

--- a/README.md
+++ b/README.md
@@ -188,14 +188,14 @@ To upgrade a previously deployed CORTX cluster, run the `upgrade-cortx-cloud.sh`
    ./upgrade-cortx-cloud.sh -s solution.yaml -i $TARGET_IMAGE
    ```
 
-Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image ghcr.io/seagate/cortx-data:2.0.0-790 is specified, then:
+Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image ghcr.io/seagate/cortx-data:2.0.0-834 is specified, then:
 
 - ghcr.io/seagate/cortx-data:2.0.0-834 will be applied to the cortx-data containers
 - ghcr.io/seagate/cortx-rgw:2.0.0-834 will be applied to the cortx-server containers
 - ghcr.io/seagate/cortx-control:2.0.0-834 will be applied to the cortx-control and cortx-ha containers
 
 
-To update the image for a specific CORTX deployment or statefulset use `kubectl set image`:
+To update the image for a specific CORTX Deployment or StatefulSet use `kubectl set image`:
 ```bash
 # Update image on all containers in a cortx-data statefulset
 kubectl set image --namespace=${NAMESPACE} statefulset cortx-data '*=ghcr.io/seagate/cortx-data:2.0.0-834'

--- a/README.md
+++ b/README.md
@@ -183,16 +183,17 @@ This upgrade process updates all containers in all CORTX pods to the new specifi
 
 To upgrade a previously deployed CORTX cluster, run the `upgrade-cortx-cloud.sh` script to patch the CORTX on Kubernetes deployments using an updated image _(:information_source: You will want to update the `TARGET_IMAGE` variable below to your desired image tag)_. The script will stop all CORTX Pods, update the Deployments and StatefulSets, and then re-start the Pods.
 
-Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image ghcr.io/seagate/cortx-data:2.0.0-790 is specified, the:
-* ghcr.io/seagate/cortx-data:2.0.0-834 will be applied to the cortx-data containers
-* ghcr.io/seagate/cortx-rgw:2.0.0-834 will be applied to the cortx-server containers
-* ghcr.io/seagate/cortx-control:2.0.0-834 will be applied to the cortx-control and cortx-ha containers
-
-
    ```bash
    TARGET_IMAGE="ghcr.io/seagate/cortx-data:2.0.0-834"
    ./upgrade-cortx-cloud.sh -s solution.yaml -i $TARGET_IMAGE
    ```
+
+Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image ghcr.io/seagate/cortx-data:2.0.0-790 is specified, then:
+
+- ghcr.io/seagate/cortx-data:2.0.0-834 will be applied to the cortx-data containers
+- ghcr.io/seagate/cortx-rgw:2.0.0-834 will be applied to the cortx-server containers
+- ghcr.io/seagate/cortx-control:2.0.0-834 will be applied to the cortx-control and cortx-ha containers
+
 
 To update the image for a specific CORTX deployment or statefulset use `kubectl set image`:
 ```bash

--- a/k8_cortx_cloud/upgrade-cortx-cloud.sh
+++ b/k8_cortx_cloud/upgrade-cortx-cloud.sh
@@ -53,11 +53,11 @@ Usage:
 Options:
     -h              Prints help information.
     -i <IMAGE>      REQUIRED. The name of the container image to upgrade to.
-                    This image may be any of the three CORTX Docker images
+                    This image may be any of the three CORTX container images
                     (cortx-data, cortx-rgw, cortx-control).  Specifying any
                     one of these images will pull all three images of the
                     same version and apply them to the appropriate
-                    deployments / statefulsets. 
+                    Deployments / StatefulSets. 
     -s <FILE>       The cluster solution configuration file. Can
                     also be set with the CORTX_SOLUTION_CONFIG_FILE
                     environment variable. Defaults to 'solution.yaml'.

--- a/k8_cortx_cloud/upgrade-cortx-cloud.sh
+++ b/k8_cortx_cloud/upgrade-cortx-cloud.sh
@@ -53,6 +53,11 @@ Usage:
 Options:
     -h              Prints help information.
     -i <IMAGE>      REQUIRED. The name of the container image to upgrade to.
+                    This image may be any of the three CORTX Docker images
+                    (cortx-data, cortx-rgw, cortx-control).  Specifying any
+                    one of these images will pull all three images of the
+                    same version and apply them to the appropriate
+                    deployments / statefulsets. 
     -s <FILE>       The cluster solution configuration file. Can
                     also be set with the CORTX_SOLUTION_CONFIG_FILE
                     environment variable. Defaults to 'solution.yaml'.


### PR DESCRIPTION

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
* Update README.md to explain that specifying any image causes all three CORTX images to be pulled.
* Update -h help for upgrade-cortx-cloud.sh to explain the same
* Update README.md to describe how to update a single deployment or statefulset only.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [x] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-32320

## CORTX image version requirements
N/A

## How was this tested?
* Documentation change only.
* Verified that commands specified in doc changes function as described (kubectl set image)

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [ ] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/walterlopatka/cortx-k8s/blob/CORTX-32320_update_upgrade_docs/README.md)