### PR TITLE
CORTX-32157: Refactor some Chart values

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -61,25 +61,8 @@ helm uninstall cortx
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |
-| configmap.clusterDomain | string | `"cluster.local"` |  |
-| configmap.clusterId | string | `""` |  |
-| configmap.clusterName | string | `"cortx-cluster"` |  |
-| configmap.clusterStorageSets | object | `{}` |  |
-| configmap.cortxControl.agent.resources.limits.cpu | string | `"500m"` |  |
-| configmap.cortxControl.agent.resources.limits.memory | string | `"256Mi"` |  |
-| configmap.cortxControl.agent.resources.requests.cpu | string | `"250m"` |  |
-| configmap.cortxControl.agent.resources.requests.memory | string | `"128Mi"` |  |
-| configmap.cortxMotr.confd.resources.limits.cpu | string | `"500m"` |  |
-| configmap.cortxMotr.confd.resources.limits.memory | string | `"512Mi"` |  |
-| configmap.cortxMotr.confd.resources.requests.cpu | string | `"250m"` |  |
-| configmap.cortxMotr.confd.resources.requests.memory | string | `"128Mi"` |  |
-| configmap.cortxMotr.extraConfiguration | string | `""` |  |
-| configmap.cortxMotr.motr.resources.limits.cpu | string | `"1000m"` |  |
-| configmap.cortxMotr.motr.resources.limits.memory | string | `"2Gi"` |  |
-| configmap.cortxMotr.motr.resources.requests.cpu | string | `"250m"` |  |
-| configmap.cortxMotr.motr.resources.requests.memory | string | `"1Gi"` |  |
-| configmap.cortxSecretName | string | `"cortx-secret"` |  |
-| configmap.cortxSecretValues | object | `{}` |  |
+| clusterId | string | Chart Release fullname | The unique ID of the CORTX cluster. |
+| clusterName | string | Chart Release fullname | The name of the CORTX cluster. |
 | consul.client.containerSecurityContext.client.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul client agent containers |
 | consul.enabled | bool | `true` | Enable installation of the Consul chart |
 | consul.server.containerSecurityContext.server.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul server agent containers |
@@ -108,6 +91,7 @@ helm uninstall cortx
 | cortxdata.localpathpvc.accessmodes[0] | string | `"ReadWriteOnce"` |  |
 | cortxdata.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
 | cortxdata.motr.containerGroupSize | int | `1` | The number of Motr IO containers per CORTX Data Pod. As the number of CVGs increase, this value can be increased to reduce the number of total CORTX Data Pods per Kubernetes Worker Node. |
+| cortxdata.motr.extraConfiguration | string | `""` |  |
 | cortxdata.motr.resources.limits.cpu | string | `"1000m"` |  |
 | cortxdata.motr.resources.limits.memory | string | `"2Gi"` |  |
 | cortxdata.motr.resources.requests.cpu | string | `"250m"` |  |
@@ -133,7 +117,6 @@ helm uninstall cortx
 | cortxha.k8s_monitor.resources.requests.memory | string | `"128Mi"` |  |
 | cortxha.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
 | cortxserver.authAdmin | string | `"cortx-admin"` |  |
-| cortxserver.authSecret | string | `"s3_auth_admin_secret"` |  |
 | cortxserver.authUser | string | `"cortx-user"` |  |
 | cortxserver.enabled | bool | `true` |  |
 | cortxserver.extraConfiguration | string | `""` |  |
@@ -152,6 +135,7 @@ helm uninstall cortx
 | cortxserver.service.ports.http | int | `80` |  |
 | cortxserver.service.ports.https | int | `443` |  |
 | cortxserver.service.type | string | `"ClusterIP"` |  |
+| existingSecret | string | `""` | The name of an existing Secret that contains CORTX configuration secrets. Required or the Chart installation will fail. |
 | externalConsul.adminSecretName | string | `"consul_admin_secret"` |  |
 | externalConsul.adminUser | string | `"admin"` |  |
 | externalConsul.endpoints | list | `[]` |  |
@@ -182,3 +166,4 @@ helm uninstall cortx
 | serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for CORTX pods |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is true, a name is generated using the fullname template |
+| storageSets | object | `{}` |  |

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -68,7 +68,7 @@ helm uninstall cortx
 | client.instanceCount | int | `1` | Number of Client instances (containers) per replica |
 | client.replicaCount | int | `1` | Number of Client replicas |
 | clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |
