### PR TITLE
CORTX-32157: Refactor HA chart values

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -104,21 +104,6 @@ helm uninstall cortx
 | cortxdata.persistentStorage.volumeMode | string | `"Block"` |  |
 | cortxdata.replicas | int | `3` |  |
 | cortxdata.storageClassName | string | `"local-block-storage"` |  |
-| cortxha.enabled | bool | `true` |  |
-| cortxha.fault_tolerance.resources.limits.cpu | string | `"500m"` |  |
-| cortxha.fault_tolerance.resources.limits.memory | string | `"1Gi"` |  |
-| cortxha.fault_tolerance.resources.requests.cpu | string | `"250m"` |  |
-| cortxha.fault_tolerance.resources.requests.memory | string | `"128Mi"` |  |
-| cortxha.health_monitor.resources.limits.cpu | string | `"500m"` |  |
-| cortxha.health_monitor.resources.limits.memory | string | `"1Gi"` |  |
-| cortxha.health_monitor.resources.requests.cpu | string | `"250m"` |  |
-| cortxha.health_monitor.resources.requests.memory | string | `"128Mi"` |  |
-| cortxha.image | string | `"ghcr.io/seagate/centos:7"` |  |
-| cortxha.k8s_monitor.resources.limits.cpu | string | `"500m"` |  |
-| cortxha.k8s_monitor.resources.limits.memory | string | `"1Gi"` |  |
-| cortxha.k8s_monitor.resources.requests.cpu | string | `"250m"` |  |
-| cortxha.k8s_monitor.resources.requests.memory | string | `"128Mi"` |  |
-| cortxha.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
 | existingSecret | string | `""` | The name of an existing Secret that contains CORTX configuration secrets. Required or the Chart installation will fail. |
 | externalConsul.adminSecretName | string | `"consul_admin_secret"` |  |
 | externalConsul.adminUser | string | `"admin"` |  |
@@ -127,6 +112,18 @@ helm uninstall cortx
 | externalKafka.adminUser | string | `"admin"` |  |
 | externalKafka.endpoints | list | `[]` |  |
 | fullnameOverride | string | `""` | A name that will fully override cortx.fullname |
+| ha.enabled | bool | `true` | Enable installation of HA instances |
+| ha.faultTolerance.resources.limits | object | `{"cpu":"500m","memory":"1Gi"}` | The resource limits for the HA Fault Tolerance containers and processes |
+| ha.faultTolerance.resources.requests | object | `{"cpu":"250m","memory":"128Mi"}` | The resource requests for the HA Fault Tolerance containers and processes |
+| ha.healthMonitor.resources.limits | object | `{"cpu":"500m","memory":"1Gi"}` | The resource limits for the HA Health Monitor containers and processes |
+| ha.healthMonitor.resources.requests | object | `{"cpu":"250m","memory":"128Mi"}` | The resource requests for the HA Health Monitor containers and processes |
+| ha.image.pullPolicy | string | `"IfNotPresent"` | HA image pull policy |
+| ha.image.registry | string | `"ghcr.io"` | HA image registry |
+| ha.image.repository | string | `"seagate/cortx-control"` | HA image name |
+| ha.image.tag | string | Chart.AppVersion | HA image tag |
+| ha.k8sMonitor.resources.limits | object | `{"cpu":"500m","memory":"1Gi"}` | The resource limits for the HA Kubernetes Monitor containers and processes |
+| ha.k8sMonitor.resources.requests | object | `{"cpu":"250m","memory":"128Mi"}` | The resource requests for the HA Kubernetes Monitor containers and processes |
+| ha.persistence.size | string | `"1Gi"` | Persistent volume size |
 | hare.hax.ports.http.port | int | `22003` | The port number of the Hax HTTP endpoint. |
 | hare.hax.ports.http.protocol | string | `"https"` | The protocol to configure the Hax HTTP endpoint as. Valid values are `http` or `https`. |
 | hare.hax.resources.limits | object | `{"cpu":"1000m","memory":"2Gi"}` | Configure the resource limits for Hax containers. This applies to all Pods that run Hax containers. |

