### PR TITLE
CORTX-34284: Do not count cortx-consul-client pods in status check

### DIFF
--- a/k8_cortx_cloud/status-cortx-cloud.sh
+++ b/k8_cortx_cloud/status-cortx-cloud.sh
@@ -983,7 +983,7 @@ else
 fi
 
 # Check Pods
-num_items=$(( num_replicas + num_worker_nodes ))
+num_items="${num_replicas}"
 count=0
 msg_info "| Checking Pods |"
 while IFS= read -r line; do
@@ -997,7 +997,7 @@ while IFS= read -r line; do
         msg_passed
         count=$((count+1))
     fi
-done < <(kubectl get pods --namespace="${namespace}" --selector=${consul_selector} --no-headers)
+done < <(kubectl get pods --namespace="${namespace}" --selector="${consul_selector}",component=server --no-headers)
 
 if [[ ${num_items} -eq ${count} ]]; then
     msg_overall_passed


### PR DESCRIPTION
## Description
status-cortx-cloud.sh was checking the total count of consul pods against the sum of expected server pods (max(3, #worker-nodes)) and expected client pods.  However, the expected number is based on the number of worker nodes not tainted w/ NoSchedule.  This does not work as expected when a node that is normally a worker node is tainted with NoSchedule.

To fix I have stopped checking for the expected number of cortx-consul-client pods, and only count cortx-consul-server pods.  This is not a useful check anyway.




## Type of change
<!--
What type of change is this? Does it fix an issue, or is it new functionality? Check as many items
as necessary to accurately describe the change. If you are checking more than one of the items,
consider splitting it up into separate PRs if it makes sense.
-->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues
<!--
If this change directly fixes or is related to any existing GitHub or Jira issue, mention those
here. You can reference a GitHub issue using "#<issue number>". If this is related to a Seagate
internal issue (Jira), please reference the CORTX-NNNNN issue number.
-->
- This change fixes an issue: CORTX-34284

## CORTX image version requirements
NA

## How was this tested?
Manual test:  deploy cluster, taint one node, run status check... confirm that all pass
Also test with node not tainted to ensure that normal case passes, too.



## Checklist
<!--
Place an 'x' in all the items that apply. You can also fill them out after the PR is submitted. This
serves as a reminder for what the maintainers will be looking for when reviewing the change.
-->

- [x] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [x] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [x] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)
