### PR TITLE
CORTX-28584: Add missing common selector labels

### DIFF
--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels:
+    matchLabels: {{- include "cortx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: control
   template:
     metadata:

--- a/charts/cortx/templates/control/service.yaml
+++ b/charts/cortx/templates/control/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: control
 spec:
   type: {{ $svc.type }}
-  selector:
+  selector: {{- include "cortx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: control
   ports:
     {{- $nodePortAllowed := or (eq $svc.type "NodePort") (eq $svc.type "LoadBalancer") }}

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels:
+    matchLabels: {{- include "cortx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: ha
   template:
     metadata:

--- a/charts/cortx/templates/ha/service-headless.yaml
+++ b/charts/cortx/templates/ha/service-headless.yaml
@@ -10,6 +10,6 @@ spec:
   type: ClusterIP
   clusterIP: None
   publishNotReadyAddresses: true
-  selector:
+  selector: {{- include "cortx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: ha
 {{- end }}

--- a/charts/cortx/templates/hax/service.yaml
+++ b/charts/cortx/templates/hax/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{ include "cortx.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
-  selector:
+  selector: {{- include "cortx.selectorLabels" . | nindent 4 }}
     cortx.io/hax-enabled: "true"
   ports:
     - name: hax-http

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -402,7 +402,7 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get services --namespace="${namespace}" --no-headers cortx-server-headless)
+done < <(kubectl get services --namespace="${namespace}" --selector=${server_selector} --no-headers | grep -- -headless)
 
 if [[ ${expected_count} -eq ${count} ]]; then
     msg_overall_passed
@@ -427,7 +427,7 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get services --namespace="${namespace}" --no-headers -l ${server_selector} | grep -v ^cortx-server-headless)
+done < <(kubectl get services --namespace="${namespace}" --no-headers -l ${server_selector} | grep -v -- -headless)
 
 if (( count >= expected_count &&  count <= max_count )); then
     msg_overall_passed
@@ -758,7 +758,7 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get services --namespace="${namespace}" --selector=${kafka_selector} --no-headers | grep -v cortx-kafka-headless)
+done < <(kubectl get services --namespace="${namespace}" --selector=${kafka_selector} --no-headers | grep -v -- -kafka-headless)
 
 if [[ ${num_items} -eq ${count} ]]; then
     msg_overall_passed
@@ -781,7 +781,7 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get services --namespace="${namespace}" --selector=${kafka_selector} --no-headers | grep cortx-kafka-headless)
+done < <(kubectl get services --namespace="${namespace}" --selector=${kafka_selector} --no-headers | grep -- -kafka-headless)
 
 if [[ ${num_items} -eq ${count} ]]; then
     msg_overall_passed
@@ -889,7 +889,7 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get services --namespace="${namespace}" --selector=${zookeeper_selector} --no-headers | grep -v cortx-zookeeper-headless)
+done < <(kubectl get services --namespace="${namespace}" --selector=${zookeeper_selector} --no-headers | grep -v -- -zookeeper-headless)
 
 if [[ ${num_items} -eq ${count} ]]; then
     msg_overall_passed
@@ -912,7 +912,7 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get services --namespace="${namespace}" --selector=${zookeeper_selector} --no-headers | grep cortx-zookeeper-headless)
+done < <(kubectl get services --namespace="${namespace}" --selector=${zookeeper_selector} --no-headers | grep -- -zookeeper-headless)
 
 if [[ ${num_items} -eq ${count} ]]; then
     msg_overall_passed


### PR DESCRIPTION
## Description

Add common selector/match labels to resources that are missing them. This ensures those resources are matched to the ones installed by the Helm Chart and the specific Release instance.

Also updated a few checks in the the status script to rely less on a hard-coded chart Release name.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-28584

## How was this tested?

Deployment, status, and other scripts. S3 I/O, CSM API requests.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