--- a/charts/cortx/templates/_cluster.yaml.tpl
+++ b/charts/cortx/templates/_cluster.yaml.tpl
@@ -55,7 +55,7 @@ cluster:
       services:
       - agent
   {{- end }}
-  {{- if .Values.cortxha.enabled }}
+  {{- if .Values.ha.enabled }}
   - name: ha_node
     components:
     - name: utils
@@ -81,7 +81,7 @@ cluster:
     {{- $nodeName := (include "cortx.control.fullname" $root) }}
     {{- include "storageset.node" (dict "name" $nodeName "id" $nodeName "type" "control_node") | nindent 4 }}
     {{- end }}
-    {{- if $root.Values.cortxha.enabled }}
+    {{- if $root.Values.ha.enabled }}
     {{- $nodeName := (include "cortx.ha.fullname" $root) }}
     {{- $hostName := (printf "%s-headless" $nodeName) }}
     {{- include "storageset.node" (dict "name" $nodeName "hostname" $hostName "id" $hostName "type" "ha_node") | nindent 4 }}

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -158,12 +158,12 @@ cortx:
       services:
       {{- include "config.yaml.service.limits" (dict "name" "agent" "resources" .Values.control.agent.resources) | nindent 6 }}
   {{- end }}
-  {{- if .Values.cortxha.enabled }}
+  {{- if .Values.ha.enabled }}
   ha:
     limits:
       services:
-      {{- include "config.yaml.service.limits" (dict "name" "fault_tolerance" "resources" .Values.cortxha.fault_tolerance.resources) | nindent 6 }}
-      {{- include "config.yaml.service.limits" (dict "name" "health_monitor" "resources" .Values.cortxha.health_monitor.resources) | nindent 6 }}
-      {{- include "config.yaml.service.limits" (dict "name" "k8s_monitor" "resources" .Values.cortxha.k8s_monitor.resources) | nindent 6 }}
+      {{- include "config.yaml.service.limits" (dict "name" "fault_tolerance" "resources" .Values.ha.faultTolerance.resources) | nindent 6 }}
+      {{- include "config.yaml.service.limits" (dict "name" "health_monitor" "resources" .Values.ha.healthMonitor.resources) | nindent 6 }}
+      {{- include "config.yaml.service.limits" (dict "name" "k8s_monitor" "resources" .Values.ha.k8sMonitor.resources) | nindent 6 }}
   {{- end }}
 {{- end -}}

