### PR TITLE
CORTX-33598 - Updated max namespace length to 20 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you have direct access to the underlying Kubernetes Nodes in your cluster, CO
 
 3. Update the solution configuration file to reflect your environment. The most common and expected updates are reflected below:
 
-   - Update the namespace you want to deploy CORTX into.  The default is "cortx".  If the namespace does not exist then it will be created for you. **There is currently a limitation on the maximum length of the namespace to 8 characters.**
+   - Update the namespace you want to deploy CORTX into.  The default is "cortx".  If the namespace does not exist then it will be created for you. **There is currently a limitation on the maximum length of the namespace to 20 characters.**
 
    - Update the `deployment_type` with the desired deployment mode. See under [Global Parameters](#global-parameters) for more details.
 
@@ -252,7 +252,7 @@ All paths below are prefixed with `solution.` for fully-qualified naming and are
 
 | Name              | Description                                                                                                                  | Default Value |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `namespace`       | The Kubernetes namespace that all CORTX-related resources will be deployed into. Currently limited to a maximum of 8 characters.
+| `namespace`       | The Kubernetes namespace that all CORTX-related resources will be deployed into. Currently limited to a maximum of 20 characters.
 | `deployment_type` | The type of deployment. This determines which Kubernetes resources are created. Valid values are `standard` and `data-only`. | `standard`    |
 
 ### Secret parameters

--- a/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
+++ b/k8_cortx_cloud/solution_validation_scripts/solution-validation.sh
@@ -48,7 +48,7 @@ fi
 ### CORTX-29861 Temporary namespace length limitation enforced
 ### This can be removed once namespaces of nominal length (20+ characters) have been validated repeatedly.
 observed_namespace_length=$(yq '.solution.namespace | length' "${solution_yaml}")
-maximum_namespace_length=8
+maximum_namespace_length=20
 
 if [[ "${observed_namespace_length}" -gt "${maximum_namespace_length}" ]]; then
     result_str="The maximum length of the targeted Kubernetes namespace is currently limited to ${maximum_namespace_length} characters. The specified namespace in ${solution_yaml} has a length of ${observed_namespace_length} characters."


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->
As part of previous changes for multiple Data and Server Pods per Worker Node, Pod FQDNs became longer and certain cases were causing cluster deployment to break post-deployment or fail completely. As such, a previous limit on namespace length was implemented to limit the exposure to these scenarios. Additional work has been done to support longer FQDNs throughout CORTX Core components, so this maximum namespace length limit can be increased.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: #CORTX-33598
- This change is related to an issue: #



## How was this tested?
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->
Locally through many deploy/destroy loops with namespaces of length 8, 10, 15, 20, 25+ characters.

## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [x] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
