### PR TITLE
CORTX-31017: Add check for cortx already deployed

### DIFF
--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -328,6 +328,13 @@ buildValues() {
     set +eu
 }
 
+if [[ -n $(helm ls --all-namespaces --short -f '^cortx$') ]]; then
+    echo "CORTX is already deployed in this Kubernetes cluster." \
+         "Only a single CORTX installation is currently supported. Exiting."
+    exit 1
+fi
+
+
 num_motr_client=$(extractBlock 'solution.common.motr.num_client_inst')
 
 # Initial solution.yaml / system state checks

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -334,7 +334,6 @@ if [[ -n $(helm ls --all-namespaces --short -f '^cortx$') ]]; then
     exit 1
 fi
 
-
 num_motr_client=$(extractBlock 'solution.common.motr.num_client_inst')
 
 # Initial solution.yaml / system state checks

--- a/k8_cortx_cloud/deploy-cortx-cloud.sh
+++ b/k8_cortx_cloud/deploy-cortx-cloud.sh
@@ -328,7 +328,7 @@ buildValues() {
     set +eu
 }
 
-if [[ -n $(helm ls --all-namespaces --short -f '^cortx$') ]]; then
+if [[ -n $(helm ls --all-namespaces --short --filter '^cortx$') ]]; then
     echo "CORTX is already deployed in this Kubernetes cluster." \
          "Only a single CORTX installation is currently supported. Exiting."
     exit 1


### PR DESCRIPTION

## Description
Error check added to deploy-cortx-cloud.sh so that it immediately exits if cortx is already deployed.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-31017

## CORTX image version requirements
N/A

## How was this tested?
- Verify standard deploy continues to work
- Test on existing cortx deployment in default namespace
- Test on existing cortx deployment in non-default namespace


## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
