### PR TITLE
CORTX-32355: Increase Consul default resources

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -71,8 +71,12 @@ helm uninstall cortx
 | clusterId | string | A random UUID (v4) | The unique ID of the CORTX cluster. |
 | clusterName | string | Chart Release fullname | The name of the CORTX cluster. |
 | consul.client.containerSecurityContext.client.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul client agent containers |
+| consul.client.resources.limits | object | `{"cpu":"500m","memory":"500Mi"}` | Client resource limits. Default values are based on a typical VM deployment and should be tuned as needed. |
+| consul.client.resources.requests | object | `{"cpu":"200m","memory":"200Mi"}` | Client resource requests. Default values are based on a typical VM deployment and should be tuned as needed. |
 | consul.enabled | bool | `true` | Enable installation of the Consul chart |
 | consul.server.containerSecurityContext.server.allowPrivilegeEscalation | bool | `false` | Allow extra privileges in Consul server agent containers |
+| consul.server.resources.limits | object | `{"cpu":"500m","memory":"500Mi"}` | Server resource limits. Default values are based on a typical VM deployment and should be tuned as needed. |
+| consul.server.resources.requests | object | `{"cpu":"200m","memory":"200Mi"}` | Server resource requests. Default values are based on a typical VM deployment and should be tuned as needed. |
 | consul.ui.enabled | bool | `false` | Enable the Consul UI |
 | control.agent.resources.limits | object | `{"cpu":"500m","memory":"256Mi"}` | The resource limits for the Control Agent containers and processes |
 | control.agent.resources.requests | object | `{"cpu":"250m","memory":"128Mi"}` | The resource requests for the Control Agent containers and processes |

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -34,11 +34,29 @@ consul:
     # -- Enable the Consul UI
     enabled: false
   server:
+    resources:
+      # -- Server resource limits. Default values are based on a typical VM deployment and should be tuned as needed.
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      # -- Server resource requests. Default values are based on a typical VM deployment and should be tuned as needed.
+      requests:
+        cpu: 200m
+        memory: 200Mi
     containerSecurityContext:
       server:
         # -- Allow extra privileges in Consul server agent containers
         allowPrivilegeEscalation: false
   client:
+    resources:
+      # -- Client resource limits. Default values are based on a typical VM deployment and should be tuned as needed.
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      # -- Client resource requests. Default values are based on a typical VM deployment and should be tuned as needed.
+      requests:
+        cpu: 200m
+        memory: 200Mi
     containerSecurityContext:
       client:
         # -- Allow extra privileges in Consul client agent containers

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -59,19 +59,19 @@ solution:
           storage: 10Gi
           resources:
             requests:
-              memory: 100Mi
-              cpu: 100m
+              memory: 200Mi
+              cpu: 200m
             limits:
-              memory: 300Mi
-              cpu: 100m
+              memory: 500Mi
+              cpu: 500m
         client:
           resources:
             requests:
-              memory: 100Mi
-              cpu: 100m
+              memory: 200Mi
+              cpu: 200m
             limits:
-              memory: 300Mi
-              cpu: 100m
+              memory: 500Mi
+              cpu: 500m
       zookeeper:
         storage_request_size: 8Gi
         data_log_dir_request_size: 8Gi
@@ -90,7 +90,7 @@ solution:
             cpu: 250m
           limits:
             memory: 2Gi
-            cpu: 1
+            cpu: 1000m
       hare:
         hax:
           resources:


### PR DESCRIPTION
## Description

The default resource settings are too low for a typical VM deployment. Increasing these by a small amount noticeably decreases deployment times. The default values have been chosen based on recommendations from CORTX-27366

I timed deployments using the before and after values, and got the following results. These are not scientific (only ran once for each configuration), but the difference is obvious. Runs typically vary +/- 20 seconds from my observations.

- K8s cluster with 5 worker nodes
- 2 data Pods per CORTX node (2 CVGs w/group size 1)
- 1 server Pod per CORTX node
- 1 client Pod per CORTX node

| CORTX node count | Previous time (seconds) | Current time (seconds) |
|:---:|---|---|
| 2 | 326 | 180 |
| 3 | 367 | 208 |
| 5 | 1118 | 334 |

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32355
- This change is related to an issue: CORTX-27366

## How was this tested?

Deployed cluster multiple times with new values.

## Additional information

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-32355_consul-default-resources/charts/cortx/README.md)