### PR TITLE
CORTX-30147: Rename Control service

### DIFF
--- a/charts/cortx/templates/control/service.yaml
+++ b/charts/cortx/templates/control/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cortx.control.fullname" . }}-loadbal-svc
+  name: {{ include "cortx.control.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "cortx.labels" . | nindent 4 }}
     app.kubernetes.io/component: control
@@ -15,10 +15,30 @@ spec:
   ports:
     {{- $nodePortAllowed := or (eq $svc.type "NodePort") (eq $svc.type "LoadBalancer") }}
     - name: control-https
+      protocol: TCP
       port: {{ $svc.ports.https }}
       targetPort: control-https
       {{- if and $nodePortAllowed (not (empty $svc.nodePorts.https)) }}
       nodePort: {{ $svc.nodePorts.https }}
       {{- end }}
+---
+# This service is deprecated and will be removed in a future release
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cortx.control.fullname" . }}-loadbal-svc
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "cortx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control
+    cortx.io/deprecated: "true"
+spec:
+  type: ClusterIP
+  selector: {{- include "cortx.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: control
+  ports:
+    - name: control-https
+      protocol: TCP
+      port: {{ $svc.ports.https }}
+      targetPort: control-https
 {{- end }}
 {{- end }}

--- a/charts/cortx/templates/hax/service.yaml
+++ b/charts/cortx/templates/hax/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "cortx.hare.hax.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "cortx.labels" . | nindent 4 }}
+  labels: {{- include "cortx.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   selector: {{- include "cortx.selectorLabels" . | nindent 4 }}

--- a/charts/cortx/templates/server/service.yaml
+++ b/charts/cortx/templates/server/service.yaml
@@ -12,7 +12,7 @@ kind: Service
 metadata:
   name: {{ printf "%s-%d" (include "cortx.server.fullname" $root) $i }}
   namespace: {{ $root.Release.Namespace }}
-  labels: {{ include "cortx.labels" $ | nindent 4 }}
+  labels: {{- include "cortx.labels" $ | nindent 4 }}
     app.kubernetes.io/component: server
 spec:
   type: {{ $svc.type }}
@@ -41,8 +41,9 @@ kind: Service
 metadata:
   name: {{ printf "cortx-io-svc-%d" $i | trunc 63 | trimSuffix "-" }}
   namespace: {{ $root.Release.Namespace }}
-  labels:
+  labels: {{- include "cortx.labels" $ | nindent 4 }}
     app.kubernetes.io/component: server
+    cortx.io/deprecated: "true"
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" $isLB }}
   selector: {{- include "cortx.selectorLabels" $ | nindent 4 }}

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -846,7 +846,7 @@ cleanup
 #       way of getting the values otherwise.
 data_service_name="cortx-server-0"  # present in cortx values.yaml... what to do?
 data_service_default_user="$(extractBlock 'solution.common.s3.default_iam_users.auth_admin' || true)"
-control_service_name="cortx-control-loadbal-svc"  # hard coded in script above installing help or cortx-control
+control_service_name="cortx-control"  # hard coded in script above installing help or cortx-control
 control_service_default_user="cortxadmin" #hard coded in cortx-configmap/templates/_config.tpl
 
 cat << EOF

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -127,15 +127,17 @@ else
     failcount=$((failcount+1))
 fi
 
-# Check services load balancer
+readonly exclude_deprecated_selector="cortx.io/deprecated!=true"  # exclude deprecated service
+
+# Check services
 count=0
-msg_info "| Checking Services: cortx-control-loadbal-svc |"
+msg_info "| Checking Services: cortx-control |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
     printf "%s..." "${status[0]}"
     msg_passed
     count=$((count+1))
-done < <(kubectl get services --namespace="${namespace}" --selector=${control_selector} --no-headers)
+done < <(kubectl get services --namespace="${namespace}" --selector=${control_selector},${exclude_deprecated_selector} --no-headers)
 
 if [[ ${expected_count} -eq ${count} ]]; then
     msg_overall_passed
@@ -427,9 +429,9 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get services --namespace="${namespace}" --no-headers -l ${server_selector} | grep -v -- -headless)
+done < <(kubectl get services --namespace="${namespace}" --no-headers --selector ${server_selector},${exclude_deprecated_selector} | grep -v -- -headless)
 
-if (( count >= expected_count &&  count <= max_count )); then
+if (( count >= expected_count && count <= max_count )); then
     msg_overall_passed
 else
     msg_overall_failed


### PR DESCRIPTION
## Description

As was done with other services, the Control service has now been renamed using the standard convention, which is the name of the component. The previous service is considered deprecated, still exists, but will be removed in the future. The type of the deprecated one is now ClusterIP, and the new service uses the user specified type.

## Breaking change

No, but in a future release the deprecated service will be removed. This is not a breaking change either, unless users are referencing the service name somewhere else. Nothing in the default deployment uses the old service name.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-30147

## How was this tested?

Deply/destroy cluster. Run status script, S3 I/O and CSM API requests.

Deleted deprecated services and status script reported success.

Deleted non-deprecated services and status script reported failure.

## Additional information

Set the `cortx.io/deprecated` label to these services to help with the status script (to ignore these when checking).

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
