### PR TITLE
CORTX-33590: Add --namespace for cortx-data sts in start-cortx-cloud.sh

### DIFF
--- a/k8_cortx_cloud/start-cortx-cloud.sh
+++ b/k8_cortx_cloud/start-cortx-cloud.sh
@@ -64,7 +64,7 @@ printf "# Start CORTX Data                                      \n"
 printf "########################################################\n"
 readonly data_selector="app.kubernetes.io/component=data,app.kubernetes.io/instance=cortx"
 num_data_sts=0
-for statefulset in $(kubectl get statefulset --selector "${data_selector}" --no-headers --output custom-columns=NAME:metadata.name --namespace="${namespace}"); do
+for statefulset in $(kubectl get statefulset --selector "${data_selector}" --no-headers --namespace=${namespace} --output custom-columns=NAME:metadata.name); do
     kubectl scale statefulset "${statefulset}" --replicas "${num_nodes}" --namespace="${namespace}"
     ((num_data_sts+=1))
 done
@@ -175,7 +175,7 @@ if [[ ${deployment_type} != "data-only" ]]; then
     printf "\n\n"
 fi
 
-if kubectl get statefulset cortx-client &> /dev/null; then
+if kubectl get statefulset cortx-client --namespace="${namespace}" &> /dev/null; then
     printf "########################################################\n"
     printf "# Start CORTX Client                                    \n"
     printf "########################################################\n"

--- a/k8_cortx_cloud/start-cortx-cloud.sh
+++ b/k8_cortx_cloud/start-cortx-cloud.sh
@@ -64,7 +64,7 @@ printf "# Start CORTX Data                                      \n"
 printf "########################################################\n"
 readonly data_selector="app.kubernetes.io/component=data,app.kubernetes.io/instance=cortx"
 num_data_sts=0
-for statefulset in $(kubectl get statefulset --selector "${data_selector}" --no-headers --output custom-columns=NAME:metadata.name); do
+for statefulset in $(kubectl get statefulset --selector "${data_selector}" --no-headers --output custom-columns=NAME:metadata.name --namespace="${namespace}"); do
     kubectl scale statefulset "${statefulset}" --replicas "${num_nodes}" --namespace="${namespace}"
     ((num_data_sts+=1))
 done

--- a/k8_cortx_cloud/start-cortx-cloud.sh
+++ b/k8_cortx_cloud/start-cortx-cloud.sh
@@ -64,7 +64,7 @@ printf "# Start CORTX Data                                      \n"
 printf "########################################################\n"
 readonly data_selector="app.kubernetes.io/component=data,app.kubernetes.io/instance=cortx"
 num_data_sts=0
-for statefulset in $(kubectl get statefulset --selector "${data_selector}" --no-headers --namespace=${namespace} --output custom-columns=NAME:metadata.name); do
+for statefulset in $(kubectl get statefulset --selector "${data_selector}" --no-headers --namespace="${namespace}" --output custom-columns=NAME:metadata.name); do
     kubectl scale statefulset "${statefulset}" --replicas "${num_nodes}" --namespace="${namespace}"
     ((num_data_sts+=1))
 done


### PR DESCRIPTION
## Description
Fix bug in which --namespace is not specified for one of the commands in start-cortx-cloud.sh.
This prevents cortx-data pods from starting correctly.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-33590



## How was this tested?
Using the cortx-k8s regression test (deploy/shutdown/start)

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
