### PR TITLE
CORTX-32157: Refactor Data chart values

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -85,25 +85,21 @@ helm uninstall cortx
 | control.service.nodePorts.https | string | `""` | Node port for HTTPS for LoadBalancer and NodePort service types |
 | control.service.ports.https | int | `8081` | Control API service HTTPS port |
 | control.service.type | string | `"ClusterIP"` | Kubernetes service type |
-| cortxdata.confd.resources.limits.cpu | string | `"500m"` |  |
-| cortxdata.confd.resources.limits.memory | string | `"512Mi"` |  |
-| cortxdata.confd.resources.requests.cpu | string | `"250m"` |  |
-| cortxdata.confd.resources.requests.memory | string | `"128Mi"` |  |
-| cortxdata.cvgs | list | `[]` |  |
-| cortxdata.image | string | `"ghcr.io/seagate/centos:7"` |  |
-| cortxdata.localpathpvc.accessmodes[0] | string | `"ReadWriteOnce"` |  |
-| cortxdata.localpathpvc.requeststoragesize | string | `"1Gi"` |  |
-| cortxdata.motr.containerGroupSize | int | `1` | The number of Motr IO containers per CORTX Data Pod. As the number of CVGs increase, this value can be increased to reduce the number of total CORTX Data Pods per Kubernetes Worker Node. |
-| cortxdata.motr.extraConfiguration | string | `""` |  |
-| cortxdata.motr.resources.limits.cpu | string | `"1000m"` |  |
-| cortxdata.motr.resources.limits.memory | string | `"2Gi"` |  |
-| cortxdata.motr.resources.requests.cpu | string | `"250m"` |  |
-| cortxdata.motr.resources.requests.memory | string | `"1Gi"` |  |
-| cortxdata.nodes | list | `[]` |  |
-| cortxdata.persistentStorage.accessModes[0] | string | `"ReadWriteMany"` |  |
-| cortxdata.persistentStorage.volumeMode | string | `"Block"` |  |
-| cortxdata.replicas | int | `3` |  |
-| cortxdata.storageClassName | string | `"local-block-storage"` |  |
+| data.blockDevicePersistence.accessModes | list | `["ReadWriteOnce"]` | Persistent volume access modes |
+| data.blockDevicePersistence.storageClass | string | `""` | Persistent Volume storage class |
+| data.blockDevicePersistence.volumeMode | string | `"Block"` | Persistent volume mode |
+| data.confd.resources.limits | object | `{"cpu":"500m","memory":"512Mi"}` | The resource limits for the Motr confd containers and processes |
+| data.confd.resources.requests | object | `{"cpu":"250m","memory":"128Mi"}` | The resource requests for the Motr confd containers and processes |
+| data.extraConfiguration | string | `""` | Extra configuration, as a multiline string, to be appended to the Motr configuration. Template expressions are allowed. The result is appended to the end of the computed configuration. |
+| data.image.pullPolicy | string | `"IfNotPresent"` | Data image pull policy |
+| data.image.registry | string | `"ghcr.io"` | Data image registry |
+| data.image.repository | string | `"seagate/cortx-data"` | Data image name |
+| data.image.tag | string | Chart.AppVersion | Data image tag |
+| data.ios.resources.limits | object | `{"cpu":"1000m","memory":"2Gi"}` | The resource limits for the Motr IOS containers and processes |
+| data.ios.resources.requests | object | `{"cpu":"250m","memory":"1Gi"}` | The resource requests for the Motr IOS containers and processes |
+| data.persistence.accessModes | list | `["ReadWriteOnce"]` | Persistent volume access modes |
+| data.persistence.size | string | `"1Gi"` | Persistent volume size |
+| data.replicaCount | int | `1` | Number of Data replicas |
 | existingSecret | string | `""` | The name of an existing Secret that contains CORTX configuration secrets. Required or the Chart installation will fail. |
 | externalConsul.adminSecretName | string | `"consul_admin_secret"` |  |
 | externalConsul.adminUser | string | `"admin"` |  |
@@ -167,4 +163,4 @@ helm uninstall cortx
 | serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for CORTX pods |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is true, a name is generated using the fullname template |
