### PR TITLE
CORTX-32157: Remove support for custom container paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,6 @@ This section contains common parameters that affect all CORTX components running
 | Name                                                  | Description                                                     | Default Value       |
 | ----------------------------------------------------- | --------------------------------------------------------------- | ------------------- |
 | `common.storage_provisioner_path`                     | TODO       | `/mnt/fs-local-volume` |
-| `common.container_path.local`                         | TODO       | `/etc/cortx` |
-| `common.container_path.log`                           | TODO       | `/etc/cortx/log` |
 | `common.s3.default_iam_users.auth_admin`              | Username for the default administrative user created for internal RGW interactions. Corresponds to `secrets.content.s3_auth_admin_secret` above. | `sgiamadmin` |
 | `common.s3.default_iam_users.auth_user`               | Username for the default user created for internal RGW interactions. Corresponds to `secrets.content.s3_auth_admin_secret` above. | `user_name` |
 | `common.s3.max_start_timeout`                         | TODO       | `240` |

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -80,38 +80,26 @@ helm uninstall cortx
 | configmap.cortxMotr.motr.resources.requests.memory | string | `"1Gi"` |  |
 | configmap.cortxSecretName | string | `"cortx-secret"` |  |
 | configmap.cortxSecretValues | object | `{}` |  |
-| configmap.cortxStoragePaths.config | string | `"/etc/cortx"` |  |
-| configmap.cortxStoragePaths.local | string | `"/etc/cortx"` |  |
-| configmap.cortxStoragePaths.log | string | `"/etc/cortx/log"` |  |
 | consul.client.containerSecurityContext.client.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul client agent containers |
 | consul.enabled | bool | `true` | Enable installation of the Consul chart |
 | consul.server.containerSecurityContext.server.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul server agent containers |
 | consul.ui.enabled | bool | `false` | Enable the Consul UI |
-| cortxclient.cfgmap.mountpath | string | `"/etc/cortx/solution"` |  |
 | cortxclient.enabled | bool | `false` |  |
 | cortxclient.image | string | `"ghcr.io/seagate/centos:7"` |  |
-| cortxclient.localpathpvc.mountpath | string | `"/etc/cortx"` |  |
 | cortxclient.motr.numclientinst | int | `1` |  |
 | cortxclient.replicas | int | `1` |  |
-| cortxclient.sslcfgmap.mountpath | string | `"/etc/cortx/solution/ssl"` |  |
 | cortxcontrol.agent.resources.limits.cpu | string | `"500m"` |  |
 | cortxcontrol.agent.resources.limits.memory | string | `"256Mi"` |  |
 | cortxcontrol.agent.resources.requests.cpu | string | `"250m"` |  |
 | cortxcontrol.agent.resources.requests.memory | string | `"128Mi"` |  |
-| cortxcontrol.cfgmap.mountpath | string | `"/etc/cortx/solution"` |  |
 | cortxcontrol.enabled | bool | `true` |  |
 | cortxcontrol.image | string | `"ghcr.io/seagate/centos:7"` |  |
-| cortxcontrol.localpathpvc.mountpath | string | `"/etc/cortx"` |  |
 | cortxcontrol.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
-| cortxcontrol.machineid.mountpath | string | `"/etc/cortx/solution/node"` |  |
 | cortxcontrol.machineid.value | string | `""` |  |
 | cortxcontrol.service.loadbal.enabled | bool | `true` |  |
 | cortxcontrol.service.loadbal.nodePorts.https | string | `""` |  |
 | cortxcontrol.service.loadbal.ports.https | int | `8081` |  |
 | cortxcontrol.service.loadbal.type | string | `"NodePort"` |  |
-| cortxcontrol.sslcfgmap.mountpath | string | `"/etc/cortx/solution/ssl"` |  |
-| cortxdata.cfgmap.mountpath | string | `"/etc/cortx/solution"` |  |
-| cortxdata.cfgmap.name | string | `"cortx"` |  |
 | cortxdata.confd.resources.limits.cpu | string | `"500m"` |  |
 | cortxdata.confd.resources.limits.memory | string | `"512Mi"` |  |
 | cortxdata.confd.resources.requests.cpu | string | `"250m"` |  |
