### PR TITLE
CORTX-32157: Refactor client Chart values

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -60,6 +60,13 @@ helm uninstall cortx
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| client.enabled | bool | `false` | Enable installation of Client instances |
+| client.image.pullPolicy | string | `"IfNotPresent"` | Client image pull policy ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images |
+| client.image.registry | string | `"ghcr.io"` | Client image registry |
+| client.image.repository | string | `"seagate/cortx-data"` | Client image name |
+| client.image.tag | string | `""` | Client image tag. If unset, defaults to the Chart AppVersion. |
+| client.instanceCount | int | `1` | Number of Client instances (containers) per replica |
+| client.replicaCount | int | `1` | Number of Client replicas |
 | clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |
 | configmap.clusterDomain | string | `"cluster.local"` |  |
 | configmap.clusterId | string | `""` |  |
@@ -84,10 +91,6 @@ helm uninstall cortx
 | consul.enabled | bool | `true` | Enable installation of the Consul chart |
 | consul.server.containerSecurityContext.server.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul server agent containers |
 | consul.ui.enabled | bool | `false` | Enable the Consul UI |
-| cortxclient.enabled | bool | `false` |  |
-| cortxclient.image | string | `"ghcr.io/seagate/centos:7"` |  |
-| cortxclient.motr.numclientinst | int | `1` |  |
-| cortxclient.replicas | int | `1` |  |
 | cortxcontrol.agent.resources.limits.cpu | string | `"500m"` |  |
 | cortxcontrol.agent.resources.limits.memory | string | `"256Mi"` |  |
 | cortxcontrol.agent.resources.requests.cpu | string | `"250m"` |  |

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -64,7 +64,7 @@ helm uninstall cortx
 | client.image.pullPolicy | string | `"IfNotPresent"` | Client image pull policy ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images |
 | client.image.registry | string | `"ghcr.io"` | Client image registry |
 | client.image.repository | string | `"seagate/cortx-data"` | Client image name |
-| client.image.tag | string | `""` | Client image tag. If unset, defaults to the Chart AppVersion. |
+| client.image.tag | string | Chart.AppVersion | Client image tag |
 | client.instanceCount | int | `1` | Number of Client instances (containers) per replica |
 | client.replicaCount | int | `1` | Number of Client replicas |
 | clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |

--- a/charts/cortx/templates/_cluster.yaml.tpl
+++ b/charts/cortx/templates/_cluster.yaml.tpl
@@ -101,7 +101,7 @@ cluster:
     {{- include "storageset.node" (dict "name" $nodeName "hostname" $hostName "id" $hostName "type" "server_node") | nindent 4 }}
     {{- end }}
     {{- end }}
-    {{- range $i := until (int $root.Values.cortxclient.replicas) }}
+    {{- range $i := until (int $root.Values.client.replicaCount) }}
     {{- $nodeName := printf "%s-%d" (include "cortx.client.fullname" $root) $i }}
     {{- $hostName := printf "%s.%s" $nodeName (include "cortx.client.serviceDomain" $root) }}
     {{- include "storageset.node" (dict "name" $nodeName "hostname" $hostName "id" $hostName "type" "client_node") | nindent 4 }}

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -23,8 +23,8 @@
 {{- end -}}
 {{- end -}}
 {{- $clientHostnames := list -}}
-{{- if .Values.cortxclient.enabled -}}
-{{- range $i := until (int .Values.cortxclient.replicas) -}}
+{{- if .Values.client.enabled -}}
+{{- range $i := until (int .Values.client.replicaCount) -}}
 {{- $clientHostnames = append $clientHostnames (printf "%s-%d.%s" (include "cortx.client.fullname" $) $i (include "cortx.client.serviceDomain" $)) -}}
 {{- end -}}
 {{- end -}}
@@ -126,9 +126,9 @@ cortx:
       - {{ printf "tcp://%s:%d" . (include "cortx.server.motrClientPort" $ | int) }}
       {{- end }}
     {{- end }}
-    {{- if .Values.cortxclient.enabled }}
+    {{- if .Values.client.enabled }}
     - name: motr_client
-      num_instances: {{ .Values.cortxclient.motr.numclientinst | int }}
+      num_instances: {{ .Values.client.instanceCount | int }}
       num_subscriptions: 1
       subscriptions:
       - fdmi

--- a/charts/cortx/templates/_images.tpl
+++ b/charts/cortx/templates/_images.tpl
@@ -1,0 +1,14 @@
+{{/*
+Return a valid CORTX image name from parts
+{{ include "cortx.images.image" ( dict "image" .Values.path.to.the.image "root" $) }}
+*/}}
+{{- define "cortx.images.image" -}}
+{{- printf "%s/%s:%s" .image.registry .image.repository (default .root.Chart.AppVersion .image.tag) -}}
+{{- end -}}
+
+{{/*
+Return the Client image name
+*/}}
+{{- define "cortx.client.image" -}}
+{{ include "cortx.images.image" (dict "image" .Values.client.image "root" .) }}
+{{- end -}}