-| storageSets | object | `{}` |  |
+| storageSets | list | `[]` |  |

--- a/charts/cortx/templates/_config.yaml.tpl
+++ b/charts/cortx/templates/_config.yaml.tpl
@@ -12,7 +12,7 @@
 {{- $dataHostnames := list -}}
 {{- $statefulSetCount := (include "cortx.data.statefulSetCount" .) | int -}}
 {{- range $stsIndex := until $statefulSetCount }}
-{{- range $i := until (int $.Values.cortxdata.replicas) -}}
+{{- range $i := until (int $.Values.data.replicaCount) -}}
 {{- $dataHostnames = append $dataHostnames (printf "%s-%d.%s" (include "cortx.data.groupFullname" (dict "root" $ "stsIndex" $stsIndex)) $i (include "cortx.data.serviceDomain" $)) -}}
 {{- end -}}
 {{- end -}}
@@ -139,10 +139,10 @@ cortx:
     {{- end }}
     limits:
       services:
-      {{- include "config.yaml.service.limits" (dict "name" "ios" "resources" .Values.cortxdata.motr.resources) | nindent 6 }}
-      {{- include "config.yaml.service.limits" (dict "name" "confd" "resources" .Values.cortxdata.confd.resources) | nindent 6 }}
-    {{- if .Values.cortxdata.motr.extraConfiguration }}
-    {{- tpl .Values.cortxdata.motr.extraConfiguration . | nindent 4 }}
+      {{- include "config.yaml.service.limits" (dict "name" "ios" "resources" .Values.data.ios.resources) | nindent 6 }}
+      {{- include "config.yaml.service.limits" (dict "name" "confd" "resources" .Values.data.confd.resources) | nindent 6 }}
+    {{- if .Values.data.extraConfiguration }}
+    {{- tpl .Values.data.extraConfiguration . | nindent 4 }}
     {{- end }}
   {{- if .Values.control.enabled }}
   csm:

--- a/charts/cortx/templates/data/service-headless.yaml
+++ b/charts/cortx/templates/data/service-headless.yaml
@@ -14,24 +14,3 @@ spec:
     cortx.io/hax-enabled: "true"
     cortx.io/service-domain: {{ include "cortx.data.serviceDomain" . }}
     cortx.io/service-type: cortx-data
-  ### TODO CORTX-29859 - These ports may be superfluous or for documentation only...
-  ports:
-    - name: hax-http
-      protocol: TCP
-      port: {{ .Values.hare.hax.ports.http.port | int }}
-      targetPort: hax-http
-    - name: hax-tcp
-      protocol: TCP
-      port: {{ include "cortx.hare.hax.tcpPort" . | int }}
-      targetPort: hax-tcp
-    - name: confd-tcp
-      protocol: TCP
-      port: {{ include "cortx.data.confdPort" $ | int }}
-      targetPort: confd-tcp
-    {{- range $i := until (len .Values.cortxdata.cvgs) }}
-    {{- $portName := printf "ios-%d-tcp" (add 1 $i) }}
-    - name: {{ $portName }}
-      protocol: TCP
-      port: {{ printf "%d" (add $i (include "cortx.data.iosPort" $) | int) }}
-      targetPort: {{ $portName }}
-    {{- end }}

--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -2,11 +2,24 @@
 {{- . | lower | trimPrefix "/" | replace "/" "-" -}}
 {{- end -}}
 
+{{- define "cortx.data.blockDeviceStorageClass" -}}
+{{- $storageClass := .Values.data.blockDevicePersistence.storageClass -}}
+  {{- if $storageClass -}}
+    {{- if (eq "-" $storageClass) -}}
+      {{- printf "storageClassName: \"\"" -}}
+    {{- else -}}
+      {{- printf "storageClassName: %s" $storageClass -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Currently only one storage set is supported */}}
 {{- $statefulSetCount := (include "cortx.data.statefulSetCount" .) | int -}}
