### PR TITLE
CORTX-31831: Add 60s Zookeeper connect timeout to Kafka container

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -194,6 +194,7 @@ helm uninstall cortx
 | kafka.serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | kafka.serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for Kafka pods |
 | kafka.transactionStateLogMinIsr | int | `2` | Overridden min.insync.replicas config for the transaction topic |
+| kafka.zookeeperConnectionTimeoutMs | int | `60000` | Extend timeout for successful Zookeeper connection |
 | kafka.zookeeper.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Zookeeper containers |
 | kafka.zookeeper.enabled | bool | `true` | Enable installation of the Zookeeper chart |
 | kafka.zookeeper.serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -194,11 +194,11 @@ helm uninstall cortx
 | kafka.serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | kafka.serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for Kafka pods |
 | kafka.transactionStateLogMinIsr | int | `2` | Overridden min.insync.replicas config for the transaction topic |
-| kafka.zookeeperConnectionTimeoutMs | int | `60000` | Extend timeout for successful Zookeeper connection |
 | kafka.zookeeper.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Zookeeper containers |
 | kafka.zookeeper.enabled | bool | `true` | Enable installation of the Zookeeper chart |
 | kafka.zookeeper.serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | kafka.zookeeper.serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for Zookeeper pods |
+| kafka.zookeeperConnectionTimeoutMs | int | `60000` | Extend timeout for successful Zookeeper connection |
 | nameOverride | string | `""` |  |
 | platform.networkPolicy.cortxControl.podAppLabel | string | `"cortx-control-pod"` |  |
 | platform.networkPolicy.cortxData.podNameLabel | string | `"cortx-data"` |  |

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -63,6 +63,8 @@ kafka:
   deleteTopicEnable: true
   # -- Overridden min.insync.replicas config for the transaction topic
   transactionStateLogMinIsr: 2
+  # -- Extend timeout for successful Zookeeper connection
+  zookeeperConnectionTimeoutMs: 60000
 
   # ZooKeeper chart configuration
   # ref: https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/values.yaml


### PR DESCRIPTION
<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
Kafka depends on Zookeeper being active and ready to receive connections.  If it cannot connect to Zookeeper within a specified timeout then it will terminate, allowing K8s to restart Kafka.  This behavior is fine, but it will look nicer if Kafka can wait longer before terminating so that it does not show any restarts on deploy.

This changeset increases the Zookeeper connect timeout from the default of 6s to 60s, which looks like plenty of time for Zookeeper to start up in a CORTX environment.


## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-31831


## CORTX image version requirements
NA

## How was this tested?
This was tested locally with focus on correct deploy of CORTX on K8s.

Negative testing: In order to verify that this has no negative impact on error cases, I did the following:

By script:
1. In a while loop....
  1. create new user (csm API)
  2. read back the current list of users (csm API) (10 times)
  3. Confirm all expected users are there

Manually, at some random time, "kubectl delete pod cortx-zookeeper-0".

All API calls function correctly. Zookeeper pods are replaced and ready within about 10 seconds. From Kafka logs I see a "unable to read data / server closed socked" exception message, a few "connection refused" exceptions (~every 2 seconds), and then "socket connection established" info message.

(In fact, even when I delete both of my two zookeeper pods everything continues to work ok, so I guess zookeeper isn't in the path of the csm IAM CRUD API calls. But at least I can see an expected "lost connection, aggressively retry connect until successful.")

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
