### PR TITLE
CORTX-33534: Exit on errors in logs-cortx-cloud.sh

### DIFF
--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -188,7 +188,7 @@ for pid in ${pids}; do
     fi
 done
 
-if [ "${failed}" == "true" ]; then
+if [[ "${failed}" == "true" ]]; then
     echo "Log collection failed.  Exiting."
     exit 1
 fi

--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -137,7 +137,6 @@ function tarPodLogs()
         --coredumps "${coredumps}" \
         --stacktrace "${stacktrace}" \
         --all "${all}"
-    echo "DEBUG: returncode = $?"
     kubectl cp "${pod}:${path}/${name}" "${logs_folder}/${name}" -c "${container}" --namespace="${namespace}"
     kubectl exec "${pod}" -c "${container}" --namespace="${namespace}" -- bash -c "rm -rf ${path}"
 
@@ -184,7 +183,7 @@ done <<< "$(kubectl get pods --namespace="${namespace}" || true)"
 # Wait for all processes to finish.  Fail on error.
 failed=false
 for pid in ${pids}; do
-    if ! wait ${pid}; then
+    if ! wait "${pid}"; then
         failed=true
     fi
 done


### PR DESCRIPTION

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
Improve error handling in logs-cortx-cloud.sh by exiting on any failure, either in the background log collection processes or the final tar.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-33534
- This change is related to an issue: #

## CORTX image version requirements
NA


## How was this tested?
Tested locally:
* Failure in background process (executable not in path)
* Failure in final tar (executable not in path)
* Confirmed error code fails

## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