-| clusterId | string | Chart Release fullname | The unique ID of the CORTX cluster. |
+| clusterId | string | A random UUID (v4) | The unique ID of the CORTX cluster. |
 | clusterName | string | Chart Release fullname | The name of the CORTX cluster. |
 | consul.client.containerSecurityContext.client.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul client agent containers |
 | consul.enabled | bool | `true` | Enable installation of the Consul chart |

--- a/charts/cortx/ci/default-values.yaml
+++ b/charts/cortx/ci/default-values.yaml
@@ -1,0 +1,1 @@
+existingSecret: mysecret

--- a/charts/cortx/templates/_cluster.yaml.tpl
+++ b/charts/cortx/templates/_cluster.yaml.tpl
@@ -7,8 +7,8 @@
 
 {{- define "cluster.yaml" -}}
 cluster:
-  name: {{ .Values.configmap.clusterName }}
-  id: {{ default uuidv4 .Values.configmap.clusterId | replace "-" "" | quote }}
+  name: {{ default (include "cortx.fullname" .) .Values.clusterName | quote }}
+  id: {{ default (include "cortx.fullname" .) .Values.clusterId | quote }}
   node_types:
   {{- $statefulSetCount := (include "cortx.data.statefulSetCount" .) | int -}}
   {{- $validatedContainerGroupSize := (include "cortx.data.validatedContainerGroupSize" .) | int -}}
@@ -69,7 +69,7 @@ cluster:
         - motr_client
     - name: hare
   {{- $root := . }}
-  {{- with .Values.configmap.clusterStorageSets }}
+  {{- with .Values.storageSets }}
   storage_sets:
   {{- range $storageSetName, $storageSet := . }}
   - name: {{ $storageSetName }}

--- a/charts/cortx/templates/_cluster.yaml.tpl
+++ b/charts/cortx/templates/_cluster.yaml.tpl
@@ -8,7 +8,7 @@
 {{- define "cluster.yaml" -}}
 cluster:
   name: {{ default (include "cortx.fullname" .) .Values.clusterName | quote }}
-  id: {{ default (include "cortx.fullname" .) .Values.clusterId | quote }}
+  id: {{ default uuidv4 .Values.clusterId | quote }}
   node_types:
   {{- $statefulSetCount := (include "cortx.data.statefulSetCount" .) | int -}}
   {{- $validatedContainerGroupSize := (include "cortx.data.validatedContainerGroupSize" .) | int -}}

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -69,7 +69,7 @@ cortx:
   rgw:
     auth_user: {{ .Values.cortxserver.authUser }}
     auth_admin: {{ .Values.cortxserver.authAdmin }}
-    auth_secret: {{ .Values.cortxserver.authSecret }}
+    auth_secret: s3_auth_admin_secret
     public:
       endpoints:
       - {{ printf "http://%s-0:%d" (include "cortx.server.fullname" .) (.Values.cortxserver.service.ports.http | int) }}
@@ -139,10 +139,10 @@ cortx:
     {{- end }}
     limits:
       services:
-      {{- include "config.yaml.service.limits" (dict "name" "ios" "resources" .Values.configmap.cortxMotr.motr.resources) | nindent 6 }}
-      {{- include "config.yaml.service.limits" (dict "name" "confd" "resources" .Values.configmap.cortxMotr.confd.resources) | nindent 6 }}
-    {{- if .Values.configmap.cortxMotr.extraConfiguration }}
-    {{- tpl .Values.configmap.cortxMotr.extraConfiguration . | nindent 4 }}
+      {{- include "config.yaml.service.limits" (dict "name" "ios" "resources" .Values.cortxdata.motr.resources) | nindent 6 }}
+      {{- include "config.yaml.service.limits" (dict "name" "confd" "resources" .Values.cortxdata.confd.resources) | nindent 6 }}
+    {{- if .Values.cortxdata.motr.extraConfiguration }}
+    {{- tpl .Values.cortxdata.motr.extraConfiguration . | nindent 4 }}
     {{- end }}
   {{- if .Values.cortxcontrol.enabled }}
   csm:
@@ -156,7 +156,7 @@ cortx:
     mgmt_secret: csm_mgmt_admin_secret
     limits:
       services:
-      {{- include "config.yaml.service.limits" (dict "name" "agent" "resources" .Values.configmap.cortxControl.agent.resources) | nindent 6 }}
+      {{- include "config.yaml.service.limits" (dict "name" "agent" "resources" .Values.cortxcontrol.agent.resources) | nindent 6 }}
   {{- end }}
   {{- if .Values.cortxha.enabled }}
   ha:

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -76,6 +76,13 @@ Return the CORTX SSL certificate configmap
 {{- end -}}
 
 {{/*
+Return the name of the CORTX secret
+*/}}
+{{- define "cortx.secretName" -}}
+{{- required "A name of a Secret containing the CORTX configuration secrets is required" (tpl .Values.existingSecret .) -}}
+{{- end -}}
+
+{{/*
 Return the name of the Control component
 */}}
 {{- define "cortx.control.fullname" -}}

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -79,7 +79,8 @@ Return the CORTX SSL certificate configmap
 Return the name of the CORTX secret
 */}}
 {{- define "cortx.secretName" -}}
-{{- required "A name of a Secret containing the CORTX configuration secrets is required" (tpl .Values.existingSecret .) -}}
+{{- $secret := tpl .Values.existingSecret . -}}
+{{- required "A name of a Secret containing the CORTX configuration secrets is required" $secret -}}
 {{- end -}}
 
 {{/*

--- a/charts/cortx/templates/client/statefulset.yaml
+++ b/charts/cortx/templates/client/statefulset.yaml
@@ -33,9 +33,9 @@ spec:
         - name: cortx-ssl-cert
           configMap:
             name: {{ include "cortx.tls.configmapName" . }}
-        - name: {{ .Values.configmap.cortxSecretName }}
+        - name: configuration-secrets
           secret:
-            secretName: {{ .Values.configmap.cortxSecretName }}
+            secretName: {{ include "cortx.secretName" . }}
         - name: data
           emptyDir: {}
       initContainers:
@@ -58,7 +58,7 @@ spec:
             mountPath: /etc/cortx/solution/ssl
           - name: data
             mountPath: /etc/cortx
-          - name: {{ .Values.configmap.cortxSecretName }}
+          - name: configuration-secrets
             mountPath: /etc/cortx/solution/secret
             readOnly: true
         env:

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -30,9 +30,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.control.fullname" . }}
-        - name: {{ .Values.configmap.cortxSecretName }}
+        - name: configuration-secrets
           secret:
-            secretName: {{ .Values.configmap.cortxSecretName }}
+            secretName: {{ include "cortx.secretName" . }}
       initContainers:
       - name: cortx-setup
         image: {{ .Values.cortxcontrol.image }}
@@ -55,7 +55,7 @@ spec:
             mountPath: /etc/cortx/solution/ssl
           - name: data
             mountPath: /etc/cortx
-          - name: {{ .Values.configmap.cortxSecretName }}
+          - name: configuration-secrets
             mountPath: /etc/cortx/solution/secret
             readOnly: true
         env:

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -44,9 +44,9 @@ spec:
         - name: cortx-ssl-cert
           configMap:
             name: {{ include "cortx.tls.configmapName" $ }}
-        - name: {{ $.Values.configmap.cortxSecretName }}
+        - name: configuration-secrets
           secret:
-            secretName: {{ $.Values.configmap.cortxSecretName }}
+            secretName: {{ include "cortx.secretName" $ }}
         - name: node-config
           configMap:
             defaultMode: 0700
@@ -96,7 +96,7 @@ spec:
             mountPath: /etc/cortx/solution/ssl
           - name: data
             mountPath: /etc/cortx
-          - name: {{ $.Values.configmap.cortxSecretName }}
+          - name: configuration-secrets
             mountPath: /etc/cortx/solution/secret
             readOnly: true
         env:

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -31,9 +31,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "cortx.ha.fullname" . }}
-        - name: {{ .Values.configmap.cortxSecretName }}
+        - name: configuration-secrets
           secret:
-            secretName: {{ .Values.configmap.cortxSecretName }}
+            secretName: {{ include "cortx.secretName" . }}
       initContainers:
       - name: cortx-setup
         image: {{ .Values.cortxha.image }}
@@ -56,7 +56,7 @@ spec:
             mountPath: /etc/cortx/solution/ssl
           - name: data
             mountPath: /etc/cortx
-          - name: {{ .Values.configmap.cortxSecretName }}
+          - name: configuration-secrets
             mountPath: /etc/cortx/solution/secret
             readOnly: true
         env:

--- a/charts/cortx/templates/networkpolicy.yaml
+++ b/charts/cortx/templates/networkpolicy.yaml
@@ -74,7 +74,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          app: {{ .Values.platform.networkPolicy.cortxControl.podAppLabel }}
+          app: {{ include "cortx.fullname" . }}-control
     ports:
       - protocol: TCP
         port: 28049

--- a/charts/cortx/templates/server/statefulset.yaml
+++ b/charts/cortx/templates/server/statefulset.yaml
@@ -33,9 +33,9 @@ spec:
         - name: cortx-ssl-cert
           configMap:
             name: {{ include "cortx.tls.configmapName" . }}
-        - name: {{ .Values.configmap.cortxSecretName }}
+        - name: configuration-secrets
           secret:
-            secretName: {{ .Values.configmap.cortxSecretName }}
+            secretName: {{ include "cortx.secretName" . }}
       initContainers:
       - name: cortx-setup
         image: {{ .Values.cortxserver.image }}
@@ -56,7 +56,7 @@ spec:
             mountPath: /etc/cortx/solution/ssl
           - name: data
             mountPath: /etc/cortx
-          - name: {{ .Values.configmap.cortxSecretName }}
+          - name: configuration-secrets
             mountPath: /etc/cortx/solution/secret
             readOnly: true
         env:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -100,7 +100,7 @@ externalKafka:
 clusterName: ""
 
 # -- The unique ID of the CORTX cluster.
-# @default -- Chart Release fullname
+# @default -- A random UUID (v4)
 clusterId: ""
 
 # -- The name of an existing Secret that contains CORTX configuration secrets. Required or the Chart installation will fail.

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -95,6 +95,17 @@ externalKafka:
   adminUser: admin
   adminSecretName: kafka_admin_secret
 
+# -- The name of the CORTX cluster.
+# @default -- Chart Release fullname
+clusterName: ""
+
+# -- The unique ID of the CORTX cluster.
+# @default -- Chart Release fullname
+clusterId: ""
+
+# -- The name of an existing Secret that contains CORTX configuration secrets. Required or the Chart installation will fail.
+existingSecret: ""
+
 # CORTX Hare component configuration
 hare:
   hax:
@@ -114,84 +125,28 @@ hare:
         cpu: 250m
         memory: 128Mi
 
-##
-## Imported values from the cortx-configmap Helm Chart. These will be changed.
-##
-configmap:
-  # clusterName is the name of the CORTX cluster
-  clusterName: cortx-cluster
-
-  # clusterId is the unique ID number of the CORTX cluster
-  clusterId: ""
-
-  # clusterDomain is the domain name of the underlying Kubernetes cluster (default is cluster.local)
-  clusterDomain: cluster.local
-
-  ### TODO Update this structure similar to solution.yaml, merge with appropriate .cortxdata elements, and convert to a list.
-  # clusterStorageSets is a Dictionary of storage sets.
-  # e.g.:
-  # clusterStorageSets:
-  #   storage-set-1:
-  #     durability:
-  #       sns: 1+0+0
-  #       dix: 1+0+0
-  #     controlUuid: "bfcb40c12e9f4fa4b924a787886a40b6"
-  #     haUuid: "0789bc5f5f544197a5c204ed5d68ab07"
-  #     nodes:
-  #       ssc-vm-g4-rhev4-0009.colo.seagate.com:
-  #         serverUuid: 50b3871d48fa4032bf27a211b4088df7
-  #         dataUuid: "8466d0079fd44cd38164d8e31f5cd067"
-  #         clientUuid: "6900a455cb634acea727cb01a7ac8e0a"
-  #       ssc-vm-g4-rhev4-0010.colo.seagate.com:
-  #         serverUuid: "05ceb17b5cdf47538db1bb89ccc247d2"
-  #         dataUuid: "eb79cc372c7443cbac768db4313cc0e8"
-  #         clientUuid: "6900a455cb634acea727cb01a7ac8e0a"
-  # UUIDs are optional and if omitted, will be randomly generated, with
-  # the exception of client UUIDs, which will not be configured if omitted.
-  clusterStorageSets: {}
-
-  # cortxControl allows configuring CORTX CSM settings
-  cortxControl:
-    agent:
-      resources:
-        requests:
-          memory: 128Mi
-          cpu: 250m
-        limits:
-          memory: 256Mi
-          cpu: 500m
-
-  # cortxMotr allows configuring CORTX MOTR settings
-  cortxMotr:
-    # An optional multi-line string that contains extra Motr configuration
-    # settings. The string may contain template expressions, and is appended to
-    # the end of the computed configuration.
-    # e.g.:
-    # extraConfiguration: |
-    #   md_size: 10
-    #   group_size: 1
-    extraConfiguration: ""
-    motr:
-      resources:
-        requests:
-          memory: 1Gi
-          cpu: 250m
-        limits:
-          memory: 2Gi
-          cpu: 1000m
-    confd:
-      resources:
-        requests:
-          memory: 128Mi
-          cpu: 250m
-        limits:
-          memory: 512Mi
-          cpu: 500m
-
-  # cortxSecretName is the name of the Secret mounted in CORTX Pods
-  cortxSecretName: "cortx-secret"
-  # cortxSecretValues: is a Dictionary of CORTX secret names and values
-  cortxSecretValues: {}
+### TODO Update this structure similar to solution.yaml, merge with appropriate .cortxdata elements, and convert to a list.
+# storageSets is a Dictionary of storage sets.
+# e.g.:
+# storageSets:
+#   storage-set-1:
+#     durability:
+#       sns: 1+0+0
+#       dix: 1+0+0
+#     controlUuid: "bfcb40c12e9f4fa4b924a787886a40b6"
+#     haUuid: "0789bc5f5f544197a5c204ed5d68ab07"
+#     nodes:
+#       ssc-vm-g4-rhev4-0009.colo.seagate.com:
+#         serverUuid: 50b3871d48fa4032bf27a211b4088df7
+#         dataUuid: "8466d0079fd44cd38164d8e31f5cd067"
+#         clientUuid: "6900a455cb634acea727cb01a7ac8e0a"
+#       ssc-vm-g4-rhev4-0010.colo.seagate.com:
+#         serverUuid: "05ceb17b5cdf47538db1bb89ccc247d2"
+#         dataUuid: "eb79cc372c7443cbac768db4313cc0e8"
+#         clientUuid: "6900a455cb634acea727cb01a7ac8e0a"
+# UUIDs are optional and if omitted, will be randomly generated, with
+# the exception of client UUIDs, which will not be configured if omitted.
+storageSets: {}
 
 ##
 ## Imported values from cortx-control Helm Chart. These will be changed.
@@ -273,9 +228,6 @@ cortxserver:
 
   authAdmin: cortx-admin
   authUser: cortx-user
-  # The below value should match the corresponding key in solution.yaml
-  # and is generally not changed by default.
-  authSecret: s3_auth_admin_secret
   maxStartTimeout: 240
   # An optional multi-line string that contains extra RGW configuration
   # settings. The string may contain template expressions, and is appended to
@@ -304,12 +256,12 @@ cortxdata:
   image: ghcr.io/seagate/centos:7
   replicas: 3
   # nodes is an array of Kubernetes worker node names on which CORTX will be deployed.
-  # NOTE: This parameter will eventually merge with .configmap.clusterStorageSets in some form.
+  # NOTE: This parameter will eventually merge with .storageSets in some form.
   nodes: []
   # cvgs is an array of container volume groups (CVG).
   # A CVG contains a name, type, an optional array of metadata devices, and
   # an array of data devices.
-  # NOTE: This parameter will eventually merge with .configmap.clusterStorageSets in some form.
+  # NOTE: This parameter will eventually merge with .storageSets in some form.
   # e.g:
   # cvgs:
   # - name: cvg-01
@@ -330,6 +282,14 @@ cortxdata:
     # -- The number of Motr IO containers per CORTX Data Pod.
     # As the number of CVGs increase, this value can be increased to reduce the number of total CORTX Data Pods per Kubernetes Worker Node.
     containerGroupSize: 1
+    # An optional multi-line string that contains extra Motr configuration
+    # settings. The string may contain template expressions, and is appended to
+    # the end of the computed configuration.
+    # e.g.:
+    # extraConfiguration: |
+    #   md_size: 10
+    #   group_size: 1
+    extraConfiguration: ""
     resources:
       requests:
         memory: 1Gi


### PR DESCRIPTION
<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description

Refactor the values to be more consistent with Helm conventions, reduce duplication, etc. (general cleanup).

- Remove the `configmap` value and relocate/consolidate child values to the top-level, or within their appropriate component sections.
- Default `clusterName` to the release fullname instead of a hard-coded name.
- Hard-code the RGW "auth_secret". This is not configurable as the Secret is created with the exact value. This is consistent with all of the other secrets, and we have never exposed this setting in solution.yaml.
- Set the secret name to an empty default, and flag it as required so the chart install fails if not specified. Existing secret names can also be a Helm template.
- Hard-code the secret's volume name in the Pod specs, there's not much reason to customize it.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32157
- This change is related to an issue: #

## How was this tested?

Deployment, ran util scripts, S3 I/O, CSM request, etc.

Since `existingSecret` is required, and is empty by default, a custom "ci" values file was added for chart linting (`ct`).

## Additional information

## Checklist

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
