### PR TITLE
CORTX-29540: Move deploy final message to Chart

### DIFF
--- a/charts/cortx/templates/NOTES.txt
+++ b/charts/cortx/templates/NOTES.txt
@@ -1,1 +1,27 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
 Thanks for installing CORTX Community Object Storage!
+
+** Please wait while CORTX Kubernetes resources are being deployed. **
+
+{{- if and .Values.server.enabled (gt (.Values.server.service.instanceCount | int) 0) }}
+
+The S3 data service is accessible through the "{{ include "cortx.server.fullname" . }}-0" Service.
+Execute the following commands to get the S3 admin user IAM credentials:
+
+  echo "Access Key: {{ .Values.server.auth.adminAccessKey }}"
+  echo "Secret Key: $(kubectl -n {{ .Release.Namespace }} get secret {{ .Values.existingSecret }} -o jsonpath="{.data.s3_auth_admin_secret}" | base64 -d)"
+
+{{- end }}
+
+{{- if .Values.control.enabled }}
+
+The CORTX control API is accessible through the "{{ include "cortx.control.fullname" . }}" Service.
+Execute the following commands to get the Control admin user credentials:
+
+  echo "Username: cortxadmin"
+  echo "Password: $(kubectl -n {{ .Release.Namespace }} get secret {{ .Values.existingSecret }} -o jsonpath="{.data.csm_mgmt_admin_secret}" | base64 -d)"
+
+{{- end }}

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -648,7 +648,7 @@ function waitForClusterReady()
 {
     set -u
 
-    printf "Now waiting for all CORTX resources to become available, press Ctrl-C to quit...\n\n"
+    printf "\nNow waiting for all CORTX resources to become available, press Ctrl-C to quit...\n\n"
 
     trap killBackgroundJobs INT
 
@@ -722,51 +722,6 @@ deployCortxSecrets
 ##########################################################
 deployCortx
 cleanup
-
-# Note: It is not ideal that some of these values are hard-coded here.
-#       The data comes from the helm charts and so there is no feasible
-#       way of getting the values otherwise.
-data_service_name="cortx-server-0"  # present in cortx values.yaml... what to do?
-data_service_default_user="$(extractBlock 'solution.common.s3.default_iam_users.auth_admin' || true)"
-control_service_name="cortx-control"  # hard coded in script above installing help or cortx-control
-control_service_default_user="cortxadmin" #hard coded in cortx-configmap/templates/_config.tpl
-
-cat << EOF
-
------------------------------------------------------------
-
-Thanks for installing CORTX Community Object Storage!
-
-** Please wait while CORTX Kubernetes resources are being deployed. **
-EOF
-
-if [[ ${components[server]} == true ]]; then
-    cat << EOF
-
-The S3 data service is accessible through the ${data_service_name} service.
-   Default IAM access key: ${data_service_default_user}
-   Default IAM secret key is accessible via:
-      kubectl get secrets/${cortx_secret_name} --namespace ${namespace} \\
-        --template={{.data.s3_auth_admin_secret}} | base64 -d
-EOF
-fi
-
-if [[ ${components[control]} == true ]]; then
-    cat << EOF
-
-The CORTX control service is accessible through the ${control_service_name} service.
-   Default control username: ${control_service_default_user}
-   Default control password is accessible via:
-      kubectl get secrets/${cortx_secret_name} --namespace ${namespace} \\
-        --template={{.data.csm_mgmt_admin_secret}} | base64 -d
-EOF
-fi
-
-cat << EOF
-
------------------------------------------------------------
-
-EOF
 
 if [[ ${CORTX_DEPLOY_NO_WAIT:-false} == true ]]; then
     exit


### PR DESCRIPTION
## Description

Move the final message from the Bash deployment script into the Helm Chart NOTES.txt template. The notes are printed at the end of the chart installation, and since it's a template it has the ability to embed Release-specific values, like service names and input parameters, which aren't as easily retrieved in the Bash script. Regardless, this removes some dependency on the Bash script.

You can re-read the notes again after the Chart install from the helm CLI command, e.g. `helm get notes cortx`, so any instructions are not lost upon clearing/closing a terminal session.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-29540

## How was this tested?

Ran normal deployment. Here's what the new output looks like:

```text
######################################################
# Deploy CORTX
######################################################
NAME: cortx
LAST DEPLOYED: Thu Jul 14 14:21:18 2022
NAMESPACE: cortx
STATUS: deployed
REVISION: 1
NOTES:
CHART NAME: cortx
CHART VERSION: 0.1.0
APP VERSION: 2.0.0-859

Thanks for installing CORTX Community Object Storage!

** Please wait while CORTX Kubernetes resources are being deployed. **

The S3 data service is accessible through the "cortx-server-0" Service.
Execute the following commands to get the S3 admin user IAM credentials:

  echo "Access Key: sgiamadmin"
  echo "Secret Key: $(kubectl -n cortx get secret cortx-secret -o jsonpath="{.data.s3_auth_admin_secret}" | base64 -d)"

The CORTX control API is accessible through the "cortx-control" Service.
Execute the following commands to get the Control admin user credentials:

  echo "Username: cortxadmin"
  echo "Password: $(kubectl -n cortx get secret cortx-secret -o jsonpath="{.data.csm_mgmt_admin_secret}" | base64 -d)"

Now waiting for all CORTX resources to become available, press Ctrl-C to quit...

Waiting for deployment "cortx-ha" rollout to finish: 0 of 1 updated replicas are available...
Waiting for deployment "cortx-control" rollout to finish: 0 of 1 updated replicas are available...
<... snip ...>

$ echo "Access Key: sgiamadmin"
Access Key: sgiamadmin

$ echo "Secret Key: $(kubectl -n cortx get secret cortx-secret -o jsonpath="{.data.s3_auth_admin_secret}" | base64 -d)"
Secret Key: my-secret-key

$ echo "Username: cortxadmin"
Username: cortxadmin

$ echo "Password: $(kubectl -n cortx get secret cortx-secret -o jsonpath="{.data.csm_mgmt_admin_secret}" | base64 -d)"
Password: mypassword
```

Here's the output from `helm install --dry-run`.

Server disabled:

```text
$ helm install --dry-run foobar charts/cortx --set existingSecret=abcd,server.enabled=false | tail -n15

NOTES:
CHART NAME: cortx
CHART VERSION: 0.1.0
APP VERSION: 2.0.0-859

Thanks for installing CORTX Community Object Storage!

** Please wait while CORTX Kubernetes resources are being deployed. **

The CORTX control API is accessible through the "foobar-cortx-control" Service.
Execute the following commands to get the Control admin user credentials:

  echo "Username: cortxadmin"
  echo "Password: $(kubectl -n cortx get secret abcd -o jsonpath="{.data.csm_mgmt_admin_secret}" | base64 -d)"
```

Control disabled:

```text
 $ helm install --namespace=test --dry-run foobar charts/cortx --set existingSecret=abcd,control.enabled=false | tail -n15

NOTES:
CHART NAME: cortx
CHART VERSION: 0.1.0
APP VERSION: 2.0.0-859

Thanks for installing CORTX Community Object Storage!

** Please wait while CORTX Kubernetes resources are being deployed. **

The S3 data service is accessible through the "foobar-cortx-server-0" Service.
Execute the following commands to get the S3 admin user IAM credentials:

  echo "Access Key: cortx-admin"
  echo "Secret Key: $(kubectl -n test get secret abcd -o jsonpath="{.data.s3_auth_admin_secret}" | base64 -d)"
```

Both Server and Control disabled:

```text
$ helm install --namespace=test --dry-run foobar charts/cortx --set existingSecret=abcd,server.enabled=false,control.enabled=false | tail -n9

NOTES:
CHART NAME: cortx
CHART VERSION: 0.1.0
APP VERSION: 2.0.0-859

Thanks for installing CORTX Community Object Storage!

** Please wait while CORTX Kubernetes resources are being deployed. **
```

## Additional information

I changed the wording of the output a little bit.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