@@ -119,7 +107,6 @@ helm uninstall cortx
 | cortxdata.cvgs | list | `[]` |  |
 | cortxdata.image | string | `"ghcr.io/seagate/centos:7"` |  |
 | cortxdata.localpathpvc.accessmodes[0] | string | `"ReadWriteOnce"` |  |
-| cortxdata.localpathpvc.mountpath | string | `"/etc/cortx"` |  |
 | cortxdata.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
 | cortxdata.motr.containerGroupSize | int | `1` | The number of Motr IO containers per CORTX Data Pod. As the number of CVGs increase, this value can be increased to reduce the number of total CORTX Data Pods per Kubernetes Worker Node. |
 | cortxdata.motr.resources.limits.cpu | string | `"1000m"` |  |
@@ -130,10 +117,7 @@ helm uninstall cortx
 | cortxdata.persistentStorage.accessModes[0] | string | `"ReadWriteMany"` |  |
 | cortxdata.persistentStorage.volumeMode | string | `"Block"` |  |
 | cortxdata.replicas | int | `3` |  |
-| cortxdata.sslcfgmap.mountpath | string | `"/etc/cortx/solution/ssl"` |  |
-| cortxdata.sslcfgmap.name | string | `"cortx-ssl-cert"` |  |
 | cortxdata.storageClassName | string | `"local-block-storage"` |  |
-| cortxha.cfgmap.mountpath | string | `"/etc/cortx/solution"` |  |
 | cortxha.enabled | bool | `true` |  |
 | cortxha.fault_tolerance.resources.limits.cpu | string | `"500m"` |  |
 | cortxha.fault_tolerance.resources.limits.memory | string | `"1Gi"` |  |
@@ -148,20 +132,15 @@ helm uninstall cortx
 | cortxha.k8s_monitor.resources.limits.memory | string | `"1Gi"` |  |
 | cortxha.k8s_monitor.resources.requests.cpu | string | `"250m"` |  |
 | cortxha.k8s_monitor.resources.requests.memory | string | `"128Mi"` |  |
-| cortxha.localpathpvc.mountpath | string | `"/etc/cortx"` |  |
 | cortxha.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
-| cortxha.machineid.mountpath | string | `"/etc/cortx/solution/node"` |  |
 | cortxha.machineid.value | string | `""` |  |
-| cortxha.sslcfgmap.mountpath | string | `"/etc/cortx/solution/ssl"` |  |
 | cortxserver.authAdmin | string | `"cortx-admin"` |  |
 | cortxserver.authSecret | string | `"s3_auth_admin_secret"` |  |
 | cortxserver.authUser | string | `"cortx-user"` |  |
-| cortxserver.cfgmap.mountpath | string | `"/etc/cortx/solution"` |  |
 | cortxserver.enabled | bool | `true` |  |
 | cortxserver.extraConfiguration | string | `""` |  |
 | cortxserver.image | string | `"ghcr.io/seagate/centos:7"` |  |
 | cortxserver.localpathpvc.accessmodes[0] | string | `"ReadWriteOnce"` |  |
-| cortxserver.localpathpvc.mountpath | string | `"/etc/cortx"` |  |
 | cortxserver.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
 | cortxserver.maxStartTimeout | int | `240` |  |
 | cortxserver.replicas | int | `3` |  |
@@ -175,7 +154,6 @@ helm uninstall cortx
 | cortxserver.service.ports.http | int | `80` |  |
 | cortxserver.service.ports.https | int | `443` |  |
 | cortxserver.service.type | string | `"ClusterIP"` |  |
-| cortxserver.sslcfgmap.mountpath | string | `"/etc/cortx/solution/ssl"` |  |
 | externalConsul.adminSecretName | string | `"consul_admin_secret"` |  |
 | externalConsul.adminUser | string | `"admin"` |  |
 | externalConsul.endpoints | list | `[]` |  |

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -55,7 +55,10 @@ cortx:
     service:
       admin: admin
       secret: common_admin_secret
-    storage: {{- toYaml .Values.configmap.cortxStoragePaths | nindent 6 }}
+    storage:
+      log: /etc/cortx/log
+      local: /etc/cortx
+      config: /etc/cortx
     security:
       ssl_certificate: /etc/cortx/solution/ssl/s3.seagate.com.pem
       domain_certificate: /etc/cortx/solution/ssl/stx.pem

