### PR TITLE
CORTX-33842: Support multiple cortx-control pods

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -86,6 +86,7 @@ helm uninstall cortx
 | control.image.repository | string | `"seagate/cortx-control"` | Control image name |
 | control.image.tag | string | Chart.AppVersion | Control image tag |
 | control.persistence.size | string | `"1Gi"` | Persistent volume size |
+| control.replicaCount | int | `1` | Number of Control replicas |
 | control.service.nodePorts.https | string | `""` | Node port for HTTPS for LoadBalancer and NodePort service types |
 | control.service.ports.https | int | `8081` | Control API service HTTPS port |
 | control.service.type | string | `"ClusterIP"` | Kubernetes service type |

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels: {{- include "cortx.labels" . | nindent 4 }}
     app.kubernetes.io/component: control
 spec:
-  replicas: {{ .Values.control.service.instanceCount }}
+  replicas: {{ .Values.control.replicaCount }}
   selector:
     matchLabels: {{- include "cortx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: control

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels: {{- include "cortx.labels" . | nindent 4 }}
     app.kubernetes.io/component: control
 spec:
-  replicas: 1
+  replicas: {{ .Values.control.service.instanceCount }}
   selector:
     matchLabels: {{- include "cortx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: control

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -192,6 +192,8 @@ storageSets: []
 control:
   # -- Enable installation of Control instances
   enabled: true
+  # -- Number of Control replicas
+  replicaCount: 1
 
   # Control image
   # ref: https://github.com/Seagate/cortx/pkgs/container/cortx-control

--- a/k8_cortx_cloud/start-cortx-cloud.sh
+++ b/k8_cortx_cloud/start-cortx-cloud.sh
@@ -28,7 +28,7 @@ if [[ ${deployment_type} != "data-only" ]]; then
     printf "########################################################\n"
     printf "# Start CORTX Control                                   \n"
     printf "########################################################\n"
-    expected_count=1
+    expected_count=$(helm get values cortx | yq .control.replicaCount)
     kubectl scale deploy cortx-control --replicas ${expected_count} --namespace="${namespace}"
 
     printf "\nWait for CORTX Control to be ready"

--- a/k8_cortx_cloud/start-cortx-cloud.sh
+++ b/k8_cortx_cloud/start-cortx-cloud.sh
@@ -28,7 +28,7 @@ if [[ ${deployment_type} != "data-only" ]]; then
     printf "########################################################\n"
     printf "# Start CORTX Control                                   \n"
     printf "########################################################\n"
-    expected_count=$(helm get values cortx | yq .control.replicaCount)
+    expected_count=$(helm get values cortx -n "${namespace}" | yq .control.replicaCount)
     kubectl scale deploy cortx-control --replicas ${expected_count} --namespace="${namespace}"
 
     printf "\nWait for CORTX Control to be ready"

--- a/k8_cortx_cloud/start-cortx-cloud.sh
+++ b/k8_cortx_cloud/start-cortx-cloud.sh
@@ -28,7 +28,7 @@ if [[ ${deployment_type} != "data-only" ]]; then
     printf "########################################################\n"
     printf "# Start CORTX Control                                   \n"
     printf "########################################################\n"
-    expected_count=$(helm get values cortx -n "${namespace}" | yq .control.replicaCount)
+    expected_count=$(helm get values cortx --all --namespace "${namespace}" --output yaml | yq .control.replicaCount)
     kubectl scale deploy cortx-control --replicas "${expected_count}" --namespace="${namespace}"
 
     printf "\nWait for CORTX Control to be ready"

--- a/k8_cortx_cloud/start-cortx-cloud.sh
+++ b/k8_cortx_cloud/start-cortx-cloud.sh
@@ -29,7 +29,7 @@ if [[ ${deployment_type} != "data-only" ]]; then
     printf "# Start CORTX Control                                   \n"
     printf "########################################################\n"
     expected_count=$(helm get values cortx -n "${namespace}" | yq .control.replicaCount)
-    kubectl scale deploy cortx-control --replicas ${expected_count} --namespace="${namespace}"
+    kubectl scale deploy cortx-control --replicas "${expected_count}" --namespace="${namespace}"
 
     printf "\nWait for CORTX Control to be ready"
     while true; do

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -114,7 +114,6 @@ else
 fi
 
 # Check pods
-count=0
 msg_info "| Checking Pods |"
 while IFS= read -r line; do
     IFS=" " read -r -a status <<< "${line}"
@@ -122,19 +121,10 @@ while IFS= read -r line; do
     printf "%s..." "${status[0]}"
     if [[ "${status[2]}" != "Running" || "${ready_status[0]}" != "${ready_status[1]}" ]]; then
         msg_failed
-        failcount=$((failcount+1))
     else
         msg_passed
-        count=$((count+1))
     fi
 done < <(kubectl get pods --namespace="${namespace}" --selector=${control_selector} --no-headers)
-
-if [[ ${expected_count} -eq ${count} ]]; then
-    msg_overall_passed
-else
-    msg_overall_failed
-    failcount=$((failcount+1))
-fi
 
 readonly exclude_deprecated_selector="cortx.io/deprecated!=true"  # exclude deprecated service
 

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -114,7 +114,7 @@ else
 fi
 
 # Check pods
-expected_count=$(helm get values cortx -n "${namespace}" | yq .control.replicaCount)
+expected_count=$(helm get values cortx --all --namespace "${namespace}" -o yaml | yq .control.replicaCount)
 count=0
 msg_info "| Checking Pods |"
 while IFS= read -r line; do

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -114,7 +114,7 @@ else
 fi
 
 # Check pods
-expected_count=$(helm get values cortx | yq .control.replicaCount)
+expected_count=$(helm get values cortx -n "${namespace}" | yq .control.replicaCount)
 count=0
 msg_info "| Checking Pods |"
 while IFS= read -r line; do

--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -114,7 +114,7 @@ else
 fi
 
 # Check pods
-expected_count=$(helm get values cortx --all --namespace "${namespace}" -o yaml | yq .control.replicaCount)
+expected_count=$(helm get values cortx --all --namespace "${namespace}" --output yaml | yq .control.replicaCount)
 count=0
 msg_info "| Checking Pods |"
 while IFS= read -r line; do

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -11,10 +11,10 @@ from utils import Logger, StopWatch
 
 
 def get_expected_cortx_control_pods(namespace):
-    cmd = f'helm get values cortx --all --namespace {namespace} | yq .control.replicaCount'
+    cmd = f'helm get values cortx --all --namespace {namespace} --output yaml | yq .control.replicaCount'
     child = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)  # nosec
     return int(child.communicate()[0])
-    
+
 def verify_pods_in_namespace(checker, namespace):
     cmd = ['kubectl', 'get', 'pods', '-n', namespace, '--no-headers']
     # nosec

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -11,7 +11,7 @@ from utils import Logger, StopWatch
 
 
 def get_expected_cortx_control_pods(namespace):
-    cmd = f'helm get values cortx -n {namespace} | yq .control.replicaCount'
+    cmd = f'helm get values cortx --all --namespace {namespace} | yq .control.replicaCount'
     child = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)  # nosec
     return int(child.communicate()[0])
     

--- a/test/regression/test_deploy.py
+++ b/test/regression/test_deploy.py
@@ -10,12 +10,17 @@ from cluster import Cluster
 from utils import Logger, StopWatch
 
 
+def get_expected_cortx_control_pods(namespace):
+    cmd = f'helm get values cortx -n {namespace} | yq .control.replicaCount'
+    child = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)  # nosec
+    return int(child.communicate()[0])
+    
 def verify_pods_in_namespace(checker, namespace):
     cmd = ['kubectl', 'get', 'pods', '-n', namespace, '--no-headers']
     # nosec
     child = subprocess.Popen(cmd, stdout=subprocess.PIPE)  # nosec
     stdout = child.communicate()[0].decode('utf-8')
-    expected_pods = {
+    deployed_pods = {
         'cortx-control': 0,
         'cortx-data': 0,
         'cortx-ha': 0,
@@ -26,16 +31,17 @@ def verify_pods_in_namespace(checker, namespace):
         podname, _ = line.split(None, 1)
         m = re.match(r'(cortx-[\w]+)', podname)
         if m:
-            if m.group(1) in expected_pods:
-                expected_pods[m.group(1)] += 1
+            if m.group(1) in deployed_pods:
+                deployed_pods[m.group(1)] += 1
 
-    checker.test(expected_pods['cortx-control'] == 1,
-                 f'Verify one cortx-control pod deployed in namespace {namespace}')
-    checker.test(expected_pods['cortx-ha'] == 1,
+    num_control_pods = get_expected_cortx_control_pods(namespace)
+    checker.test(deployed_pods['cortx-control'] == num_control_pods,
+                 f'Verify {num_control_pods} cortx-control pod deployed in namespace {namespace}')
+    checker.test(deployed_pods['cortx-ha'] == 1,
                  f'Verify one cortx-ha pod deployed in namespace {namespace}')
-    checker.test(expected_pods['cortx-data'] >= 1,
+    checker.test(deployed_pods['cortx-data'] >= 1,
                  f'Verify at least one cortx-data pod deployed in namespace {namespace}')
-    checker.test(expected_pods['cortx-server'] >= 1,
+    checker.test(deployed_pods['cortx-server'] >= 1,
                  f'Verify at least one cortx-server pod deployed in namespace {namespace}')
 
 def run_deploy_test(cluster, logger, checker, shutdown=False):


### PR DESCRIPTION
## Description
This change provides support for multiple cortx-control pods in a cluster. 
This is supported in helm value: `control.replicaCount`.
There is no support in solution.yaml for this at this time.


## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-33842

## CORTX image version requirements
N/A

## How was this tested?
1. Deploy with 1 pod, 3 pods, 10 pods
2. Verify that all cortx-control pods are serving data
3. Verify that all cortx-control pods are in sync (all accept write requests, all return same GET responses)
4. Run basic k8s deploy regression test.

## Additional information
There may be issues with running multiple cortx-control pods in terms of the implementation of those containers.  I have done basic functional test, but I leave it to the team responsible for cortx-control implementation to do due diligence in developer test.

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
