### PR TITLE
CORTX-33749 - Workaround for conntrack table issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ k8_cortx_cloud/cortx-cloud-helm-pkg/cortx-configmap/auto-gen-*
 
 # Runtime-dependent Helm Charts
 charts/cortx/charts
+
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -412,9 +412,9 @@ Once you are done with your debugging session, you can exit the shell session an
 
 ### Consistent "connection reset by peer" issues
 
-If you experience consistent "connection reset by peer" errors when operating CORTX in a high traffic volume or large file transfer environment, you may be affected by an issue in the `conntrack` Linux networking module and its conservative default settings. The original issue is covered in depth in the Kubernetes blog post titled ["kube-proxy Subtleties: Debugging an Intermittent Connection Reset"](https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/).
+If you experience consistent "connection reset by peer" errors when operating CORTX in a high traffic volume or large file transfer environment, you may be affected by an issue in the `conntrack` Linux networking module and its aggressive default settings. The original issue is covered in depth in the Kubernetes blog post titled ["kube-proxy Subtleties: Debugging an Intermittent Connection Reset"](https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/).
 
-The prevailing fix for this issue in a Kubernetes environment is to set `conntrack` to a more liberal processing state. That can be done by performing the following command on your underlying Kubernetes worker nodes. Note that how you apply and persist this command on underlying Kubernetes worker nodes will vary by environment, distribution, or service you are using. This fix is implemented in the [`prereq-deploy-cortx-cloud.sh`](k8_cortx_cloud/prereq-deploy-cortx-cloud.sh#L226-L241) script as a reference example.
+The prevailing fix for this issue in a Kubernetes environment is to set `conntrack` to a more relaxed processing state. That can be done by performing the following command on your underlying Kubernetes worker nodes. Note that how you apply and persist this command on underlying Kubernetes worker nodes will vary by environment, distribution, or service you are using. This fix is implemented in the [`prereq-deploy-cortx-cloud.sh`](k8_cortx_cloud/prereq-deploy-cortx-cloud.sh#L226-L241) script as a reference example.
 
 ```bash
 echo 1 > /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal

--- a/README.md
+++ b/README.md
@@ -410,6 +410,18 @@ Once you are done with your debugging session, you can exit the shell session an
 
 **_Note:_** This requires a `kubectl` [minimum version of 1.20](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
+### Consistent "connection reset by peer" issues
+
+If you experience consistent "connection reset by peer" errors when operating CORTX in a high traffic volume or large file transfer environment, you may be affected by an issue in the `conntrack` Linux networking module and its conservative default settings. The original issue is covered in depth in the Kubernetes blog post titled ["kube-proxy Subtleties: Debugging an Intermittent Connection Reset"](https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/).
+
+The prevailing fix for this issue in a Kubernetes environment is to set `conntrack` to a more liberal processing state. That can be done by performing the following command on your underlying Kubernetes worker nodes. Note that how you apply and persist this command on underlying Kubernetes worker nodes will vary by environment, distribution, or service you are using. This fix is implemented in the [`prereq-deploy-cortx-cloud.sh`](k8_cortx_cloud/prereq-deploy-cortx-cloud.sh#L226-L241) script as a reference example.
+
+```bash
+echo 1 > /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal
+```
+
+More details on this issue are captured in the [Prerequisite use cases for deploying CORTX on Kubernetes](doc/prereq-deploy-use-cases.md#consistent-connection-reset-by-peer-issues) page for further explanation.
+
 ## Glossary
 
 For any terms, acronyms, or phrases that are unfamiliar to you as an end-user, please consult the [GLOSSARY](GLOSSARY.md) page for a growing list of definitions and clarifications as needed.

--- a/doc/prereq-deploy-use-cases.md
+++ b/doc/prereq-deploy-use-cases.md
@@ -52,3 +52,20 @@ The following example will mount the device located at `/dev/sdb`, create a file
 ```bash
 sudo ./prereq-deploy-cortx-cloud.sh -d /dev/sdb -s solution-1234.yaml -p
 ```
+
+## Consistent "connection reset by peer" issues
+
+If you experience consistent "connection reset by peer" errors when operating CORTX in a high traffic volume or large file transfer environment, you may be affected by an issue in the `conntrack` Linux networking module and its conservative default settings. The original issue is covered in depth in the Kubernetes blog post titled ["kube-proxy Subtleties: Debugging an Intermittent Connection Reset"](https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/).
+
+The prevailing fix for this issue in a Kubernetes environment is to set `conntrack` to a more liberal processing state. That can be done by performing the following command on your underlying Kubernetes worker nodes. Note that how you apply and persist this command on underlying Kubernetes worker nodes will vary by environment, distribution, or service you are using. This fix is implemented in the [`prereq-deploy-cortx-cloud.sh`](../k8_cortx_cloud/prereq-deploy-cortx-cloud.sh#L226-L241) script as a reference example.
+
+```bash
+echo 1 > /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal
+```
+
+This implemeted fix is only one way to solve this specific issue, as it is highly dependent upon the underlying Linux OS and kernel settings, Kubernetes cluster settings, Container Networking Interface (CNI) component selection and configuration, kube-proxy component settings, and application-specific activity. If this specific does not resolve your explicit "connection reset by peer issues", you can reference the original Kubernetes Issues and Pull Requests below for more of the conversation that handles the individual settings that can be manually adjusted for your specific environment.
+
+**Follow-up issues:**
+- https://github.com/kubernetes/kubernetes/issues/74839
+- https://github.com/kubernetes/kubernetes/pull/74840
+- https://github.com/kubernetes/kubernetes/issues/94861

--- a/doc/prereq-deploy-use-cases.md
+++ b/doc/prereq-deploy-use-cases.md
@@ -55,9 +55,9 @@ sudo ./prereq-deploy-cortx-cloud.sh -d /dev/sdb -s solution-1234.yaml -p
 
 ## Consistent "connection reset by peer" issues
 
-If you experience consistent "connection reset by peer" errors when operating CORTX in a high traffic volume or large file transfer environment, you may be affected by an issue in the `conntrack` Linux networking module and its conservative default settings. The original issue is covered in depth in the Kubernetes blog post titled ["kube-proxy Subtleties: Debugging an Intermittent Connection Reset"](https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/).
+If you experience consistent "connection reset by peer" errors when operating CORTX in a high traffic volume or large file transfer environment, you may be affected by an issue in the `conntrack` Linux networking module and its aggressive default settings. The original issue is covered in depth in the Kubernetes blog post titled ["kube-proxy Subtleties: Debugging an Intermittent Connection Reset"](https://kubernetes.io/blog/2019/03/29/kube-proxy-subtleties-debugging-an-intermittent-connection-reset/).
 
-The prevailing fix for this issue in a Kubernetes environment is to set `conntrack` to a more liberal processing state. That can be done by performing the following command on your underlying Kubernetes worker nodes. Note that how you apply and persist this command on underlying Kubernetes worker nodes will vary by environment, distribution, or service you are using. This fix is implemented in the [`prereq-deploy-cortx-cloud.sh`](../k8_cortx_cloud/prereq-deploy-cortx-cloud.sh#L226-L241) script as a reference example.
+The prevailing fix for this issue in a Kubernetes environment is to set `conntrack` to a more relaxed processing state. That can be done by performing the following command on your underlying Kubernetes worker nodes. Note that how you apply and persist this command on underlying Kubernetes worker nodes will vary by environment, distribution, or service you are using. This fix is implemented in the [`prereq-deploy-cortx-cloud.sh`](../k8_cortx_cloud/prereq-deploy-cortx-cloud.sh#L226-L241) script as a reference example.
 
 ```bash
 echo 1 > /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

<!--
Thank you for your contribution! Before opening this pull request, please complete the template
completely. Unless instructed otherwise, do not delete any sections.
-->
## Description
<!--
Describe what this change does and the motivation behind it. Why is it required? What problems does
it solve?
-->

This PR implements a fix for the observed "connection reset by peer" issue resulting in underlying Linux networking configuration issues. It is meant as a reference example for how to manage this issue in a Kubernetes environment. 

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [x] Third-party dependency update
- [x] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: #CORTX-33749
- This change is related to an issue: #CORTX-33217

## How was this tested?
<!--
In-lieu of requiring automated tests for changes (we're working on that!), we are asking you to
provide a brief description of how this change was tested, especially any details specific to the
change.
-->
Locally and on test machines. 

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [x] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/Seagate/cortx-k8s/blob/CORTX-33749_add_conntrack_to_prereq_script/README.md)
[View rendered doc/prereq-deploy-use-cases.md](https://github.com/Seagate/cortx-k8s/blob/CORTX-33749_add_conntrack_to_prereq_script/doc/prereq-deploy-use-cases.md)