### PR TITLE
CORTX-32842: Replace PVC with EmptyDir for cortx-control deployment

### DIFF
--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -28,8 +28,7 @@ spec:
           configMap:
             name: {{ include "cortx.tls.configmapName" . }}
         - name: data
-          persistentVolumeClaim:
-            claimName: {{ include "cortx.control.fullname" . }}
+          emptyDir: {}
         - name: configuration-secrets
           secret:
             secretName: {{ include "cortx.secretName" . }}

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -155,42 +155,6 @@ else
     failcount=$((failcount+1))
 fi
 
-# Check storage local
-count=0
-num_pvs_pvcs=2
-[[ ${data_deployment} == true ]] && num_pvs_pvcs=0
-msg_info "| Checking Storage: Local [PVCs/PVs] |"
-while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "${line}"
-    printf "PVC: %s..." "${status[0]}"
-    if [[ "${status[1]}" != "Bound" ]]; then
-        msg_failed
-        failcount=$((failcount+1))
-    else
-        msg_passed
-        count=$((count+1))
-    fi
-done < <(kubectl get pvc --namespace="${namespace}" --selector=${control_selector} --no-headers)
-
-while IFS= read -r line; do
-    IFS=" " read -r -a status <<< "${line}"
-    printf "PV: %s..." "${status[5]}"
-    if [[ "${status[4]}" != "Bound" ]]; then
-        msg_failed
-        failcount=$((failcount+1))
-    else
-        msg_passed
-        count=$((count+1))
-    fi
-done < <(kubectl get pv --no-headers | grep "${namespace}/cortx-control")
-
-if [[ ${num_pvs_pvcs} -eq ${count} ]]; then
-    msg_overall_passed
-else
-    msg_overall_failed
-    failcount=$((failcount+1))
-fi
-
 #########################################################################################
 # CORTX Data
 #########################################################################################


### PR DESCRIPTION
## Description
This change replaces the local PVC with an EmptyDir for the data volume for the cortx-control pod.  The goal of this change is to avoid having the cortx-control pod bound to a specific node.


## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-32842

## CORTX image version requirements
N/A

## How was this tested?
1. Verified via local deploy and user creation/S3 IO smoke test.
2. Verified that status-, logs-cortx-cloud.sh scripts
3. Ran basic deploy regression test


## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
