### PR TITLE
CORTX-31536: Bump CORTX version to 835

### DIFF
--- a/charts/cortx/Chart.yaml
+++ b/charts/cortx/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.0-825
+appVersion: 2.0.0-835
 dependencies:
   - condition: consul.enabled
     name: consul

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -1,6 +1,6 @@
 # cortx
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-825](https://img.shields.io/badge/AppVersion-2.0.0--825-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-835](https://img.shields.io/badge/AppVersion-2.0.0--835-informational?style=flat-square)
 
 CORTX is a distributed object storage system designed for great efficiency, massive capacity, and high HDD-utilization.
 

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -11,11 +11,11 @@ solution:
       csm_auth_admin_secret: null
       csm_mgmt_admin_secret: null
   images:
-    cortxcontrol: ghcr.io/seagate/cortx-control:2.0.0-825
-    cortxdata: ghcr.io/seagate/cortx-data:2.0.0-825
-    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-825
-    cortxha: ghcr.io/seagate/cortx-control:2.0.0-825
-    cortxclient: ghcr.io/seagate/cortx-data:2.0.0-825
+    cortxcontrol: ghcr.io/seagate/cortx-control:2.0.0-835
+    cortxdata: ghcr.io/seagate/cortx-data:2.0.0-835
+    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-835
+    cortxha: ghcr.io/seagate/cortx-control:2.0.0-835
+    cortxclient: ghcr.io/seagate/cortx-data:2.0.0-835
     consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r97
     zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9


### PR DESCRIPTION
## Description

Update CORTX images to build 835.

This includes a fix for CORTX-31536 to address Control and HA Pod init hangs.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-31536

## CORTX image version requirements

This change requires the following images:

- `cortx-data:2.0.0-835`
- `cortx-rgw:2.0.0-835`
- `cortx-control:2.0.0-835`

## How was this tested?

Successful deployment, then S3 I/O and some CSM API requests.

I would like to test this further with a loop of the Control Pod itself. The HA Pod still might have some issues. Otherwise, it's good to get this in use generally.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [X] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [X] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
