### PR TITLE
CORTX-32157: Replace control/ha UUIDs with hostnames

### DIFF
--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.cortxcontrol.enabled }}
-{{- $machineId := (include "cortx.control.fullname" .) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,7 +15,7 @@ spec:
     metadata:
       labels: {{- include "cortx.labels" . | nindent 8 }}
         app.kubernetes.io/component: control
-        cortx.io/machine-id: {{ $machineId | quote }}
+        cortx.io/machine-id: {{ include "cortx.control.fullname" . | quote }}
         cortx.io/service-type: cortx-control
     spec:
       hostname: {{ include "cortx.control.fullname" . }}
@@ -47,7 +46,7 @@ spec:
         {{- else }}
         args:
           - -c
-          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -n $MACHINE_ID -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
+          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
         {{- end }}
         volumeMounts:
           - name: cortx-configuration
@@ -60,8 +59,6 @@ spec:
             mountPath: /etc/cortx/solution/secret
             readOnly: true
         env:
-          - name: MACHINE_ID
-            value: {{ $machineId | quote }}
           - name: NODE_NAME
             valueFrom:
               fieldRef:

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.cortxcontrol.enabled }}
+{{- $machineId := (include "cortx.control.fullname" .) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,9 +16,7 @@ spec:
     metadata:
       labels: {{- include "cortx.labels" . | nindent 8 }}
         app.kubernetes.io/component: control
-        {{- if .Values.cortxcontrol.machineid.value }}
-        cortx.io/machine-id: {{ .Values.cortxcontrol.machineid.value }}
-        {{- end }}
+        cortx.io/machine-id: {{ $machineId | quote }}
         cortx.io/service-type: cortx-control
     spec:
       hostname: {{ include "cortx.control.fullname" . }}
@@ -29,14 +28,12 @@ spec:
         - name: cortx-ssl-cert
           configMap:
             name: {{ include "cortx.tls.configmapName" . }}
-        {{- if .Values.cortxcontrol.machineid.value }}
         - name: machine-id
           downwardAPI:
             items:
               - path: "id"
                 fieldRef:
                   fieldPath: metadata.labels['cortx.io/machine-id']
-        {{- end }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.control.fullname" . }}
@@ -56,21 +53,15 @@ spec:
         {{- else }}
         args:
           - -c
-          {{- if .Values.cortxcontrol.machineid.value }}
-          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -n $MACHINE_ID -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
-          {{- else }}
-          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
-          {{- end }}
+          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -n $MACHINE_ID -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
         {{- end }}
         volumeMounts:
           - name: cortx-configuration
             mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
             mountPath: /etc/cortx/solution/ssl
-          {{- if .Values.cortxcontrol.machineid.value }}
           - name: machine-id
             mountPath: /etc/cortx/solution/node
-          {{- end }}
           - name: data
             mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
@@ -78,7 +69,7 @@ spec:
             readOnly: true
         env:
           - name: MACHINE_ID
-            value: {{ printf "%s" .Values.cortxcontrol.machineid.value | quote }}
+            value: {{ $machineId | quote }}
           - name: NODE_NAME
             valueFrom:
               fieldRef:
@@ -105,10 +96,8 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            {{- if .Values.cortxcontrol.machineid.value }}
             - name: machine-id
               mountPath: /etc/cortx/solution/node
-            {{- end }}
             - name: data
               mountPath: /etc/cortx
           env:

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -28,12 +28,6 @@ spec:
         - name: cortx-ssl-cert
           configMap:
             name: {{ include "cortx.tls.configmapName" . }}
-        - name: machine-id
-          downwardAPI:
-            items:
-              - path: "id"
-                fieldRef:
-                  fieldPath: metadata.labels['cortx.io/machine-id']
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.control.fullname" . }}
@@ -60,8 +54,6 @@ spec:
             mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
             mountPath: /etc/cortx/solution/ssl
-          - name: machine-id
-            mountPath: /etc/cortx/solution/node
           - name: data
             mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
@@ -96,8 +88,6 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            - name: machine-id
-              mountPath: /etc/cortx/solution/node
             - name: data
               mountPath: /etc/cortx
           env:

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -29,12 +29,6 @@ spec:
         - name: cortx-ssl-cert
           configMap:
             name: {{ include "cortx.tls.configmapName" . }}
-        - name: machine-id
-          downwardAPI:
-            items:
-              - path: "id"
-                fieldRef:
-                  fieldPath: metadata.labels['cortx.io/machine-id']
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.ha.fullname" . }}
@@ -61,8 +55,6 @@ spec:
             mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
             mountPath: /etc/cortx/solution/ssl
-          - name: machine-id
-            mountPath: /etc/cortx/solution/node
           - name: data
             mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
@@ -97,8 +89,6 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            - name: machine-id
-              mountPath: /etc/cortx/solution/node
             - name: data
               mountPath: /etc/cortx
           env:
@@ -132,8 +122,6 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            - name: machine-id
-              mountPath: /etc/cortx/solution/node
             - name: data
               mountPath: /etc/cortx
           env:
@@ -167,8 +155,6 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            - name: machine-id
-              mountPath: /etc/cortx/solution/node
             - name: data
               mountPath: /etc/cortx
           env:

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.cortxha.enabled }}
+{{- $machineId := printf "%s-headless" (include "cortx.ha.fullname" . ) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,9 +16,7 @@ spec:
     metadata:
       labels: {{- include "cortx.labels" . | nindent 8 }}
         app.kubernetes.io/component: ha
-        {{- if .Values.cortxha.machineid.value }}
-        cortx.io/machine-id: {{ .Values.cortxha.machineid.value }}
-        {{- end }}
+        cortx.io/machine-id: {{ $machineId | quote }}
         cortx.io/service-type: cortx-ha
     spec:
       hostname: {{ include "cortx.ha.fullname" . }}-headless
@@ -30,14 +29,12 @@ spec:
         - name: cortx-ssl-cert
           configMap:
             name: {{ include "cortx.tls.configmapName" . }}
-        {{- if .Values.cortxha.machineid.value }}
         - name: machine-id
           downwardAPI:
             items:
               - path: "id"
                 fieldRef:
                   fieldPath: metadata.labels['cortx.io/machine-id']
-        {{- end }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.ha.fullname" . }}
@@ -57,21 +54,15 @@ spec:
         {{- else }}
         args:
           - -c
-          {{- if .Values.cortxha.machineid.value }}
           - /opt/seagate/cortx/provisioner/bin/cortx_deploy -n $MACHINE_ID -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
-          {{- else }}
-          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
-          {{- end }}
         {{- end }}
         volumeMounts:
           - name: cortx-configuration
             mountPath: /etc/cortx/solution
           - name: cortx-ssl-cert
             mountPath: /etc/cortx/solution/ssl
-          {{- if .Values.cortxha.machineid.value }}
           - name: machine-id
             mountPath: /etc/cortx/solution/node
-          {{- end }}
           - name: data
             mountPath: /etc/cortx
           - name: {{ .Values.configmap.cortxSecretName }}
@@ -79,7 +70,7 @@ spec:
             readOnly: true
         env:
           - name: MACHINE_ID
-            value: {{ printf "%s" .Values.cortxha.machineid.value | quote }}
+            value: {{ $machineId | quote }}
           - name: NODE_NAME
             valueFrom:
               fieldRef:
@@ -106,10 +97,8 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            {{- if .Values.cortxha.machineid.value }}
             - name: machine-id
               mountPath: /etc/cortx/solution/node
-            {{- end }}
             - name: data
               mountPath: /etc/cortx
           env:
@@ -143,10 +132,8 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            {{- if .Values.cortxha.machineid.value }}
             - name: machine-id
               mountPath: /etc/cortx/solution/node
-            {{- end }}
             - name: data
               mountPath: /etc/cortx
           env:
@@ -180,10 +167,8 @@ spec:
               mountPath: /etc/cortx/solution
             - name: cortx-ssl-cert
               mountPath: /etc/cortx/solution/ssl
-            {{- if .Values.cortxha.machineid.value }}
             - name: machine-id
               mountPath: /etc/cortx/solution/node
-            {{- end }}
             - name: data
               mountPath: /etc/cortx
           env:

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.cortxha.enabled }}
-{{- $machineId := printf "%s-headless" (include "cortx.ha.fullname" . ) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,7 +15,7 @@ spec:
     metadata:
       labels: {{- include "cortx.labels" . | nindent 8 }}
         app.kubernetes.io/component: ha
-        cortx.io/machine-id: {{ $machineId | quote }}
+        cortx.io/machine-id: {{ printf "%s-headless" (include "cortx.ha.fullname" . ) }}
         cortx.io/service-type: cortx-ha
     spec:
       hostname: {{ include "cortx.ha.fullname" . }}-headless
@@ -48,7 +47,7 @@ spec:
         {{- else }}
         args:
           - -c
-          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -n $MACHINE_ID -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
+          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
         {{- end }}
         volumeMounts:
           - name: cortx-configuration
@@ -61,8 +60,6 @@ spec:
             mountPath: /etc/cortx/solution/secret
             readOnly: true
         env:
-          - name: MACHINE_ID
-            value: {{ $machineId | quote }}
           - name: NODE_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
## Description

For Control and HA Pods, replace the random UUID machine-id/cluster node IDs, and use the Pod hostname instead, the same way as the Server, Data and Client Pods are done. This simplifies deployment by removing some required values, and makes a `helm upgrade` based Chart upgrade safer since it removes the value randomness.

All environment variables and volume mounts are removed. Provisioner uses the Pod hostname instead.

Note that the `cortx.io/machine-id` Pod labels have been preserved. The HA k8s monitor is using this label (although it appears only to consider the Control Pod and not its own Pod).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32157

## How was this tested?

- Deployment and other scripts
- S3 I/O
- CSM API requests

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
