### PR TITLE
CORTX-32157: Remove CORTX version field from Chart

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -83,7 +83,6 @@ helm uninstall cortx
 | configmap.cortxStoragePaths.config | string | `"/etc/cortx"` |  |
 | configmap.cortxStoragePaths.local | string | `"/etc/cortx"` |  |
 | configmap.cortxStoragePaths.log | string | `"/etc/cortx/log"` |  |
-| configmap.cortxVersion | string | `"unknown"` |  |
 | consul.client.containerSecurityContext.client.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul client agent containers |
 | consul.enabled | bool | `true` | Enable installation of the Consul chart |
 | consul.server.containerSecurityContext.server.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul server agent containers |

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -52,7 +52,6 @@ cortx:
   common:
     release:
       name: CORTX
-      version: {{ .Values.configmap.cortxVersion }}
     service:
       admin: admin
       secret: common_admin_secret

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -139,12 +139,6 @@ configmap:
   # the exception of client UUIDs, which will not be configured if omitted.
   clusterStorageSets: {}
 
-  # cortxVersion is a version string representing the CORTX version being
-  # installed
-  # e.g.:
-  # cortxVersion: 2.0.0-624-custom-ci
-  cortxVersion: "unknown"
-
   # cortxStoragePaths allows configuring the location of CORTX filesystem paths
   cortxStoragePaths:
     local: "/etc/cortx"

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -203,12 +203,6 @@ buildValues() {
         | $to.configmap.cortxStoragePaths = $from.solution.common.container_path
         | $to' "${values_file}" "${solution_yaml}"
 
-    # shellcheck disable=SC2016
-    yq -i eval-all '
-        select(fi==0) ref $to | select(fi==1) ref $from
-        | $to.configmap.cortxVersion = ($from.solution.images.cortxdata | capture(".*?/.*:(?P<tag>.*)") | .tag)
-        | $to' "${values_file}" "${solution_yaml}"
-
     yq -i "
         .cortxserver.enabled = ${components[server]}
         | .cortxha.enabled = ${components[ha]}


### PR DESCRIPTION
## Description

Remove `cortx.common.release.version` from the generated `config.yaml` file. This simplifies the Chart deployment and reduces the amount of configuration required by users.

When the version is omitted, Provisioner sets a default value. It parses the `RELEASE.info` file located in the container image, which happens to also best represent the actual CORTX version. By not specifying the version, we take advantage of this default behavior, and remove the requirement for users to set it. There shouldn't be any reason a user would be required to set the version when the software already knows it.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32157

## How was this tested?

- Used current image 845 and a custom image
- Deployed and performed S3 I/O.
- Examined the generated config.yaml ConfigMap entry for correctness
- Viewed `cortx-setup` container logs and see the defaults being set
- Verified `/etc/cortx/cluster.conf` has the correct value

Images used:

```console
$ yq .solution.images ~/src/centos.yaml | grep ^cortx
cortxcontrol: cortx-docker.colo.seagate.com/seagate/cortx-control:2.0.0-7078-custom-ci
cortxdata: cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-7078-custom-ci
cortxserver: cortx-docker.colo.seagate.com/seagate/cortx-rgw:2.0.0-7078-custom-ci
cortxha: cortx-docker.colo.seagate.com/seagate/cortx-control:2.0.0-7078-custom-ci
cortxclient: cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-7078-custom-ci
```

Note the above is a custom image. The version would have previously been set incorrectly by the deployment script for custom images, but now it works.

A container log:

```text
2022-07-05 22:21:00 cortx_setup [43]: INFO [config_apply] Applying config yaml:///etc/cortx/solution/config.yaml
2022-07-05 22:21:00 cortx_setup [43]: WARNING [save] Release key cortx>common>release>version is missing or has incorrect value.
2022-07-05 22:21:00 cortx_setup [43]: INFO [save] Adding key "cortx>common>release>version" and value "2.0.0-7078" in confstore.
```

Checking the generated `cluster.conf` file:

```console
$ for x in deploy/cortx-{control,ha} statefulset/cortx-{client,server} statefulset/cortx-data-g{0,1}; do kubectl exec $x -- yq -c .cortx.common.release /etc/cortx/cluster.conf; done
Defaulted container "cortx-csm-agent" out of: cortx-csm-agent, cortx-setup (init)
{"name":"CORTX","version":"2.0.0-7078"}
Defaulted container "cortx-ha-fault-tolerance" out of: cortx-ha-fault-tolerance, cortx-ha-health-monitor, cortx-ha-k8s-monitor, cortx-setup (init)
{"name":"CORTX","version":"2.0.0-7078"}
Defaulted container "cortx-hax" out of: cortx-hax, cortx-motr-client-001, cortx-setup (init)
{"name":"CORTX","version":"2.0.0-7078"}
Defaulted container "cortx-rgw" out of: cortx-rgw, cortx-hax, cortx-setup (init)
{"name":"CORTX","version":"2.0.0-7078"}
Defaulted container "cortx-hax" out of: cortx-hax, cortx-motr-confd, cortx-motr-io-001, node-config (init), cortx-setup (init)
{"name":"CORTX","version":"2.0.0-7078"}
Defaulted container "cortx-hax" out of: cortx-hax, cortx-motr-confd, cortx-motr-io-001, node-config (init), cortx-setup (init)
{"name":"CORTX","version":"2.0.0-7078"}
```

## Additional information

I also noticed that setting `cortx.common.release.name` is pretty pointless, but left it in. We always hard-code it to `CORTX`. If you try to change it, Provisioner will complain and revert it back to `CORTX`. If you don't set it, Provisioner just sets it to the default of `CORTX`. I've left it in since it does print a warning message without it.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-32157_remove-version/charts/cortx/README.md)