### PR TITLE
CORTX-29838: Fix containerPort off-by-one regression

### DIFF
--- a/charts/cortx/templates/data/statefulset.yaml
+++ b/charts/cortx/templates/data/statefulset.yaml
@@ -153,7 +153,7 @@ spec:
               mountPath: /etc/cortx
           ports:
           - name: {{ printf "ios-%d-tcp" $ioIndex }}
-            containerPort: {{ printf "%d" (add $ioIndex (include "cortx.data.iosPort" $) | int) }}
+            containerPort: {{ printf "%d" (add $cvgIndex (include "cortx.data.iosPort" $) | int) }}
           {{- if $.Values.data.ios.resources }}
           resources: {{- toYaml $.Values.data.ios.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
## Description

The Data IOS port is starting at the wrong value (off-by-one). This was a regression added in #302, identified in CORTX-29838. 

Now the first IOS instance in the Pod matches the port configure in config.yaml. The containerPort definitions don't affect any functionality in this case, they just serve as documentation.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change is related to an issue: CORTX-29838

## How was this tested?

Deployed, checked StatefulSet definition.

## Additional information

Note that the port numbers configured are not reflected in the runtime state of the CORTX cluster. This is a regression in CORTX software, being tracked by CORTX-33705.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
