### PR TITLE
ConfigMap updates, add Client helper script

### DIFF
--- a/charts/cortx/templates/client/scripts-configmap.yaml
+++ b/charts/cortx/templates/client/scripts-configmap.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.cortxclient.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cortx.client.fullname" . }}-scripts
+  labels: {{- include "cortx.labels" . | nindent 4 }}
+data:
+  motr-env.sh: |-
+    #!/bin/bash
+
+    machine_id="$(< /etc/machine-id)"
+    fid="$(hctl fetch-fids --conf-dir "/etc/cortx/hare/config/${machine_id}" --service motr_client --index $((CLIENT_INDEX-1)) --json | jq -r .fid)"
+    if (( $? != 0 )); then
+        echo "Error running 'hctl fetch-fids'"
+        return
+    fi
+
+    . "/etc/cortx/motr_client/sysconfig/${machine_id}/motr_client-${fid}"
+    export MOTR_PROFILE_FID MOTR_CLIENT_EP MOTR_HA_EP MOTR_PROCESS_FID
+
+    m0shim() {
+        local cmd="$1"
+        shift
+
+        local args=()
+        case "$cmd" in
+            m0cat | m0client | m0cp | m0cp_mt | m0touch | m0trunc)
+                args+=(--local "${MOTR_CLIENT_EP}" --ha "${MOTR_HA_EP}" --profile "${MOTR_PROFILE_FID}" --process "${MOTR_PROCESS_FID}")
+                ;;
+            m0kv)
+                args+=(-l "${MOTR_CLIENT_EP}" -h "${MOTR_HA_EP}" -p "${MOTR_PROFILE_FID}" -f "${MOTR_PROCESS_FID}")
+                ;;
+            *)
+                echo "Unsupported m0 command"
+                return 1
+                ;;
+        esac
+
+        "${cmd}" "${args[@]}" "$@"
+    }
+{{- end }}

--- a/charts/cortx/templates/client/statefulset.yaml
+++ b/charts/cortx/templates/client/statefulset.yaml
@@ -38,6 +38,10 @@ spec:
             secretName: {{ .Values.configmap.cortxSecretName }}
         - name: data
           emptyDir: {}
+        - name: scripts
+          configMap:
+            name: {{ printf "%s-scripts" (include "cortx.client.fullname" .) }}
+            defaultMode: 0755
       initContainers:
       - name: cortx-setup
         image: {{ .Values.cortxclient.image }}
@@ -131,6 +135,9 @@ spec:
               mountPath: {{ $.Values.cortxclient.sslcfgmap.mountpath }}
             - name: data
               mountPath: {{ $.Values.cortxclient.localpathpvc.mountpath }}
+            - name: scripts
+              mountPath: /scripts/motr-env.sh
+              subPath: motr-env.sh
           env:
             - name: CLIENT_INDEX
               value: {{ printf "%d" (add 1 $i) | quote }}

--- a/charts/cortx/templates/data/scripts-configmap.yaml
+++ b/charts/cortx/templates/data/scripts-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cortx.data.fullname" . }}-node
+  name: {{ include "cortx.data.fullname" . }}-scripts
   labels: {{- include "cortx.labels" . | nindent 4 }}
 data:
   entrypoint.sh: |-

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -38,10 +38,10 @@ spec:
         - name: {{ .Values.configmap.cortxSecretName }}
           secret:
             secretName: {{ .Values.configmap.cortxSecretName }}
-        - name: node-config
+        - name: scripts
           configMap:
             defaultMode: 0700
-            name: {{ include "cortx.data.fullname" . }}-node
+            name: {{ include "cortx.data.fullname" . }}-scripts
       initContainers:
       - name: node-config
         image: {{ .Values.cortxdata.image }}
@@ -49,7 +49,7 @@ spec:
         command:
           - /nodeconfig/entrypoint.sh
         volumeMounts:
-        - name: node-config
+        - name: scripts
           mountPath: /nodeconfig
           readOnly: true
         securityContext:


### PR DESCRIPTION
## Description

When testing previous Client chart changes, I ran into some difficulty figuring out how to use the client commands. I received some help, and thought it would be useful to distill that learning and make it easier to for others use for debugging purposes.

This PR does two things, first it renames some ConfigMaps to indicate that they contain helper scripts.

The second and main change, is to add a helper script for use within Client containers to run m0* commands. Here's example usage:

```text
❯ kubectl exec -it cortx-client-0 -c cortx-motr-client-001 -- /bin/bash
[root@cortx-client-0 /]# . /scripts/motr-env.sh
[root@cortx-client-0 /]# env | grep ^MOTR
MOTR_PROFILE_FID=0x7000000000000001:0x0
MOTR_PROCESS_FID=0x7200000000000001:0xc
MOTR_CLIENT_EP=inet:tcp:cortx-client-0.cortx-client-headless.cortx.svc.cluster.local@21501
MOTR_HA_EP=inet:tcp:cortx-client-0.cortx-client-headless.cortx.svc.cluster.local@22001
[root@cortx-client-0 /]# dd if=/dev/urandom of=/tmp/128M bs=1M count=128
128+0 records in
128+0 records out
134217728 bytes (134 MB, 128 MiB) copied, 1.12547 s, 119 MB/s
[root@cortx-client-0 /]# m0shim m0cp --object 12:34 --block-size 1m --block-count 16 --layout-id 9 /tmp/128M
[root@cortx-client-0 /]# m0shim m0cp --object 12:34 --block-size 1m --block-count 16 --layout-id 9 /tmp/128M
Object 12:34 already exists: rc=-17. To update an existing object, use -u=start index.
[root@cortx-client-0 /]# m0shim m0mkfs --help
Unsupported m0 command
```

First, you `exec` into one of the Client containers. Each container has an "index" environment variable, which designates which client it is in relation to the Motr configuration. The script fetches information about the client (using `hctl fetch-fids`) and stores them in environment variables. When sourcing the script, it will export those env vars, and provide a `m0shim` bash function. This function allows the calling of a select handful of m0* commands and automatically sets some required command line arguments. I picked the commands that looked interesting, but I don't have much practical experience with them.

## Breaking change
<!--
If this change introduces any breaking changes, describe what it breaks and what action is required
to address it. We prefer deprecating things first before breaking them entirely. If you are unable
to support deprecation in this change, or are actually removing the deprecated the item, please
state so.

You can delete this section if there are no breaking changes.
-->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: 

## How was this tested?

See usage example above.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
