### PR TITLE
Bump CORTX version to 886

### DIFF
--- a/charts/cortx/Chart.yaml
+++ b/charts/cortx/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.0-879
+appVersion: 2.0.0-886
 dependencies:
   - condition: consul.enabled
     name: consul

--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -1,6 +1,6 @@
 # cortx
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-879](https://img.shields.io/badge/AppVersion-2.0.0--879-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-886](https://img.shields.io/badge/AppVersion-2.0.0--886-informational?style=flat-square)
 
 CORTX is a distributed object storage system designed for great efficiency, massive capacity, and high HDD-utilization.
 

--- a/k8_cortx_cloud/solution.example.yaml
+++ b/k8_cortx_cloud/solution.example.yaml
@@ -11,11 +11,11 @@ solution:
       csm_auth_admin_secret: null
       csm_mgmt_admin_secret: null
   images:
-    cortxcontrol: ghcr.io/seagate/cortx-control:2.0.0-879
-    cortxdata: ghcr.io/seagate/cortx-data:2.0.0-879
-    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-879
-    cortxha: ghcr.io/seagate/cortx-control:2.0.0-879
-    cortxclient: ghcr.io/seagate/cortx-data:2.0.0-879
+    cortxcontrol: ghcr.io/seagate/cortx-control:2.0.0-886
+    cortxdata: ghcr.io/seagate/cortx-data:2.0.0-886
+    cortxserver: ghcr.io/seagate/cortx-rgw:2.0.0-886
+    cortxha: ghcr.io/seagate/cortx-control:2.0.0-886
+    cortxclient: ghcr.io/seagate/cortx-data:2.0.0-886
     consul: ghcr.io/seagate/consul:1.11.4
     kafka: ghcr.io/seagate/kafka:3.0.0-debian-10-r97
     zookeeper: ghcr.io/seagate/zookeeper:3.8.0-debian-10-r9


### PR DESCRIPTION
## Description

Upgrade to CORTX images 886.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## How was this tested?

Deploy, S3 I/O, CSM API requests.

## Additional information

FYI, I notice a significant performance degradation in S3 I/O, likely due to new debug output going to stderr.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [X] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [X] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)


-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/bump-version/charts/cortx/README.md)