### PR TITLE
Let Helm manage dependent Chart install

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -24,18 +24,10 @@ Kubernetes: `>=1.22.0-0`
 
 ### Downloading the Chart
 
-Locally download the Chart files:
+Download the Chart files:
 
 ```bash
 git clone https://github.com/Seagate/cortx-k8s.git
-```
-
-Install Chart dependencies:
-
-```bash
-helm repo add hashicorp https://helm.releases.hashicorp.com
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm dependency build cortx-k8s/charts/cortx
 ```
 
 ### Installing the Chart
@@ -43,7 +35,7 @@ helm dependency build cortx-k8s/charts/cortx
 To install the chart with the release name `cortx` and a configuration specified by the `myvalues.yaml` file:
 
 ```bash
-helm install cortx cortx-k8s/charts/cortx -f myvalues.yaml
+helm install --dependency-update cortx cortx-k8s/charts/cortx -f myvalues.yaml
 ```
 
 See the [Parameters](#parameters) section for details about all of the options available for configuration.

--- a/charts/cortx/README.md.gotmpl
+++ b/charts/cortx/README.md.gotmpl
@@ -16,18 +16,10 @@
 
 ### Downloading the Chart
 
-Locally download the Chart files:
+Download the Chart files:
 
 ```bash
 git clone https://github.com/Seagate/cortx-k8s.git
-```
-
-Install Chart dependencies:
-
-```bash
-helm repo add hashicorp https://helm.releases.hashicorp.com
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm dependency build cortx-k8s/charts/cortx
 ```
 
 ### Installing the Chart
@@ -35,7 +27,7 @@ helm dependency build cortx-k8s/charts/cortx
 To install the chart with the release name `{{ template "chart.name" . }}` and a configuration specified by the `myvalues.yaml` file:
 
 ```bash
-helm install {{ template "chart.name" . }} cortx-k8s/charts/cortx -f myvalues.yaml
+helm install --dependency-update {{ template "chart.name" . }} cortx-k8s/charts/cortx -f myvalues.yaml
 ```
 
 See the [Parameters](#parameters) section for details about all of the options available for configuration.

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -436,16 +436,6 @@ fi
 # Begin CORTX on k8s deployment
 ##########################################################
 
-function deployCortxPrereqs()
-{
-    # Add Helm repository dependencies
-    helm repo add hashicorp https://helm.releases.hashicorp.com
-    helm repo add bitnami https://charts.bitnami.com/bitnami
-
-    # Installing a chart from the filesystem requires fetching the dependencies
-    helm dependency build ../charts/cortx
-}
-
 function deployRancherProvisioner()
 {
     local image
@@ -489,6 +479,7 @@ function deployCortx()
         "${values[@]}" \
         --namespace "${namespace}" \
         --create-namespace \
+        --dependency-update \
         || exit $?
 }
 
@@ -688,7 +679,6 @@ if [[ "${num_worker_nodes}" -gt "${max_kafka_inst}" ]]; then
     num_kafka_replicas=${max_kafka_inst}
 fi
 
-deployCortxPrereqs
 deployRancherProvisioner
 if [[ -z ${cortx_localblockstorage_skipdeployment} ]]; then
     deployCortxLocalBlockStorage


### PR DESCRIPTION
## Description

Helm can update and install Chart dependencies by using the install `--dependency-update` flag. It isn't necessary to manually install the repositories and then build the dependencies.

If the local chart files exist already on the next deployment, Helm won't go out and attempt to update them. So this is a slight optimization in that it's less likely to require contacting the remote Chart repos every deployment.

In the future, we can avoid this completely by creating a CORTX Chart artifact (e.g. `helm package`) and bundle the dependencies with it, and update instructions to use the released Chart (then later, create a Helm repo).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [X] Code quality improvements to existing code or test additions/updates

## How was this tested?

1. Fresh install with no Helm repos installed and a clean "charts" directory. Deploy script adds repos and downloads the charts automatically
2. A subsequent deployment with charts already downloaded. Deploy script does not update repos or download anything.
3. A subsequent deployment with one of the chart .gz files deleted. Deploy script updates repost and downloads the charts automatically.

## Additional information

## Checklist

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)

-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/chart-dependencies/charts/cortx/README.md)
[View rendered charts/cortx/README.md.gotmpl](https://github.com/keithpine/cortx-k8s/blob/chart-dependencies/charts/cortx/README.md.gotmpl)