### PR TITLE
Prototype:  K8s job to tar files in cortx PVC

### DIFF
--- a/k8_cortx_cloud/get-logs-from-pvc.sh
+++ b/k8_cortx_cloud/get-logs-from-pvc.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+pvc=$1
+namespace="${2:-default}"
+
+function help()
+{
+    echo "$0 <pvc> [<namespace>]"
+    exit 1
+}
+
+if [ -z "${pvc}" ]; then help; fi
+
+job_name="cortx-log-${pvc}"
+
+cat << EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${job_name}"
+  namespace: "${namespace}"
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+        - image: busybox
+          name: "${job_name}"
+          command:
+            - sh
+            - -c
+            - tar cz -C /etc "${pvc}" | base64
+          volumeMounts:
+            - mountPath: "/etc/${pvc}"
+              name: data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: "${pvc}"
+      restartPolicy: Never
+EOF
+
+
+# Wait for job to complete
+pod_status="starting"
+while [ "${pod_status}" != "Completed" ]; do
+    sleep 1
+    while IFS= read -r line; do
+        IFS=" " read -r -a my_array <<< "${line}"
+        pod_name="${my_array[0]}"
+        pod_status="${my_array[2]}"
+        echo "Waiting for job to complete (${pod_name}  ${pod_status})"
+    done <<< "$(kubectl get pod --namespace ${namespace} | grep ^${job_name})"
+done
+
+
+# Get logs, save to .tgz
+outfile="${pvc}.tgz"
+echo "Saving logs to ${outfile}"
+kubectl logs "${pod_name}" --namespace ${namespace} | base64 -d > ${outfile}
+
+# Delete the job
+kubectl delete job "${job_name}" --namespace "${namespace}"


### PR DESCRIPTION
## Description

CORTX-32645 requests a method for getting log files from CORTX
pods that are inaccessible (e.g. Terminated).  The files are
stored in PVs on the worker nodes.

The script has the idea of creating a job that starts a pod
that mounts the PVC that contains the files that the Admin
is after and tars the file to stdout.  Once the job completes
the script runs "kubectl logs" to get the tar file and write
it to local disk.

The CORTX PVCs are all simply named, so it is straightforward
for an admin to know and use the PVC name.  Examples:

cortx-ha  (for the cortx-ha pod)

data-cortx-server-[0-9] for cortx-server pods

data-cortx-data-g[0-9]-[0-9] for cortx-data pods

(cortx-control pods no longer use a backing PVC, so this is not included)

Really any PVC that can be mounted in the containers file system can be used.

Signed-off-by: Walter Lopatka <walter.lopatka@seagate.com>


