### PR TITLE
CORTX-34189 Fix status-cortx-cloud.sh regression (data-only deploy)

### DIFF
--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -115,6 +115,7 @@ fi
 
 # Check pods
 expected_count=$(helm get values cortx --all --namespace "${namespace}" --output yaml | yq .control.replicaCount)
+[[ ${data_deployment} == true ]] && expected_count=0
 count=0
 msg_info "| Checking Pods |"
 while IFS= read -r line; do
@@ -141,6 +142,7 @@ readonly exclude_deprecated_selector="cortx.io/deprecated!=true"  # exclude depr
 
 # Check services
 expected_count=1
+[[ ${data_deployment} == true ]] && expected_count=0
 count=0
 msg_info "| Checking Services: cortx-control |"
 while IFS= read -r line; do

--- a/test/regression/data-only.yaml
+++ b/test/regression/data-only.yaml
@@ -1,0 +1,5 @@
+solution:
+  deployment_type: data-only
+  common:
+    motr:
+      num_client_inst: 1

--- a/test/regression/testlists/alltests.yaml
+++ b/test/regression/testlists/alltests.yaml
@@ -16,3 +16,8 @@ test_deploy_basic_default_with_motrclient:
   id: TEST-DEPLOY-0004
   cmd: ./test_deploy.py -s {{ k8_cloud_dir }}/solution.example.yaml -s {{ solution }} -s {{ test_dir }}/namespace.default.yaml -s {{ test_dir }}/client.yaml --shutdown --localfs={{ localfs }}
 
+#Deploy into default namespace
+test_deploy_basic_default_data_only:
+  id: TEST-DEPLOY-0005
+  cmd: ./test_deploy.py -s {{ k8_cloud_dir }}/solution.example.yaml -s {{ solution }} -s {{ test_dir }}/namespace.default.yaml -s {{ test_dir }}/data-only.yaml --shutdown --localfs={{ localfs }}
+

--- a/test/regression/testlists/deploy_all.yaml
+++ b/test/regression/testlists/deploy_all.yaml
@@ -6,3 +6,4 @@ testlist:
  - test_deploy_basic_default
  - test_deploy_basic_with_motrclient
  - test_deploy_basic_default_with_motrclient
+ - test_deploy_basic_default_data_only


### PR DESCRIPTION

## Description
With v0.10.0 and the introduction of potentially multiple replicas of cortx-control pods, I introduced a regression in status-cortx-cloud.sh, such that the script reported failures with a data-only deployment. This is because logic was added to account for potentially multiple replicas did not take into account a possible data-only deployment.

Along with the fix I have added a basic regression test that deploys with data-only deployment.


## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
- This change fixes an issue: CORTX-34189
- This change is related to an issue: #

## CORTX image version requirements
N/A

## How was this tested?
Added new regression test that deploys with data-only deployment.
I also ran the existing regression test to confirm that standard deployment works as expected.


## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [ x All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
