### PR TITLE
CORTX-34141: Add -d option to get-logs-from-pvc.sh

### DIFF
--- a/k8_cortx_cloud/get-logs-from-pvc.sh
+++ b/k8_cortx_cloud/get-logs-from-pvc.sh
@@ -162,7 +162,7 @@ fi
 printf "Waiting for tar to complete.\n"
 kubectl exec --namespace "${namespace}" "${pod_name}" -- sh -c 'until [ -f /tmp/tarfile_created ]; do sleep 1; done' || exit_msg "Failed waiting for job to complete" 1
 
-if kubectl exec --namespace "${namespace}" "${pod_name}" -- sh -c 'ls /tmp/tar_failed &> /dev/null' 2> /dev/null
+if kubectl exec --namespace "${namespace}" "${pod_name}" -- sh -c '[ -e /tmp/tar_failed ]' 2> /dev/null
 then
     kubectl logs --namespace "${namespace}" "${pod_name}"
     msg="Failed to collect files from PVC ${pvc}"

--- a/k8_cortx_cloud/get-logs-from-pvc.sh
+++ b/k8_cortx_cloud/get-logs-from-pvc.sh
@@ -162,11 +162,11 @@ fi
 printf "Waiting for tar to complete.\n"
 kubectl exec --namespace "${namespace}" "${pod_name}" -- sh -c 'until [ -f /tmp/tarfile_created ]; do sleep 1; done' || exit_msg "Failed waiting for job to complete" 1
 
-if kubectl exec --namespace "${namespace}" "${pod_name}" -- sh -c 'ls /tmp/tar_failed &> /dev/null'
+if kubectl exec --namespace "${namespace}" "${pod_name}" -- sh -c 'ls /tmp/tar_failed &> /dev/null' 2> /dev/null
 then
     kubectl logs --namespace "${namespace}" "${pod_name}"
     msg="Failed to collect files from PVC ${pvc}"
-    if [ -n "${path}" ]; then 
+    if [[ -n "${path}" ]]; then 
         msg="${msg}, path=${path}"
     fi
     exit_msg "${msg}" 1


### PR DESCRIPTION

## Description
Add a -d option to allow user to specify a subdirectory of the PVC to collect logs from.

## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-34141



## How was this tested?
Manual test:
- Verified that data for the specified subdirectory only is collected
- Verified that an invalid path will result in an error.  


## Additional information
<!--
Feel free to mention any other information here about this PR that you feel is important and doesn't
fit into any of the other sections.
-->

## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [x] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
