### PR TITLE
CORTX-33135: cortx-setup logging enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ CORTX_DEPLOY_CUSTOM_VALUES_FILE="myvalues.yaml" ./deploy-cortx-cloud.sh solution
 
 ### Crash-looping InitContainers
 
+#### Debugging
+
 During CORTX deployments, there are edge cases where the InitContainers of a CORTX pod will fail into a CrashLoopBackoff state and it becomes difficult to capture the internal logs that provide necessary context for such error conditions. This command can be used to spin up a debugging container instance that has access to those same logs.
 
 ```bash
@@ -409,6 +411,27 @@ kubectl exec -it cortx-debug -c cortx-setup -- sh
 Once you are done with your debugging session, you can exit the shell session and delete the `cortx-debug` pod.
 
 **_Note:_** This requires a `kubectl` [minimum version of 1.20](https://kubernetes.io/docs/tasks/tools/#kubectl).
+
+#### Increase Setup Log Details
+
+Another troubleshooting tool is to increase the amount of information logged to the `cortx-setup` InitContainers' stdout, making the setup logs available to cluster logging solutions. The deployment script configures the setup components to perform logging with `"component"` detail. This means that the components' setup files will be redirected to the container's standard out. Another option is `"all"`, which is the most verbose configuration and redirects all files created during setup. The final option is `"default"` (or the empty `""`), which disables any extra logging details and only contains the setup command's normal output.
+
+The setup log details can be configured on a global level, or per-component, using a [custom values file](#overriding-helm-chart-values). All values are optional. Example:
+
+```yaml
+# Configure all components with the most verbose setup logging
+global:
+  cortx:
+    setupLoggingDetail: "all"
+
+# Configure control with default (no extra details) logging
+control:
+  setupLoggingDetail: "default"
+
+# Configure server with component-only logging
+server:
+  setupLoggingDetail: "component"
+```
 
 ### Consistent "connection reset by peer" issues
 

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -67,6 +67,7 @@ helm uninstall cortx
 | client.image.tag | string | Chart.AppVersion | Client image tag |
 | client.instanceCount | int | `1` | Number of Client instances (containers) per replica |
 | client.replicaCount | int | `1` | Number of Client replicas |
+| client.setupLoggingDetail | string | `""` | Configure cortx-setup Init Container logging detail levels. "default" for default (no extra details), "component" for extra component logs, and "all" for all logs. An empty value means use the global value. If all values are empty, behaves as-if "default". |
 | clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |
 | clusterId | string | A random UUID (v4) | The unique ID of the CORTX cluster. |
 | clusterName | string | Chart Release fullname | The name of the CORTX cluster. |
@@ -89,6 +90,7 @@ helm uninstall cortx
 | control.service.nodePorts.https | string | `""` | Node port for HTTPS for LoadBalancer and NodePort service types |
 | control.service.ports.https | int | `8081` | Control API service HTTPS port |
 | control.service.type | string | `"ClusterIP"` | Kubernetes service type |
+| control.setupLoggingDetail | string | `""` | Configure cortx-setup Init Container logging detail levels. "default" for default (no extra details), "component" for extra component logs, and "all" for all logs. An empty value means use the global value. If all values are empty, behaves as-if "default". |
 | data.blockDevicePersistence.accessModes | list | `["ReadWriteOnce"]` | Persistent volume access modes |
 | data.blockDevicePersistence.storageClass | string | `""` | Persistent Volume storage class |
 | data.blockDevicePersistence.volumeMode | string | `"Block"` | Persistent volume mode |
@@ -104,6 +106,7 @@ helm uninstall cortx
 | data.persistence.accessModes | list | `["ReadWriteOnce"]` | Persistent volume access modes |
 | data.persistence.size | string | `"1Gi"` | Persistent volume size |
 | data.replicaCount | int | `1` | Number of Data replicas |
+| data.setupLoggingDetail | string | `""` | Configure cortx-setup Init Container logging detail levels. "default" for default (no extra details), "component" for extra component logs, and "all" for all logs. An empty value means use the global value. If all values are empty, behaves as-if "default". |
 | existingSecret | string | `""` | The name of an existing Secret that contains CORTX configuration secrets. Required or the Chart installation will fail. |
 | externalConsul.adminSecretName | string | `"consul_admin_secret"` |  |
 | externalConsul.adminUser | string | `"admin"` |  |
@@ -115,6 +118,7 @@ helm uninstall cortx
 | global.cortx.image.pullPolicy | string | `""` | CORTX image pull policy. Overrides CORTX component `image.pullPolicy`. |
 | global.cortx.image.registry | string | `""` | CORTX container image registry. Overrides CORTX component `image.registry`. |
 | global.cortx.image.tag | string | `""` | CORTX image tag. Overrides CORTX component `image.tag`. |
+| global.cortx.setupLoggingDetail | string | `""` | Configure cortx-setup Init Container logging detail levels. Overridden by component settings. "default" for default (no extra details), "component" for extra component logs, and "all" for all logs. An empty value means use the component-specific value. If all values are empty, behaves as-if "default". |
 | global.imageRegistry | string | `""` | Global container image registry. Overrides CORTX component `image.registry` and sub-charts (except Consul). |
 | ha.enabled | bool | `true` | Enable installation of HA instances |
 | ha.faultTolerance.resources.limits | object | `{"cpu":"500m","memory":"1Gi"}` | The resource limits for the HA Fault Tolerance containers and processes |
@@ -128,6 +132,7 @@ helm uninstall cortx
 | ha.k8sMonitor.resources.limits | object | `{"cpu":"500m","memory":"1Gi"}` | The resource limits for the HA Kubernetes Monitor containers and processes |
 | ha.k8sMonitor.resources.requests | object | `{"cpu":"250m","memory":"128Mi"}` | The resource requests for the HA Kubernetes Monitor containers and processes |
 | ha.persistence.size | string | `"1Gi"` | Persistent volume size |
+| ha.setupLoggingDetail | string | `""` | Configure cortx-setup Init Container logging detail levels. "default" for default (no extra details), "component" for extra component logs, and "all" for all logs. An empty value means use the global value. If all values are empty, behaves as-if "default". |
 | hare.hax.ports.http.port | int | `22003` | The port number of the Hax HTTP endpoint. |
 | hare.hax.ports.http.protocol | string | `"https"` | The protocol to configure the Hax HTTP endpoint as. Valid values are `http` or `https`. |
 | hare.hax.resources.limits | object | `{"cpu":"1000m","memory":"2Gi"}` | Configure the resource limits for Hax containers. This applies to all Pods that run Hax containers. |
@@ -167,6 +172,7 @@ helm uninstall cortx
 | server.service.ports.http | int | `80` | RGW S3 service HTTP port |
 | server.service.ports.https | int | `443` | RGW S3 service HTTPS port |
 | server.service.type | string | `"ClusterIP"` | Kubernetes service type |
+| server.setupLoggingDetail | string | `""` | Configure cortx-setup Init Container logging detail levels. "default" for default (no extra details), "component" for extra component logs, and "all" for all logs. An empty value means use the global value. If all values are empty, behaves as-if "default". |
 | serviceAccount.annotations | object | `{}` | Custom annotations for the CORTX ServiceAccount |
 | serviceAccount.automountServiceAccountToken | bool | `false` | Allow auto mounting of the service account token |
 | serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for CORTX pods |

--- a/charts/cortx/templates/_helpers.tpl
+++ b/charts/cortx/templates/_helpers.tpl
@@ -269,3 +269,11 @@ Return the Motr-client endpoint port
 {{- define "cortx.client.motrClientPort" -}}
 21501
 {{- end -}}
+
+{{/*
+Return the setup container log details setting for the component. The component value overrides the global value.
+{{ include "cortx.setupLoggingDetail" ( dict "component" .Values.path.to.the.component "root" $) }}
+*/}}
+{{- define "cortx.setupLoggingDetail" -}}
+{{- coalesce .component.setupLoggingDetail .root.Values.global.cortx.setupLoggingDetail -}}
+{{- end -}}

--- a/charts/cortx/templates/client/statefulset.yaml
+++ b/charts/cortx/templates/client/statefulset.yaml
@@ -38,7 +38,23 @@ spec:
             secretName: {{ include "cortx.secretName" . }}
         - name: data
           emptyDir: {}
-      {{- $imageContext := dict "image" .Values.client.image "root" . }}
+      {{- $logFiles := list }}
+      {{- $logDetails := include "cortx.setupLoggingDetail" ( dict "component" .Values.client "root" .) }}
+      {{- if has $logDetails (list "component" "all") }}
+        {{- $logFiles = list
+              "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/hare_deployment/setup.log"
+              "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/setup.log"
+              "/etc/cortx/log/motr/$TAIL_MACHINE_ID/mini_provisioner"
+              "/etc/cortx/log/utils/$TAIL_MACHINE_ID/utils_setup.log" }}
+        {{- if (eq $logDetails "all") }}
+          {{- $logFiles = concat $logFiles (list
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/consul-elect-rc-leader.log"
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/consul-watch-handler.log"
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/hare-consul.log"
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/hare-hax.log") }}
+        {{- end }}
+      {{- end }}
+      {{- $imageContext := dict "image" .Values.client.image "logFiles" $logFiles "root" . }}
       initContainers:
         {{- include "cortx.containers.setup" $imageContext | nindent 8 }}
       containers:

--- a/charts/cortx/templates/control/deployment.yaml
+++ b/charts/cortx/templates/control/deployment.yaml
@@ -32,7 +32,14 @@ spec:
         - name: configuration-secrets
           secret:
             secretName: {{ include "cortx.secretName" . }}
-      {{- $imageContext := dict "image" .Values.control.image "root" . }}
+      {{- $logFiles := list }}
+      {{- $logDetails := include "cortx.setupLoggingDetail" ( dict "component" .Values.control "root" .) }}
+      {{- if has $logDetails (list "component" "all") }}
+        {{- $logFiles = list
+            "/etc/cortx/log/utils/$TAIL_MACHINE_ID/utils_setup.log"
+            "/etc/cortx/log/csm/csm_setup.log" }}
+      {{- end }}
+      {{- $imageContext := dict "image" .Values.control.image "logFiles" $logFiles "root" . }}
       initContainers:
       {{- include "cortx.containers.setup" $imageContext | nindent 8 }}
       containers:

--- a/charts/cortx/templates/ha/deployment.yaml
+++ b/charts/cortx/templates/ha/deployment.yaml
@@ -34,7 +34,15 @@ spec:
         - name: configuration-secrets
           secret:
             secretName: {{ include "cortx.secretName" . }}
-      {{- $imageContext := dict "image" .Values.ha.image "root" . }}
+      {{- $logFiles := list }}
+      {{- $logDetails := include "cortx.setupLoggingDetail" ( dict "component" .Values.ha "root" .) }}
+      {{- if has $logDetails (list "component" "all") }}
+        {{- $logFiles = list
+            "/etc/cortx/log/utils/$TAIL_MACHINE_ID/utils_setup.log"
+            "/etc/cortx/log/ha/$TAIL_MACHINE_ID/ha_setup.log"
+            "/etc/cortx/log/ha/$TAIL_MACHINE_ID/event_manager.log" }}
+      {{- end }}
+      {{- $imageContext := dict "image" .Values.ha.image "logFiles" $logFiles "root" . }}
       initContainers:
       {{- include "cortx.containers.setup" $imageContext | nindent 8 }}
       containers:

--- a/charts/cortx/templates/server/statefulset.yaml
+++ b/charts/cortx/templates/server/statefulset.yaml
@@ -36,7 +36,25 @@ spec:
         - name: configuration-secrets
           secret:
             secretName: {{ include "cortx.secretName" . }}
-      {{- $imageContext := dict "image" .Values.server.image "root" . }}
+      {{- $logFiles := list }}
+      {{- $logDetails := include "cortx.setupLoggingDetail" ( dict "component" .Values.server "root" .) }}
+      {{- if has $logDetails (list "component" "all") }}
+        {{- $logFiles = list
+              "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/hare_deployment/setup.log"
+              "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/setup.log"
+              "/etc/cortx/log/motr/$TAIL_MACHINE_ID/mini_provisioner"
+              "/etc/cortx/log/rgw/$TAIL_MACHINE_ID/rgw_setup.log"
+              "/etc/cortx/log/utils/$TAIL_MACHINE_ID/utils_setup.log" }}
+        {{- if (eq $logDetails "all") }}
+          {{- $logFiles = concat $logFiles (list
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/consul-elect-rc-leader.log"
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/consul-watch-handler.log"
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/hare-consul.log"
+                "/etc/cortx/log/hare/log/$TAIL_MACHINE_ID/hare-hax.log"
+                "/etc/cortx/log/rgw/$TAIL_MACHINE_ID/radosgw-admin.log") }}
+        {{- end }}
+      {{- end }}
+      {{- $imageContext := dict "image" .Values.server.image "logFiles" $logFiles "root" . }}
       initContainers:
         {{- include "cortx.containers.setup" $imageContext | nindent 8 }}
       containers:

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -21,6 +21,11 @@ global:
       # -- CORTX image pull policy. Overrides CORTX component `image.pullPolicy`.
       pullPolicy: ""
 
+    # -- Configure cortx-setup Init Container logging detail levels. Overridden by component settings.
+    # "default" for default (no extra details), "component" for extra component logs, and "all" for all logs.
+    # An empty value means use the component-specific value. If all values are empty, behaves as-if "default".
+    setupLoggingDetail: ""
+
 # -- A name that will partially override cortx.fullname
 nameOverride: ""
 
@@ -256,6 +261,11 @@ control:
       # -- Node port for HTTPS for LoadBalancer and NodePort service types
       https: ""
 
+  # -- Configure cortx-setup Init Container logging detail levels.
+  # "default" for default (no extra details), "component" for extra component logs, and "all" for all logs.
+  # An empty value means use the global value. If all values are empty, behaves as-if "default".
+  setupLoggingDetail: ""
+
 # Deploy CORTX HA instance
 # HA manages the CORTX cluster availability
 # ref: https://github.com/Seagate/cortx-ha
@@ -329,6 +339,11 @@ ha:
   persistence:
     # -- Persistent volume size
     size: 1Gi
+
+  # -- Configure cortx-setup Init Container logging detail levels.
+  # "default" for default (no extra details), "component" for extra component logs, and "all" for all logs.
+  # An empty value means use the global value. If all values are empty, behaves as-if "default".
+  setupLoggingDetail: ""
 
 # Deploy CORTX Server instances
 # Server provides S3 storage
@@ -413,6 +428,11 @@ server:
   ##   motr_max_rpc_msg_size: 524288
   extraConfiguration: ""
 
+  # -- Configure cortx-setup Init Container logging detail levels.
+  # "default" for default (no extra details), "component" for extra component logs, and "all" for all logs.
+  # An empty value means use the global value. If all values are empty, behaves as-if "default".
+  setupLoggingDetail: ""
+
 # Deploy CORTX Data instances
 # Data provides the Motr object store
 data:
@@ -494,6 +514,11 @@ data:
     accessModes:
       - ReadWriteOnce
 
+  # -- Configure cortx-setup Init Container logging detail levels.
+  # "default" for default (no extra details), "component" for extra component logs, and "all" for all logs.
+  # An empty value means use the global value. If all values are empty, behaves as-if "default".
+  setupLoggingDetail: ""
+
 # Deploy CORTX Motr Client instances
 # Motr Clients are generally a developer tool used for testing purposes
 client:
@@ -517,3 +542,8 @@ client:
     # -- Client image pull policy
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     pullPolicy: IfNotPresent
+
+  # -- Configure cortx-setup Init Container logging detail levels.
+  # "default" for default (no extra details), "component" for extra component logs, and "all" for all logs.
+  # An empty value means use the global value. If all values are empty, behaves as-if "default".
+  setupLoggingDetail: ""

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -161,6 +161,9 @@ buildValues() {
         (.global.storageClass, .consul.server.storageClass) = \"local-path\"
         | .existingSecret = \"${cortx_secret_name}\"" > "${values_file}"
 
+    # Configure all cortx-setup containers for console component logging
+    yq -i '.global.cortx.setupLoggingDetail = "component"' "${values_file}"
+
     # shellcheck disable=SC2016
     yq -i eval-all '
         select(fi==0) ref $to | select(fi==1) ref $from


### PR DESCRIPTION
## Description

Add the ability to control more verbose container logging for cortx-setup InitContainers. When configured, setup log files will be
re-directed to the container's stdout. This allows setup logs to be captured by cluster logging solutions, and aids in troubleshooting, since logs will be available outside of the containers. The alternative is to exec into a debug container and examine the logs manually.

Configure is performed via global and component `setupLoggingDetail` values. Valid settings are:

-  `"default"` (or `""`): no detailed logging
- `"component"`: component-only logging
- `"all"`: component plus all other setup files (e.g. Consul-related)

If the global value is set, it can be overridden by the component version (this the opposite of global image settings).

By default, the deployment script uses `"component"` logging, which is a good balance of logging output. The default chart value is `""`, or `"default"`. Users of the deployment script can re-configure this with a custom values file.

## Breaking change

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-33135

## How was this tested?

Deployed cluster in multiple scenarios:

- With no custom values, everything setup with "component"
- With various custom values overriding the deployment
- With various custom values, overriding per-component

## Additional information

The selection of files to redirect are hand-curated and based on observations of what is being logged during setup.

If CORTX implements it's own console logging in the future for setup, we can remove this.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [X] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-33135_setup-logging/README.md)
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-33135_setup-logging/charts/cortx/README.md)