-{{- $validatedContainerGroupSize := (include "cortx.data.validatedContainerGroupSize" .) | int -}}
-{{- range $stsIndex := until $statefulSetCount -}}
-{{- $startingCvgIndex := (mul $stsIndex ($validatedContainerGroupSize | int)) | int -}}
-{{- $endingCvgIndex := (add (mul $stsIndex ($validatedContainerGroupSize | int)) ($validatedContainerGroupSize | int)) | int -}}
+{{- if gt $statefulSetCount 0 }}
+{{- $storageSet := first .Values.storageSets }}
+{{- $cvgGroups := $storageSet.storage | chunk ($storageSet.containerGroupSize | int) }}
+{{- range $stsIndex := until $statefulSetCount }}
+{{- $cvgGroup := index $cvgGroups $stsIndex }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -18,7 +31,7 @@ metadata:
 spec:
   podManagementPolicy: Parallel
   serviceName: {{ include "cortx.data.fullname" $ }}-headless
-  replicas: {{ $.Values.cortxdata.replicas }}
+  replicas: {{ $.Values.data.replicaCount }}
   selector:
     matchLabels: {{- include "cortx.selectorLabels" $ | nindent 6 }}
       app.kubernetes.io/component: data
@@ -51,10 +64,12 @@ spec:
           configMap:
             defaultMode: 0700
             name: {{ include "cortx.data.fullname" $ }}-node
+      {{- $image := include "cortx.data.image" $ }}
+      {{- $imagePullPolicy := $.Values.data.image.pullPolicy }}
       initContainers:
       - name: node-config
-        image: {{ $.Values.cortxdata.image }}
-        imagePullPolicy: IfNotPresent
+        image: {{ $image }}
+        imagePullPolicy: {{ $imagePullPolicy | quote }}
         command:
           - /nodeconfig/entrypoint.sh
         volumeMounts:
@@ -63,96 +78,13 @@ spec:
           readOnly: true
         securityContext:
           privileged: true
-      - name: cortx-setup
-        image: {{ $.Values.cortxdata.image }}
-        imagePullPolicy: IfNotPresent
-        command:
-          - /bin/sh
-        {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
-        args:
-          - -c
-          - sleep $(shuf -i 5-10 -n 1)s
-        {{- else }}
-        args:
-          - -c
-          - /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf
-        {{- end }}
-        volumeDevices:
-          {{- range $cvgIndex := untilStep $startingCvgIndex $endingCvgIndex 1 }}
-          {{- $cvg := index $.Values.cortxdata.cvgs $cvgIndex }}
-          {{- if $cvg.devices.metadata }}
-          - name: {{ printf "block-%s" (include "cortx.data.devicePathToString" $cvg.devices.metadata.device) }}
-            devicePath: {{ $cvg.devices.metadata.device | quote }}
-          {{- end }}
-          {{- range $cvg.devices.data }}
-          - name: {{ printf "block-%s" (include "cortx.data.devicePathToString" .device ) }}
-            devicePath: {{ .device | quote }}
-          {{- end }}
-          {{- end }}
-        volumeMounts:
-          - name: cortx-configuration
-            mountPath: /etc/cortx/solution
-          - name: cortx-ssl-cert
-            mountPath: /etc/cortx/solution/ssl
-          - name: data
-            mountPath: /etc/cortx
-          - name: configuration-secrets
-            mountPath: /etc/cortx/solution/secret
-            readOnly: true
-        env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+      {{- include "cortx.containers.dataSetup" (dict "cvgGroup" $cvgGroup "root" $ ) | nindent 6 }}
       containers:
-        - name: cortx-hax
-          image: {{ $.Values.cortxdata.image }}
-          imagePullPolicy: IfNotPresent
-          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
-          command: ["/bin/sleep", "3650d"]
-          {{- else }}
-          command:
-            - /bin/sh
-          args:
-            - -c
-            - /opt/seagate/cortx/hare/bin/hare_setup start --config yaml:///etc/cortx/cluster.conf
-          {{- end }}
-          volumeMounts:
-            - name: cortx-configuration
-              mountPath: /etc/cortx/solution
-            - name: cortx-ssl-cert
-              mountPath: /etc/cortx/solution/ssl
-            - name: data
-              mountPath: /etc/cortx
-          env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          ports:
-          - name: hax-http
-            containerPort: {{ $.Values.hare.hax.ports.http.port | int }}
-            protocol: TCP
-          - name: hax-tcp
-            containerPort: {{ include "cortx.hare.hax.tcpPort" . | int }}
-            protocol: TCP
-          {{- if $.Values.hare.hax.resources }}
-          resources: {{- toYaml $.Values.hare.hax.resources | nindent 12 }}
-          {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: false
+        {{- include "cortx.containers.hax" (dict "image" $.Values.data.image "root" $ ) | nindent 8 }}
         - name: cortx-motr-confd
-          image: {{ $.Values.cortxdata.image }}
-          imagePullPolicy: IfNotPresent
-          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
+          image: {{ $image }}
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          {{- if eq $image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -161,18 +93,7 @@ spec:
             - -c
             - /opt/seagate/cortx/motr/bin/motr_setup start --services confd --config yaml:///etc/cortx/cluster.conf
           {{- end }}
-          volumeDevices:
-            {{- range $cvgIndex := untilStep $startingCvgIndex $endingCvgIndex 1 }}
-            {{- $cvg := index $.Values.cortxdata.cvgs $cvgIndex }}
-            {{- if $cvg.devices.metadata }}
-            - name: {{ printf "block-%s" (include "cortx.data.devicePathToString" $cvg.devices.metadata.device) }}
-              devicePath: {{ $cvg.devices.metadata.device | quote }}
-            {{- end }}
-            {{- range $cvg.devices.data }}
-            - name: {{ printf "block-%s" (include "cortx.data.devicePathToString" .device ) }}
-              devicePath: {{ .device | quote }}
-            {{- end }}
-            {{- end }}
+          {{- include "cortx.containers.dataBlockDeviceVolumes" $cvgGroup | nindent 10 }}
           volumeMounts:
             - name: cortx-configuration
               mountPath: /etc/cortx/solution
@@ -192,16 +113,16 @@ spec:
           ports:
           - name: confd-tcp
             containerPort: {{ include "cortx.data.confdPort" $ | int }}
-          {{- if $.Values.cortxdata.confd.resources }}
-          resources: {{- toYaml $.Values.cortxdata.confd.resources | nindent 12 }}
+          {{- if $.Values.data.confd.resources }}
+          resources: {{- toYaml $.Values.data.confd.resources | nindent 12 }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-        {{- range $cvgIndex := untilStep $startingCvgIndex $endingCvgIndex 1 }}
-        {{- $ioIndex := (add1 (mod $cvgIndex $validatedContainerGroupSize)) | int }}
+        {{- range $cvgIndex := until (len $cvgGroup) }}
+        {{- $ioIndex := add1 $cvgIndex }}
         - name: {{ printf "cortx-motr-io-%03d" $ioIndex }}
-          image: {{ $.Values.cortxdata.image }}
-          imagePullPolicy: IfNotPresent
+          image: {{ $image }}
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
           env:
             - name: IO_INDEX
               value: {{ printf "%d" $ioIndex | quote }}
@@ -213,7 +134,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if eq $.Values.cortxdata.image  "ghcr.io/seagate/centos:7" }}
+          {{- if eq $image "ghcr.io/seagate/centos:7" }}
           command: ["/bin/sleep", "3650d"]
           {{- else }}
           command:
@@ -222,16 +143,7 @@ spec:
             - -c
             - /opt/seagate/cortx/motr/bin/motr_setup start --services ioservice --idx $IO_INDEX --config yaml:///etc/cortx/cluster.conf
           {{- end }}
-          volumeDevices:
-            {{- $cvg := index $.Values.cortxdata.cvgs $cvgIndex }}
-            {{- if $cvg.devices.metadata }}
-            - name: {{ printf "block-%s" (include "cortx.data.devicePathToString" $cvg.devices.metadata.device) }}
-              devicePath: {{ $cvg.devices.metadata.device | quote }}
-            {{- end }}
-            {{- range $cvg.devices.data }}
-            - name: {{ printf "block-%s" (include "cortx.data.devicePathToString" .device ) }}
-              devicePath: {{ .device | quote }}
-            {{- end }}
+          {{- include "cortx.containers.dataBlockDeviceVolumes" ((index $cvgGroup $cvgIndex) | list) | nindent 10 }}
           volumeMounts:
             - name: cortx-configuration
               mountPath: /etc/cortx/solution
@@ -242,8 +154,8 @@ spec:
           ports:
           - name: {{ printf "ios-%d-tcp" $ioIndex }}
             containerPort: {{ printf "%d" (add $ioIndex (include "cortx.data.iosPort" $) | int) }}
-          {{- if $.Values.cortxdata.motr.resources }}
-          resources: {{- toYaml $.Values.cortxdata.motr.resources | nindent 12 }}
+          {{- if $.Values.data.ios.resources }}
+          resources: {{- toYaml $.Values.data.ios.resources | nindent 12 }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -252,34 +164,19 @@ spec:
   - metadata:
       name: data
     spec:
-      accessModes: {{- toYaml $.Values.cortxdata.localpathpvc.accessmodes | nindent 6 }}
+      accessModes: {{- toYaml $.Values.data.persistence.accessModes | nindent 6 }}
       storageClassName: local-path
       resources:
         requests:
-          storage: {{ $.Values.cortxdata.localpathpvc.requeststoragesize }}
-  {{- range $cvgIndex := untilStep $startingCvgIndex $endingCvgIndex 1 }}
-  {{- $cvg := index $.Values.cortxdata.cvgs $cvgIndex }}
-  {{- if $cvg.devices.metadata }}
-  - metadata:
-      name: {{ printf "block-%s" (include "cortx.data.devicePathToString" $cvg.devices.metadata.device) }}
-    spec:
-      accessModes: {{- toYaml $.Values.cortxdata.persistentStorage.accessModes | nindent 6 }}
-      volumeMode: {{ $.Values.cortxdata.persistentStorage.volumeMode | quote }}
-      storageClassName: {{ $.Values.cortxdata.storageClassName | quote }}
-      resources:
-        requests:
-          storage: {{ $cvg.devices.metadata.size | quote }}
-      selector:
-        matchLabels:
-          cortx.io/device-path: {{ include "cortx.data.devicePathToString" $cvg.devices.metadata.device | quote }}
-  {{- end }}
-  {{- range $cvg.devices.data }}
+          storage: {{ $.Values.data.persistence.size }}
+  {{- range $cvg := $cvgGroup }}
+  {{- range concat (list $cvg.devices.metadata) $cvg.devices.data }}
   - metadata:
       name: {{ printf "block-%s" (include "cortx.data.devicePathToString" .device) }}
     spec:
-      accessModes: {{- toYaml $.Values.cortxdata.persistentStorage.accessModes | nindent 6 }}
-      volumeMode: {{ $.Values.cortxdata.persistentStorage.volumeMode | quote }}
-      storageClassName: {{ $.Values.cortxdata.storageClassName | quote }}
+      accessModes: {{- toYaml $.Values.data.blockDevicePersistence.accessModes | nindent 6 }}
+      volumeMode: {{ $.Values.data.blockDevicePersistence.volumeMode | quote }}
+      {{- include "cortx.data.blockDeviceStorageClass" $ | nindent 6 }}
       resources:
         requests:
           storage: {{ .size | quote }}
@@ -289,4 +186,5 @@ spec:
   {{- end }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -132,28 +132,42 @@ hare:
         cpu: 250m
         memory: 128Mi
 
-### TODO Update this structure similar to solution.yaml, merge with appropriate .cortxdata elements, and convert to a list.
-# storageSets is a Dictionary of storage sets.
+# storageSets is a List of storage sets.
+# Note that currently, only one storage set is supported.
 # e.g.:
 # storageSets:
-#   storage-set-1:
+#   - name: storage-set-1
 #     durability:
 #       sns: 1+0+0
 #       dix: 1+0+0
-#     controlUuid: "bfcb40c12e9f4fa4b924a787886a40b6"
-#     haUuid: "0789bc5f5f544197a5c204ed5d68ab07"
-#     nodes:
-#       ssc-vm-g4-rhev4-0009.colo.seagate.com:
-#         serverUuid: 50b3871d48fa4032bf27a211b4088df7
-#         dataUuid: "8466d0079fd44cd38164d8e31f5cd067"
-#         clientUuid: "6900a455cb634acea727cb01a7ac8e0a"
-#       ssc-vm-g4-rhev4-0010.colo.seagate.com:
-#         serverUuid: "05ceb17b5cdf47538db1bb89ccc247d2"
-#         dataUuid: "eb79cc372c7443cbac768db4313cc0e8"
-#         clientUuid: "6900a455cb634acea727cb01a7ac8e0a"
-# UUIDs are optional and if omitted, will be randomly generated, with
-# the exception of client UUIDs, which will not be configured if omitted.
-storageSets: {}
+#     # The number of Motr IO containers per CORTX Data Pod.
+#     # As the number of CVGs increase, this value can be increased to reduce
+#     # the number of total CORTX Data Pods per Kubernetes Worker Node.
+#     containerGroupSize: 1
+#     storage:
+#       - name: cvg-1
+#         type: ios
+#         devices:
+#           metadata:
+#             device: /dev/sdc
+#             size: 25Gi
+#           data:
+#             - device: /dev/sdd
+#               size: 25Gi
+#             - device: /dev/sde
+#               size: 25Gi
+#       - name: cvg-2
+#         type: ios
+#         devices:
+#           metadata:
+#             device: /dev/sdf
+#             size: 25Gi
+#           data:
+#             - device: /dev/sdg
+#               size: 25Gi
+#             - device: /dev/sdh
+#               size: 25Gi
+storageSets: []
 
 # Deploy CORTX Control instance
 # Control provides APIs to manage the CORTX cluster
@@ -364,65 +378,85 @@ server:
   ##   motr_max_rpc_msg_size: 524288
   extraConfiguration: ""
 
-##
-## Imported values from cortx-data Helm Chart. These will be changed.
-##
-cortxdata:
-  image: ghcr.io/seagate/centos:7
-  replicas: 3
-  # nodes is an array of Kubernetes worker node names on which CORTX will be deployed.
-  # NOTE: This parameter will eventually merge with .storageSets in some form.
-  nodes: []
-  # cvgs is an array of container volume groups (CVG).
-  # A CVG contains a name, type, an optional array of metadata devices, and
-  # an array of data devices.
-  # NOTE: This parameter will eventually merge with .storageSets in some form.
-  # e.g:
-  # cvgs:
-  # - name: cvg-01
-  #   type: ios
-  #   metadataDevices:
-  #     - /dev/sdc
-  #   dataDevices:
-  #     - /dev/sdd
-  #     - /dev/sde
-  #     - /dev/sdf
-  cvgs: []
-  storageClassName: local-block-storage
-  persistentStorage:
-    volumeMode: Block
-    accessModes:
-    - ReadWriteMany
-  motr:
-    # -- The number of Motr IO containers per CORTX Data Pod.
-    # As the number of CVGs increase, this value can be increased to reduce the number of total CORTX Data Pods per Kubernetes Worker Node.
-    containerGroupSize: 1
-    # An optional multi-line string that contains extra Motr configuration
-    # settings. The string may contain template expressions, and is appended to
-    # the end of the computed configuration.
-    # e.g.:
-    # extraConfiguration: |
-    #   md_size: 10
-    #   group_size: 1
-    extraConfiguration: ""
+# Deploy CORTX Data instances
+# Data provides the Motr object store
+data:
+  # -- Number of Data replicas
+  replicaCount: 1
+
+  # -- Extra configuration, as a multiline string, to be appended to the Motr configuration.
+  # Template expressions are allowed. The result is appended to the end of the computed configuration.
+  ## e.g.:
+  ## extraConfiguration: |
+  ##   md_size: 10
+  ##   group_size: 1
+  extraConfiguration: ""
+
+  # Data image
+  # ref: https://github.com/Seagate/cortx/pkgs/container/cortx-data
+  image:
+    # -- Data image registry
+    registry: ghcr.io
+    # -- Data image name
+    repository: seagate/cortx-data
+    # -- Data image tag
+    # @default -- Chart.AppVersion
+    tag: ""
+    # -- Data image pull policy
+    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    pullPolicy: IfNotPresent
+
+  # Motr IOS component settings
+  ios:
+    # Motr IOS component resource requests and limits
+    # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # These values specify the CORTX resource minimum requirements and limits.
+    # The values apply to both container resources and the CORTX internal configuration.
     resources:
-      requests:
-        memory: 1Gi
-        cpu: 250m
+      # -- The resource limits for the Motr IOS containers and processes
       limits:
-        memory: 2Gi
         cpu: 1000m
-  confd:
-    resources:
+        memory: 2Gi
+      # -- The resource requests for the Motr IOS containers and processes
       requests:
-        memory: 128Mi
         cpu: 250m
+        memory: 1Gi
+
+  # Motr confd component settings
+  confd:
+    # Motr confd component resource requests and limits
+    # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    # These values specify the CORTX resource minimum requirements and limits.
+    # The values apply to both container resources and the CORTX internal configuration.
+    resources:
+      # -- The resource limits for the Motr confd containers and processes
       limits:
-        memory: 512Mi
         cpu: 500m
-  localpathpvc:
-    requeststoragesize: 1Gi
-    accessmodes:
+        memory: 512Mi
+      # -- The resource requests for the Motr confd containers and processes
+      requests:
+        cpu: 250m
+        memory: 128Mi
+
+  # Persistence settings
+  persistence:
+    # -- Persistent volume size
+    size: 1Gi
+    # -- Persistent volume access modes
+    accessModes:
+      - ReadWriteOnce
+
+  # Persistence settings for Motr Block Devices
+  blockDevicePersistence:
+    # -- Persistent Volume storage class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+    storageClass: ""
+    # -- Persistent volume mode
+    volumeMode: Block
+    # -- Persistent volume access modes
+    accessModes:
       - ReadWriteOnce
 
 # Deploy CORTX Motr Client instances

--- a/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data-blk-data/templates/cortx-data-blk-data-pv.yaml
+++ b/k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-data-blk-data/templates/cortx-data-blk-data-pv.yaml
@@ -21,7 +21,7 @@ spec:
   capacity:
     storage: {{ $deviceiter.size }}
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   volumeMode: {{ $.Values.cortxblkdata.storage.volumeMode }}
   storageClassName: {{ $.Values.cortxblkdata.storageClassName }}
   persistentVolumeReclaimPolicy: Retain


### PR DESCRIPTION
## Description

Cleanup Data chart values, in the same vein as previous changes.

* Rename object from cortxdata to data
* Use camel case for variable names
* Use new image style
* Etc.

This has significant changes in regards to the storage set definitions. The storage sets are now defined as a top level list, in the exact same format as [solution.yaml](https://github.com/Seagate/cortx-k8s/blob/6f7cf87636f0020e63f9fda4703914a83f437375/k8_cortx_cloud/solution.example.yaml#L163-L216) except for:

- Key names use camel case
- The `nodes` key is removed since it is not being used. Instead, the `data.replicaCount` defines the number of nodes

The logic to construct the CVG groups and determine the number of StatefulSets has been changed to use Helm (Sprig's really) `chunk` function, which groups all the CVG objects into the storage set's `containerGroupSize` value. This grouping means less manual calculation of counts, and no need for tracking index values.

There is still only support for a single storage set, the template errors out if there's more than one.

The block device PV access modes have been changed to `ReadWriteOnce` by default. `ReadWriteMany` isn't necessary.

Port definitions have been removed from the data headless Service. It was not worth the effort to properly handle the dynamic nature of the CVGs, and none of the other headless services specify anything. The port definitions are merely documentation not functional. We can decide to add them back later if necessary.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32157

## How was this tested?

Deployment on a 2-node cluster with two CVGs, and using both group sizes of 1 and 2, with S3/IO. Ran status script.

I capture the Cluster state using `kubectl get deployments,statefulsets,services,cm -o yaml`, for both group size cases, and for before and after this change. Everything was identical in the "after" case except for the expected:

- Removal of ports from headless server
- Change of `accessMode` for block devices to `ReadWriteOnce`
- Unique metadata

All volumes, PVCs, Pods, etc. were identical.

## Additional information

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-32157_data-refactor/charts/cortx/README.md)