### PR TITLE
CORTX-33534: Improve logs-cortx-cloud.sh error handling.

### DIFF
--- a/k8_cortx_cloud/logs-cortx-cloud.sh
+++ b/k8_cortx_cloud/logs-cortx-cloud.sh
@@ -110,14 +110,14 @@ function tarPodLogs()
     done
 
     # Get support bundle.  Use first container.
-    local path="/var/cortx/support_bundle"
+    local path="var/cortx/support_bundle"
     local name="bundle-logs-${pod}-${date}"
     local container=$1
 
     printf "\n ⭐ Generating support-bundle logs for pod: %s\n" "${pod}"
     # shellcheck disable=SC2016
     kubectl exec "${pod}" -c "${container}" --namespace="${namespace}" -- \
-      env location="file://${path}" \
+      env location="file:///${path}" \
           name="${name}" \
           modules="${modules}" \
           duration="${duration}" \
@@ -137,9 +137,10 @@ function tarPodLogs()
         --binlogs "${binlogs}" \
         --coredumps "${coredumps}" \
         --stacktrace "${stacktrace}" \
-        --all "${all}"'
-    kubectl cp "${pod}:${path}/${name}" "${logs_folder}/${name}" -c "${container}" --namespace="${namespace}"
-    kubectl exec "${pod}" -c "${container}" --namespace="${namespace}" -- bash -c "rm -rf ${path}"
+        --all "${all}"' || return
+    kubectl cp "${pod}:${path}/${name}" "${logs_folder}/${name}" -c "${container}" --namespace="${namespace}" || return
+
+    kubectl exec "${pod}" -c "${container}" --namespace="${namespace}" -- bash -c "rm -rf /${path}"
 
   else
     # There are no remaining arguments.  Get logs from default container.


### PR DESCRIPTION
## Description
Improved error handling in logs-cotrx-cloud.sh:

- On kubectl failures, exit function early (and avoid additional, unhelpful error messages)
- Avoid "kubectl cp" with leading slash (/) on target, which causes an annoying "tar" error.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-33534

## CORTX image version requirements
N/A

## How was this tested?
Local test:
- Verify no regression
- Test with pods evacuated from one node to see response to kubectl errors

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
