### PR TITLE
CORTX-30147: Upgrade script should work with StatefulSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,32 +184,34 @@ This upgrade process updates all containers in all CORTX pods to the new specifi
 To upgrade a previously deployed CORTX cluster, run the `upgrade-cortx-cloud.sh` script to patch the CORTX on Kubernetes deployments using an updated image _(:information_source: You will want to update the `TARGET_IMAGE` variable below to your desired image tag)_. The script will stop all CORTX Pods, update the Deployments and StatefulSets, and then re-start the Pods.
 
    ```bash
-   TARGET_IMAGE="ghcr.io/seagate/cortx-data:2.0.0-834"
+   TARGET_IMAGE="ghcr.io/seagate/cortx-data:2.0.0-835"
    ./upgrade-cortx-cloud.sh -s solution.yaml -i $TARGET_IMAGE
    ```
 
-Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image ghcr.io/seagate/cortx-data:2.0.0-834 is specified, then:
+Note: There are three separate CORTX images (cortx-data, cortx-rgw, and cortx-control).  By specifying any one of these images, all images will be updated to that same version.  For example, if the image `ghcr.io/seagate/cortx-data:2.0.0-835` is specified, then:
 
-- ghcr.io/seagate/cortx-data:2.0.0-834 will be applied to the cortx-data and cortx-client containers
-- ghcr.io/seagate/cortx-rgw:2.0.0-834 will be applied to the cortx-server containers
-- ghcr.io/seagate/cortx-control:2.0.0-834 will be applied to the cortx-control and cortx-ha containers
-
+- `ghcr.io/seagate/cortx-data:2.0.0-835` will be applied to the cortx-data and cortx-client containers
+- `ghcr.io/seagate/cortx-rgw:2.0.0-835` will be applied to the cortx-server containers
+- `ghcr.io/seagate/cortx-control:2.0.0-835` will be applied to the cortx-control and cortx-ha containers
 
 To update the image for a specific CORTX Deployment or StatefulSet use `kubectl set image`:
+
 ```bash
 # Update image on all containers in a cortx-data statefulset
-kubectl set image --namespace=${NAMESPACE} statefulset cortx-data '*=ghcr.io/seagate/cortx-data:2.0.0-834'
+kubectl set image --namespace=${NAMESPACE} statefulset cortx-data '*=ghcr.io/seagate/cortx-data:2.0.0-835'
 
 # Update image on all containers in a cortx-server statefulset
-kubectl set image --namespace=${NAMESPACE} statefulset cortx-server '*=ghcr.io/seagate/cortx-rgw:2.0.0-834'
+kubectl set image --namespace=${NAMESPACE} statefulset cortx-server '*=ghcr.io/seagate/cortx-rgw:2.0.0-835'
 
 # Update image on all containers in a cortx-control deployment
-kubectl set image --namespace=${NAMESPACE} deployment cortx-control '*=ghcr.io/seagate/cortx-control:2.0.0-834'
+kubectl set image --namespace=${NAMESPACE} deployment cortx-control '*=ghcr.io/seagate/cortx-control:2.0.0-835'
 
 # Update image on all containers in a cortx-ha deployment
-kubectl set image --namespace=${NAMESPACE} deployment cortx-ha '*=ghcr.io/seagate/cortx-control:2.0.0-834'
-```
+kubectl set image --namespace=${NAMESPACE} deployment cortx-ha '*=ghcr.io/seagate/cortx-control:2.0.0-835'
 
+# Update image on all containers in a cortx-client statefulset
+kubectl set image --namespace=${NAMESPACE} statefulset cortx-client '*=ghcr.io/seagate/cortx-client:2.0.0-835'
+```
 
 ### Using CORTX on Kubernetes
 

--- a/k8_cortx_cloud/upgrade-cortx-cloud.sh
+++ b/k8_cortx_cloud/upgrade-cortx-cloud.sh
@@ -57,7 +57,7 @@ Options:
                     (cortx-data, cortx-rgw, cortx-control).  Specifying any
                     one of these images will pull all three images of the
                     same version and apply them to the appropriate
-                    Deployments / StatefulSets. 
+                    Deployments / StatefulSets.
     -s <FILE>       The cluster solution configuration file. Can
                     also be set with the CORTX_SOLUTION_CONFIG_FILE
                     environment variable. Defaults to 'solution.yaml'.
@@ -120,7 +120,7 @@ printf "Using solution config file '%s'\n" "${SOLUTION_FILE}"
 pods_ready=true
 
 readonly cortx_pod_filter="cortx-control-\|cortx-data-\|cortx-ha-\|cortx-server-\|cortx-client-"
-readonly cortx_deployment_filter="cortx-control\|cortx-data-\|cortx-ha\|cortx-server\|cortx-client-"
+readonly cortx_deployment_filter="cortx-control\|cortx-data\|cortx-ha\|cortx-server\|cortx-client"
 
 printf "\n%s\n" "${CYAN-}Checking Pod readiness:${CLEAR-}"
 
@@ -175,19 +175,19 @@ else
     k8s_controller="deployment"
     while IFS= read -r deployment; do
         case "${deployment}" in
-        cortx-server-*) 
+        cortx-server)
             IMAGE="${RGW_IMAGE}"
             k8s_controller="statefulset"
             ;;
-        cortx-data-*|cortx-client-*)
+        cortx-data|cortx-client)
             IMAGE="${DATA_IMAGE}"
-            k8s_controller="deployment"
+            k8s_controller="statefulset"
             ;;
         cortx-control|cortx-ha)
             IMAGE="${CONTROL_IMAGE}"
             k8s_controller="deployment"
             ;;
-        *) 
+        *)
             printf "NO MATCH FOR %s.  Skipping upgrade of image.\n" "${deployment}"
             continue
             ;;


### PR DESCRIPTION
## Description

The upgrade script wasn't fixed to handle changes from Deployment to StatefulSet, so this change does that.

<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-30147

## How was this tested?

Ran an upgrade. All images are seen to be updated. Basically:

```
# Deploy cluster

# check images
❯ kubectl get deployments,statefulset -l app.kubernetes.io/name=cortx --namespace="${NAMESPACE}" --output=jsonpath="{range .items[*]}{.metadata.name} => {.spec.template.spec.containers[0].image}{'\n'}{end}"
cortx-control => ghcr.io/seagate/cortx-control:2.0.0-835
cortx-ha => ghcr.io/seagate/cortx-control:2.0.0-835
cortx-client => ghcr.io/seagate/cortx-data:2.0.0-835
cortx-data => ghcr.io/seagate/cortx-data:2.0.0-835
cortx-server => ghcr.io/seagate/cortx-rgw:2.0.0-835

# upgrade
./upgrade-cortx-cloud.sh -i ghcr.io/seagate/cortx-data:2.0.0-836 -s ~/src/centos.yaml

# check images
❯ kubectl get deployments,statefulset -l app.kubernetes.io/name=cortx --namespace="${NAMESPACE}" --output=jsonpath="{range .items[*]}{.metadata.name} => {.spec.template.spec.containers[0].image}{'\n'}{end}"
cortx-control => ghcr.io/seagate/cortx-control:2.0.0-836
cortx-ha => ghcr.io/seagate/cortx-control:2.0.0-836
cortx-client => ghcr.io/seagate/cortx-data:2.0.0-836
cortx-data => ghcr.io/seagate/cortx-data:2.0.0-836
cortx-server => ghcr.io/seagate/cortx-rgw:2.0.0-836
```

## Additional information

Update README to include manual upgrade of Client resources. I also bumped the referenced version to the latest supported. I don't think it's necessary for every image change, but I was editing it so why not.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
