### PR TITLE
CORTX-31831: Enable startup probe for Kafka containers

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -170,6 +170,8 @@ helm uninstall cortx
 | kafka.enabled | bool | `true` | Enable installation of the Kafka chart |
 | kafka.serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | kafka.serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for Kafka pods |
+| kafka.startupProbe.enabled | bool | `true` | Enable startup probe to allow for slow Zookeeper startup |
+| kafka.startupProbe.initialDelaySeconds | int | `10` | Initial delay for startup probe |
 | kafka.transactionStateLogMinIsr | int | `2` | Overridden min.insync.replicas config for the transaction topic |
 | kafka.zookeeper.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Zookeeper containers |
 | kafka.zookeeper.enabled | bool | `true` | Enable installation of the Zookeeper chart |

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -65,6 +65,11 @@ kafka:
   transactionStateLogMinIsr: 2
   # -- Extend timeout for successful Zookeeper connection
   zookeeperConnectionTimeoutMs: 60000
+  startupProbe:
+    # -- Enable startup probe to allow for slow Zookeeper startup
+    enabled: true
+    # -- Initial delay for startup probe
+    initialDelaySeconds: 10
 
   # ZooKeeper chart configuration
   # ref: https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/values.yaml


### PR DESCRIPTION

## Description
This change enables the startup probe for Kafka containers.  This allows sufficient time for Zookeeper to be available to the Kafka containers.  (This is related to the previous PR #310.)


## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-31831

## CORTX image version requirements
N/A

## How was this tested?
Verified by manually deploying, watching kafka events and pod status.


## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
