### PR TITLE
CORTX-33591: Collect logs from cortx-client containers

### DIFF
--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -154,7 +154,7 @@ while IFS= read -r line; do
     pods_found=$((pods_found+1))
 
     case ${pod_name} in
-      cortx-control-* | cortx-data-* | cortx-ha-* | cortx-server-*)
+      cortx-control-* | cortx-data-* | cortx-ha-* | cortx-server-* | cortx-client-*)
         containers=$(kubectl get pods "${pod_name}" -n "${namespace}" -o jsonpath="{.spec['containers', 'initContainers'][*].name}")
         IFS=" " read -r -a containers <<< "${containers}"
         tarPodLogs "${pod_name}" "${containers[@]}" &


### PR DESCRIPTION
## Description
Collect logs from cortx-client containers.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-33591

## How was this tested?
Ran "logs-cortx-cloud.sh" with solution.common.motr.num_client_inst = 2 (so cortx-client pods are deployed), and verified that 1) there are no warnings in log-cortx-cloud.sh stdout/stderr and 2) the client container logs are present in the output support bundle tar file.


## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
