### PR TITLE
Deploy with custom Chart values

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,25 @@ After the CORTX Kubernetes resources are created, the deployment script will wai
 | `CORTX_DEPLOY_SERVER_TIMEOUT`  | Server Deployment timeout duration  | `10m` (10 minutes)        |
 | `CORTX_DEPLOY_NO_WAIT`         | Disable all waits when `true`       | `false`, wait is enabled |
 
+### Overriding Helm Chart Values
+
+During the deployment process, the CORTX Helm Chart is installed, based on the input from the `solution.yaml` file. The solution file does not support all possible Chart value configuration settings. For those times you want to customize the deployment beyond what is available in `solution.yaml`, you can specify a custom Chart values.yaml file using the `CORTX_DEPLOY_CUSTOM_VALUES_FILE` environment variable. The custom file will **override** anything set in `solution.yaml` or calculated by the deployment script, so be careful when using this feature. See the [Chart documentation](charts/cortx/README.md) for details on possible configuration settings.
+
+For example, this values file will enable the Consul Web UI:
+
+```yaml
+consul:
+  ui:
+    # Enable the Consul Web UI
+    enable: true
+```
+
+Set the environment variable when deploying:
+
+```bash
+CORTX_DEPLOY_CUSTOM_VALUES_FILE="myvalues.yaml" ./deploy-cortx-cloud.sh solution.yaml
+```
+
 ### Crash-looping InitContainers
 
 During CORTX deployments, there are edge cases where the InitContainers of a CORTX pod will fail into a CrashLoopBackoff state and it becomes difficult to capture the internal logs that provide necessary context for such error conditions. This command can be used to spin up a debugging container instance that has access to those same logs.


### PR DESCRIPTION
## Description

Specify a custom values.yaml file when using the deployment script to add or override calculated values. This makes it possible to configure things not supported by `solution.yaml`, for example, enabling the Consul Web UI by default.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## How was this tested?

```bash
❯ cat myvalues.yaml 
consul:
  ui:
    enabled: true
```

Deploy with the above values file, and I can see the Consul UI is enabled.

Specify a non-existent file, and see an error is report and the deploy script exits before installing.

Specify a blank env var, or none at all, and notice a normal, unmodified deployment (no Consul UI).


## Additional information

## Checklist

- [X] The change is tested and works locally.
- [X] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/keithpine/cortx-k8s/blob/deploy-custom-values/README.md)