--- a/charts/cortx/templates/client/service-headless.yaml
+++ b/charts/cortx/templates/client/service-headless.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortxclient.enabled }}
+{{- if .Values.client.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cortx/templates/client/statefulset.yaml
+++ b/charts/cortx/templates/client/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortxclient.enabled }}
+{{- if .Values.client.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -9,7 +9,7 @@ metadata:
 spec:
   podManagementPolicy: Parallel
   serviceName: {{ include "cortx.client.fullname" . }}-headless
-  replicas: {{ .Values.cortxclient.replicas }}
+  replicas: {{ .Values.client.replicaCount }}
   selector:
     matchLabels: {{- include "cortx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: client
@@ -38,15 +38,17 @@ spec:
             secretName: {{ .Values.configmap.cortxSecretName }}
         - name: data
           emptyDir: {}
+      {{- $image := include "cortx.client.image" . }}
+      {{- $imagePullPolicy := .Values.client.image.pullPolicy }}
       initContainers:
       - name: cortx-setup
-        image: {{ .Values.cortxclient.image }}
-        imagePullPolicy: IfNotPresent
+        image: {{ $image }}
+        imagePullPolicy: {{ $imagePullPolicy | quote }}
         command:
           - /bin/sh
         args:
           - -c
-        {{- if eq .Values.cortxclient.image "ghcr.io/seagate/centos:7" }}
+        {{- if eq $image "ghcr.io/seagate/centos:7" }}
           - sleep $(shuf -i 5-10 -n 1)s
         {{- else }}
           - /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
@@ -72,9 +74,9 @@ spec:
                 fieldPath: metadata.name
       containers:
         - name: cortx-hax
-          image: {{ .Values.cortxclient.image }}
-          imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxclient.image "ghcr.io/seagate/centos:7" }}
+          image: {{ $image }}
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          {{- if eq $image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -111,11 +113,11 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-        {{- range $i := until (.Values.cortxclient.motr.numclientinst | int) }}
+        {{- range $i := until (.Values.client.instanceCount | int) }}
         - name: {{ printf "cortx-motr-client-%03d" (add 1 $i) }}
-          image: {{ $.Values.cortxclient.image }}
-          imagePullPolicy: IfNotPresent
-          {{- if eq $.Values.cortxclient.image "ghcr.io/seagate/centos:7" }}
+          image: {{ $image }}
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          {{- if eq $image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -350,12 +350,24 @@ cortxdata:
     accessmodes:
       - ReadWriteOnce
 
-##
-## Imported values from cortx-client Helm Chart. These will be changed.
-##
-cortxclient:
+# Deploy CORTX Motr Client instances
+# Motr Clients are generally a developer tool used for testing purposes
+client:
+  # -- Enable installation of Client instances
   enabled: false
-  replicas: 1
-  image: ghcr.io/seagate/centos:7
-  motr:
-    numclientinst: 1
+  # -- Number of Client replicas
+  replicaCount: 1
+  # -- Number of Client instances (containers) per replica
+  instanceCount: 1
+  # Client image
+  # ref: https://github.com/Seagate/cortx/pkgs/container/cortx-data
+  image:
+    # -- Client image registry
+    registry: ghcr.io
+    # -- Client image name
+    repository: seagate/cortx-data
+    # -- Client image tag. If unset, defaults to the Chart AppVersion.
+    tag: ""
+    # -- Client image pull policy
+    # ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    pullPolicy: IfNotPresent

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -366,7 +366,8 @@ client:
     registry: ghcr.io
     # -- Client image name
     repository: seagate/cortx-data
-    # -- Client image tag. If unset, defaults to the Chart AppVersion.
+    # -- Client image tag
+    # @default -- Chart.AppVersion
     tag: ""
     # -- Client image pull policy
     # ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -196,7 +196,7 @@ buildValues() {
         .cortxserver.enabled = ${components[server]}
         | .cortxha.enabled = ${components[ha]}
         | .cortxcontrol.enabled = ${components[control]}
-        | .cortxclient.enabled = ${components[client]}" "${values_file}"
+        | .client.enabled = ${components[client]}" "${values_file}"
 
     # shellcheck disable=SC2016
     yq -i eval-all '
@@ -320,15 +320,12 @@ buildValues() {
     [[ ${components[client]} == false ]] && client_replicas=0
 
     yq -i "
-        .cortxclient.replicas = ${client_replicas}
-        | .cortxclient.motr.numclientinst = ${num_motr_client}" "${values_file}"
-
-    # shellcheck disable=SC2016
-    yq -i eval-all '
-        select(fi==0) ref $to | select(fi==1) ref $from
-        | with($to.cortxclient;
-            .image = $from.solution.images.cortxclient)
-        | $to' "${values_file}" "${solution_yaml}"
+        .client.replicaCount = ${client_replicas}
+        | .client.instanceCount = ${num_motr_client}
+        | .client.image = (
+            load(\"${solution_yaml}\")
+            | .solution.images.cortxclient
+            | capture(\"(?P<registry>.*?)/(?P<repository>.*):(?P<tag>.*)\"))" "${values_file}"
 
     set +eu
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->

Refactor the Chart values for the (Motr) client component.

- Remove redundant "cortx" prefix
- Use camelcase to match Helm conventions
- Convert image into an object. Tag is undefined and will default to the Chart `AppVersion` value.
- Default to the real CORTX client image, instead of centos.
- Allow `imagePullPolicy` to be configurable

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-32157
- This change is related to an issue: #

## How was this tested?

Deployed cluster, with and without Client enabled. Ran m0 client in container.

Ran `helm template` and saw default values, like the image, being correctly configured.

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