--- a/charts/cortx/templates/_images.tpl
+++ b/charts/cortx/templates/_images.tpl
@@ -14,6 +14,13 @@ Return the Control image name
 {{- end -}}
 
 {{/*
+Return the HA image name
+*/}}
+{{- define "cortx.ha.image" -}}
+{{ include "cortx.images.image" (dict "image" .Values.ha.image "root" .) }}
+{{- end -}}
+
+{{/*
 Return the Server image name
 */}}
 {{- define "cortx.server.image" -}}

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortxha.enabled }}
+{{- if .Values.ha.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,44 +35,14 @@ spec:
           secret:
             secretName: {{ include "cortx.secretName" . }}
       initContainers:
-      - name: cortx-setup
-        image: {{ .Values.cortxha.image }}
-        imagePullPolicy: IfNotPresent
-        command:
-          - /bin/sh
-        {{- if eq .Values.cortxha.image  "ghcr.io/seagate/centos:7" }}
-        args:
-          - -c
-          - sleep $(shuf -i 5-10 -n 1)s
-        {{- else }}
-        args:
-          - -c
-          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
-        {{- end }}
-        volumeMounts:
-          - name: cortx-configuration
-            mountPath: /etc/cortx/solution
-          - name: cortx-ssl-cert
-            mountPath: /etc/cortx/solution/ssl
-          - name: data
-            mountPath: /etc/cortx
-          - name: configuration-secrets
-            mountPath: /etc/cortx/solution/secret
-            readOnly: true
-        env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+      {{- include "cortx.containers.setup" (dict "image" .Values.ha.image "root" . ) | nindent 8 }}
       containers:
+        {{- $image := include "cortx.ha.image" . }}
+        {{- $imagePullPolicy := .Values.ha.image.pullPolicy }}
         - name: cortx-ha-fault-tolerance
-          image: {{ .Values.cortxha.image }}
-          imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxha.image  "ghcr.io/seagate/centos:7" }}
+          image: {{ $image }}
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          {{- if eq $image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -97,15 +67,15 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          {{- if .Values.cortxha.fault_tolerance.resources }}
-          resources: {{- toYaml .Values.cortxha.fault_tolerance.resources | nindent 12 }}
+          {{- if .Values.ha.faultTolerance.resources }}
+          resources: {{- toYaml .Values.ha.faultTolerance.resources | nindent 12 }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
         - name: cortx-ha-health-monitor
-          image: {{ .Values.cortxha.image }}
-          imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxha.image  "ghcr.io/seagate/centos:7" }}
+          image: {{ $image }}
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          {{- if eq $image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -130,15 +100,15 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          {{- if .Values.cortxha.health_monitor.resources }}
-          resources: {{- toYaml .Values.cortxha.health_monitor.resources | nindent 12 }}
+          {{- if .Values.ha.healthMonitor.resources }}
+          resources: {{- toYaml .Values.ha.healthMonitor.resources | nindent 12 }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
         - name: cortx-ha-k8s-monitor
-          image: {{ .Values.cortxha.image }}
-          imagePullPolicy: IfNotPresent
-          {{- if eq .Values.cortxha.image  "ghcr.io/seagate/centos:7" }}
+          image: {{ $image }}
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          {{- if eq $image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -163,8 +133,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          {{- if .Values.cortxha.k8s_monitor.resources }}
-          resources: {{- toYaml .Values.cortxha.k8s_monitor.resources | nindent 12 }}
+          {{- if .Values.ha.k8sMonitor.resources }}
+          resources: {{- toYaml .Values.ha.k8sMonitor.resources | nindent 12 }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/cortx/templates/ha/pvc.yaml
+++ b/charts/cortx/templates/ha/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortxha.enabled }}
+{{- if .Values.ha.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,5 +12,5 @@ spec:
   storageClassName: local-path
   resources:
     requests:
-      storage: {{ .Values.cortxha.localpathpvc.requeststoragesize | quote }}
+      storage: {{ .Values.ha.persistence.size | quote }}
 {{- end }}

--- a/charts/cortx/templates/ha/rbac.yaml
+++ b/charts/cortx/templates/ha/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortxha.enabled }}
+{{- if .Values.ha.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/cortx/templates/ha/service-headless.yaml
+++ b/charts/cortx/templates/ha/service-headless.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortxha.enabled }}
+{{- if .Values.ha.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cortx/templates/ha/serviceaccount.yaml
+++ b/charts/cortx/templates/ha/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cortxha.enabled }}
+{{- if .Values.ha.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -108,6 +108,8 @@ existingSecret: ""
 
 # CORTX Hare component configuration
 hare:
+  # Hax settings
+  # Hax is deployed as a container in multiple workloads. These settings apply to all container instances.
   hax:
     ports:
       http:
@@ -115,6 +117,11 @@ hare:
         port: 22003
         # -- The protocol to configure the Hax HTTP endpoint as. Valid values are `http` or `https`.
         protocol: https
+
+    # Hax component resource requests and limits
+    # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # These values specify the CORTX resource minimum requirements and limits.
+    # The values apply to both container resources and the CORTX internal configuration.
     resources:
       # -- Configure the resource limits for Hax containers. This applies to all Pods that run Hax containers.
       limits:
@@ -200,38 +207,79 @@ control:
     # -- Persistent volume size
     size: 1Gi
 
-##
-## Imported values from cortx-ha Helm Chart. These will be changed.
-##
-cortxha:
+# Deploy CORTX HA instance
+# HA manages the CORTX cluster availability
+# ref: https://github.com/Seagate/cortx-ha
+ha:
+    # -- Enable installation of HA instances
   enabled: true
-  image: ghcr.io/seagate/centos:7
-  fault_tolerance:
+
+  # HA image
+  # ref: https://github.com/Seagate/cortx/pkgs/container/cortx-control
+  image:
+    # -- HA image registry
+    registry: ghcr.io
+    # -- HA image name
+    repository: seagate/cortx-control
+    # -- HA image tag
+    # @default -- Chart.AppVersion
+    tag: ""
+    # -- HA image pull policy
+    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    pullPolicy: IfNotPresent
+
+  # HA Fault Tolerance component settings
+  faultTolerance:
+    # HA Fault Tolerance component resource requests and limits
+    # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # These values specify the CORTX resource minimum requirements and limits.
+    # The values apply to both container resources and the CORTX internal configuration.
     resources:
-      requests:
-        memory: 128Mi
-        cpu: 250m
+      # -- The resource limits for the HA Fault Tolerance containers and processes
       limits:
-        memory: 1Gi
         cpu: 500m
-  health_monitor:
+        memory: 1Gi
+      # -- The resource requests for the HA Fault Tolerance containers and processes
+      requests:
+        cpu: 250m
+        memory: 128Mi
+
+  # HA Health Monitor component settings
+  healthMonitor:
+    # HA Health Monitor component resource requests and limits
+    # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # These values specify the CORTX resource minimum requirements and limits.
+    # The values apply to both container resources and the CORTX internal configuration.
     resources:
-      requests:
-        memory: 128Mi
-        cpu: 250m
+      # -- The resource limits for the HA Health Monitor containers and processes
       limits:
-        memory: 1Gi
         cpu: 500m
-  k8s_monitor:
+        memory: 1Gi
+      # -- The resource requests for the HA Health Monitor containers and processes
+      requests:
+        cpu: 250m
+        memory: 128Mi
+
+  # HA Kubernetes Monitor component settings
+  k8sMonitor:
+    # HA Kubernetes Monitor component resource requests and limits
+    # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # These values specify the CORTX resource minimum requirements and limits.
+    # The values apply to both container resources and the CORTX internal configuration.
     resources:
-      requests:
-        memory: 128Mi
-        cpu: 250m
+      # -- The resource limits for the HA Kubernetes Monitor containers and processes
       limits:
-        memory: 1Gi
         cpu: 500m
-  localpathpvc:
-    requeststoragesize: 1Gi
+        memory: 1Gi
+      # -- The resource requests for the HA Kubernetes Monitor containers and processes
+      requests:
+        cpu: 250m
+        memory: 128Mi
+
+  # Persistence settings
+  persistence:
+    # -- Persistent volume size
+    size: 1Gi
 
 # Deploy CORTX Server instances
 # Server provides S3 storage


### PR DESCRIPTION
## Description

Cleanup HA chart values, in the same vein as previous changes.

- Rename object from cortxha to ha
- Document values
- Use camel case for variable names
- Use new image format and simplify assignment in deploy script

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-32157
- This change is related to an issue: #

## How was this tested?

Deployed cluster, ran scripts, S3 I/O, CSM APIs

Compared the output of `kubectl get deployments,statefulsets,services,cm -o yaml` from before and after this change, it is identical, minus the unique deployment metadata.

Changed default resources values and saw them applied successfully to the Deployment.

## Additional information

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-32157_ha-refactor/charts/cortx/README.md)