--- a/charts/cortx/templates/client/statefulset.yaml
+++ b/charts/cortx/templates/client/statefulset.yaml
@@ -53,11 +53,11 @@ spec:
         {{- end }}
         volumeMounts:
           - name: cortx-configuration
-            mountPath: {{ .Values.cortxclient.cfgmap.mountpath }}
+            mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
-            mountPath: {{ .Values.cortxclient.sslcfgmap.mountpath }}
+            mountPath: /etc/cortx/solution/ssl
           - name: data
-            mountPath: {{ .Values.cortxclient.localpathpvc.mountpath }}
+            mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
             mountPath: /etc/cortx/solution/secret
             readOnly: true
@@ -85,11 +85,11 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ .Values.cortxclient.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ .Values.cortxclient.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             - name: data
-              mountPath: {{ .Values.cortxclient.localpathpvc.mountpath }}
+              mountPath: /etc/cortx
           env:
             - name: NODE_NAME
               valueFrom:
@@ -126,11 +126,11 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ $.Values.cortxclient.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ $.Values.cortxclient.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             - name: data
-              mountPath: {{ $.Values.cortxclient.localpathpvc.mountpath }}
+              mountPath: /etc/cortx
           env:
             - name: CLIENT_INDEX
               value: {{ printf "%d" (add 1 $i) | quote }}

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -37,7 +37,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.labels['cortx.io/machine-id']
         {{- end }}
-        - name: local-path-pv
+        - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.control.fullname" . }}
         - name: {{ .Values.configmap.cortxSecretName }}
@@ -64,15 +64,15 @@ spec:
         {{- end }}
         volumeMounts:
           - name: cortx-configuration
-            mountPath: {{ .Values.cortxcontrol.cfgmap.mountpath }}
+            mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
-            mountPath: {{ .Values.cortxcontrol.sslcfgmap.mountpath }}
+            mountPath: /etc/cortx/solution/ssl
           {{- if .Values.cortxcontrol.machineid.value }}
           - name: machine-id
-            mountPath: {{ .Values.cortxcontrol.machineid.mountpath }}
+            mountPath: /etc/cortx/solution/node
           {{- end }}
-          - name: local-path-pv
-            mountPath: {{ .Values.cortxcontrol.localpathpvc.mountpath }}
+          - name: data
+            mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
             mountPath: /etc/cortx/solution/secret
             readOnly: true
@@ -102,15 +102,15 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ .Values.cortxcontrol.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ .Values.cortxcontrol.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             {{- if .Values.cortxcontrol.machineid.value }}
             - name: machine-id
-              mountPath: {{ .Values.cortxcontrol.machineid.mountpath }}
+              mountPath: /etc/cortx/solution/node
             {{- end }}
-            - name: local-path-pv
-              mountPath: {{ .Values.cortxcontrol.localpathpvc.mountpath }}
+            - name: data
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -40,10 +40,10 @@ spec:
       volumes:
         - name: cortx-configuration
           configMap:
-            name: {{ $.Values.cortxdata.cfgmap.name }}
+            name: {{ include "cortx.configmapName" $ }}
         - name: cortx-ssl-cert
           configMap:
-            name: {{ $.Values.cortxdata.sslcfgmap.name }}
+            name: {{ include "cortx.tls.configmapName" $ }}
         - name: {{ $.Values.configmap.cortxSecretName }}
           secret:
             secretName: {{ $.Values.configmap.cortxSecretName }}
@@ -91,11 +91,11 @@ spec:
           {{- end }}
         volumeMounts:
           - name: cortx-configuration
-            mountPath: {{ $.Values.cortxdata.cfgmap.mountpath }}
+            mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
-            mountPath: {{ $.Values.cortxdata.sslcfgmap.mountpath }}
+            mountPath: /etc/cortx/solution/ssl
           - name: data
-            mountPath: {{ $.Values.cortxdata.localpathpvc.mountpath }}
+            mountPath: /etc/cortx
           - name: {{ $.Values.configmap.cortxSecretName }}
             mountPath: /etc/cortx/solution/secret
             readOnly: true
@@ -123,11 +123,11 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ $.Values.cortxdata.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ $.Values.cortxdata.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             - name: data
-              mountPath: {{ $.Values.cortxdata.localpathpvc.mountpath }}
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:
@@ -175,11 +175,11 @@ spec:
             {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ $.Values.cortxdata.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ $.Values.cortxdata.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             - name: data
-              mountPath: {{ $.Values.cortxdata.localpathpvc.mountpath }}
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:
@@ -234,11 +234,11 @@ spec:
             {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ $.Values.cortxdata.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ $.Values.cortxdata.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             - name: data
-              mountPath: {{ $.Values.cortxdata.localpathpvc.mountpath }}
+              mountPath: /etc/cortx
           ports:
           - name: {{ printf "ios-%d-tcp" $ioIndex }}
             containerPort: {{ printf "%d" (add $ioIndex (include "cortx.data.iosPort" $) | int) }}

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -38,7 +38,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.labels['cortx.io/machine-id']
         {{- end }}
-        - name: local-path-pv
+        - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.ha.fullname" . }}
         - name: {{ .Values.configmap.cortxSecretName }}
@@ -65,15 +65,15 @@ spec:
         {{- end }}
         volumeMounts:
           - name: cortx-configuration
-            mountPath: {{ .Values.cortxha.cfgmap.mountpath }}
+            mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
-            mountPath: {{ .Values.cortxha.sslcfgmap.mountpath }}
+            mountPath: /etc/cortx/solution/ssl
           {{- if .Values.cortxha.machineid.value }}
           - name: machine-id
-            mountPath: {{ .Values.cortxha.machineid.mountpath }}
+            mountPath: /etc/cortx/solution/node
           {{- end }}
-          - name: local-path-pv
-            mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
+          - name: data
+            mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
             mountPath: /etc/cortx/solution/secret
             readOnly: true
@@ -103,15 +103,15 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ .Values.cortxha.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ .Values.cortxha.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             {{- if .Values.cortxha.machineid.value }}
             - name: machine-id
-              mountPath: {{ .Values.cortxha.machineid.mountpath }}
+              mountPath: /etc/cortx/solution/node
             {{- end }}
-            - name: local-path-pv
-              mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
+            - name: data
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:
@@ -140,15 +140,15 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ .Values.cortxha.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ .Values.cortxha.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             {{- if .Values.cortxha.machineid.value }}
             - name: machine-id
-              mountPath: {{ .Values.cortxha.machineid.mountpath }}
+              mountPath: /etc/cortx/solution/node
             {{- end }}
-            - name: local-path-pv
-              mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
+            - name: data
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:
@@ -177,15 +177,15 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ .Values.cortxha.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ .Values.cortxha.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             {{- if .Values.cortxha.machineid.value }}
             - name: machine-id
-              mountPath: {{ .Values.cortxha.machineid.mountpath }}
+              mountPath: /etc/cortx/solution/node
             {{- end }}
-            - name: local-path-pv
-              mountPath: {{ .Values.cortxha.localpathpvc.mountpath }}
+            - name: data
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:

--- a/charts/cortx/templates/server/statefulset.yaml
+++ b/charts/cortx/templates/server/statefulset.yaml
@@ -51,11 +51,11 @@ spec:
           {{- end }}
         volumeMounts:
           - name: cortx-configuration
-            mountPath: {{ .Values.cortxserver.cfgmap.mountpath }}
+            mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
-            mountPath: {{ .Values.cortxserver.sslcfgmap.mountpath }}
+            mountPath: /etc/cortx/solution/ssl
           - name: data
-            mountPath: {{ .Values.cortxserver.localpathpvc.mountpath }}
+            mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
             mountPath: /etc/cortx/solution/secret
             readOnly: true
@@ -83,11 +83,11 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ .Values.cortxserver.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ .Values.cortxserver.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             - name: data
-              mountPath: {{ .Values.cortxserver.localpathpvc.mountpath }}
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:
@@ -124,11 +124,11 @@ spec:
           {{- end }}
           volumeMounts:
             - name: cortx-configuration
-              mountPath: {{ .Values.cortxserver.cfgmap.mountpath }}
+              mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
-              mountPath: {{ .Values.cortxserver.sslcfgmap.mountpath }}
+              mountPath: /etc/cortx/solution/ssl
             - name: data
-              mountPath: {{ .Values.cortxserver.localpathpvc.mountpath }}
+              mountPath: /etc/cortx
           env:
           - name: NODE_NAME
             valueFrom:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -139,12 +139,6 @@ configmap:
   # the exception of client UUIDs, which will not be configured if omitted.
   clusterStorageSets: {}
 
-  # cortxStoragePaths allows configuring the location of CORTX filesystem paths
-  cortxStoragePaths:
-    local: "/etc/cortx"
-    log: "/etc/cortx/log"
-    config: "/etc/cortx"
-
   # cortxControl allows configuring CORTX CSM settings
   cortxControl:
     agent:
@@ -230,15 +224,9 @@ cortxcontrol:
         https: 8081
       nodePorts:
         https: ""
-  cfgmap:
-    mountpath: /etc/cortx/solution
-  sslcfgmap:
-    mountpath: /etc/cortx/solution/ssl
   machineid:
-    mountpath: /etc/cortx/solution/node
     value: ""
   localpathpvc:
-    mountpath: /etc/cortx
     requeststoragesize: 1Gi
 
 ##
@@ -271,15 +259,9 @@ cortxha:
       limits:
         memory: 1Gi
         cpu: 500m
-  cfgmap:
-    mountpath: /etc/cortx/solution
-  sslcfgmap:
-    mountpath: /etc/cortx/solution/ssl
   machineid:
-    mountpath: /etc/cortx/solution/node
     value: ""
   localpathpvc:
-    mountpath: /etc/cortx
     requeststoragesize: 1Gi
 
 ##
@@ -297,12 +279,7 @@ cortxserver:
       limits:
         memory: 2Gi
         cpu: 2000m
-  cfgmap:
-    mountpath: /etc/cortx/solution
-  sslcfgmap:
-    mountpath: /etc/cortx/solution/ssl
   localpathpvc:
-    mountpath: /etc/cortx
     requeststoragesize: 1Gi
     accessmodes:
       - ReadWriteOnce
@@ -381,14 +358,7 @@ cortxdata:
       limits:
         memory: 512Mi
         cpu: 500m
-  cfgmap:
-    mountpath: /etc/cortx/solution
-    name: cortx
-  sslcfgmap:
-    mountpath: /etc/cortx/solution/ssl
-    name: cortx-ssl-cert
   localpathpvc:
-    mountpath: /etc/cortx
     requeststoragesize: 1Gi
     accessmodes:
       - ReadWriteOnce
@@ -402,9 +372,3 @@ cortxclient:
   image: ghcr.io/seagate/centos:7
   motr:
     numclientinst: 1
-  cfgmap:
-    mountpath: /etc/cortx/solution
-  sslcfgmap:
-    mountpath: /etc/cortx/solution/ssl
-  localpathpvc:
-    mountpath: /etc/cortx

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -149,11 +149,6 @@ buildValues() {
     # Initialize
     yq --null-input "
         (.global.storageClass, .consul.server.storageClass) = \"local-path\"
-        | (.cortxclient.localpathpvc.mountpath,
-           .cortxcontrol.localpathpvc.mountpath,
-           .cortxdata.localpathpvc.mountpath,
-           .cortxha.localpathpvc.mountpath,
-           .cortxserver.localpathpvc.mountpath) = \"${local_storage}\"
         | .configmap.cortxSecretName = \"${cortx_secret_name}\"" > "${values_file}"
 
     # shellcheck disable=SC2016
@@ -195,12 +190,6 @@ buildValues() {
             | .authUser = $from.solution.common.s3.default_iam_users.auth_user
             | .maxStartTimeout = $from.solution.common.s3.max_start_timeout
             | .extraConfiguration = $from.solution.common.s3.extra_configuration)
-        | $to' "${values_file}" "${solution_yaml}"
-
-    # shellcheck disable=SC2016
-    yq -i eval-all '
-        select(fi==0) ref $to | select(fi==1) ref $from
-        | $to.configmap.cortxStoragePaths = $from.solution.common.container_path
         | $to' "${values_file}" "${solution_yaml}"
 
     yq -i "
@@ -318,7 +307,6 @@ buildValues() {
         select(fi==0) ref $to | select(fi==1) ref $from
         | with($to.cortxserver;
             .image           = $from.solution.images.cortxserver
-            | .cfgmap.volmountname = "config001"
             | .rgw.resources = $from.solution.common.resource_allocation.server.rgw.resources)
         | $to' "${values_file}" "${solution_yaml}"
 
@@ -336,8 +324,7 @@ buildValues() {
         .hare.hax.ports.http.protocol = \"${hax_service_protocol}\"
         | with(.cortxdata;
             .replicas = ${data_replicas}
-            | .storageClassName = \"${cortx_localblockstorage_storageclassname}\"
-            | .localpathpvc.mountpath = \"${local_storage}\")" "${values_file}"
+            | .storageClassName = \"${cortx_localblockstorage_storageclassname}\")" "${values_file}"
 
     # shellcheck disable=SC2016
     yq -i eval-all '
@@ -790,10 +777,6 @@ num_kafka_replicas=${num_worker_nodes}
 if [[ "${num_worker_nodes}" -gt "${max_kafka_inst}" ]]; then
     num_kafka_replicas=${max_kafka_inst}
 fi
-
-# Get the storage paths to use
-local_storage=$(parseSolution 'solution.common.container_path.local' | cut -f2 -d'>')
-readonly local_storage
 
 ##########################################################
 # Deploy CORTX cloud pre-requisites

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -23,9 +23,6 @@ solution:
     busybox: ghcr.io/seagate/busybox:latest
   common:
     storage_provisioner_path: /mnt/fs-local-volume
-    container_path:
-      local: /etc/cortx
-      log: /etc/cortx/log
     s3:
       default_iam_users:
         auth_admin: "sgiamadmin"

--- a/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-check.yaml
@@ -12,9 +12,6 @@ solution:
     rancher: required
   common:
     storage_provisioner_path: required
-    container_path:
-      local: required
-      log: required
     s3:
       default_iam_users:
         auth_admin: required

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -39,6 +39,12 @@ if [[ "${invalid_paths}" != "[]" ]]; then
 fi
 ### CORTX-29861 yq validation replacement [/end]
 
+# Warn for keys/sections that have been removed and are no longer required
+# shellcheck disable=SC2312
+if [[ $(yq '.solution.common | has("container_path")' "${solution_yaml}") == "true" ]]; then
+    echo "WARNING: section 'solution.common.container_path' has been removed in v0.9.0. Custom container paths are not supported. You can remove it from your solution file."
+fi
+
 ### CORTX-29861 Temporary namespace length limitation enforced
 ### This can be removed once namespaces of nominal length (20+ characters) have been validated repeatedly.
 observed_namespace_length=$(yq '.solution.namespace | length' "${solution_yaml}")


### PR DESCRIPTION
## Description

This change removes the ability to set custom container paths via the solution.yaml `solution.common.container_path.*` settings.

These paths set the CORTX configuration in `config.yaml` as well as set mount paths in the containers. The problem is that changing these can break the deployment. It either never worked, or broke as the deployment code has evolved. The affected configuration paths `local` and `log`.

The settings are removed from `solution.example.yaml` and a friendly warning is provided to the user notifying them of this change and it suggests removing the settings.

All containers now have hard-coded paths to the previous default and known working path locations. This simplifies the deployment and removes the chance of incorrect user-configuration. Note that the `config` location was never configurable by the user. There are already several hard-coded paths pointing to this location.

When paths are configured to the non-defaults, all CORTX Pods CrashLoop:

- RGW Pods CrashLoop because during init, Hare writes to the `local` path, but RGW setup reads from the `config` path (fetch-fids fails)
- Control Pods CrashLoop during csm agent startup because of the same failure to fetch fid information
- Data and Client Pods CrashLoop because a machine ID isn't found

Changing the `log` path means that log files could be located on ephemeral storage. There is only a single persistent PVC for each Pod, so the logs directory should be located there to preserve logs when Pods are deleted.

## Breaking change
No, but changing the `container_path` settings in solution.yaml no longer has any effect.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32157

## How was this tested?

- Ran deployment, status and log scripts.
- Performed S3 I/O and CSM requests.
- Inspected ConfigMap and Workload specifications.

Also deployed prior to this change with different container paths and noticed all the CrashLoops.

## Checklist

- [X] The change is tested and works locally.
- [X] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
