### PR TITLE
CORTX-32850: Add Server container probes

### DIFF
--- a/charts/cortx/README.md
+++ b/charts/cortx/README.md
@@ -157,8 +157,29 @@ helm uninstall cortx
 | server.persistence.accessModes | list | `["ReadWriteOnce"]` | Persistent volume access modes |
 | server.persistence.size | string | `"1Gi"` | Persistent volume size |
 | server.replicaCount | int | `1` | Number of Server replicas |
+| server.rgw.customLivenessProbe | object | `{}` | Override the default RGW liveness probe with a custom one. |
+| server.rgw.customReadinessProbe | object | `{}` | Override the default RGW readiness probe with a custom one. |
+| server.rgw.customStartupProbe | object | `{}` | Override the default RGW startup probe with a custom one. |
+| server.rgw.livenessProbe.enabled | bool | `false` | Enable the RGW container liveness probe |
+| server.rgw.livenessProbe.failureThreshold | int | `5` | Number of times to retry the liveness probe after it fails, before the pod is marked Unready. |
+| server.rgw.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds to wait before the liveness probe is initiated |
+| server.rgw.livenessProbe.periodSeconds | int | `5` | How often (in seconds) to perform the liveness probe |
+| server.rgw.livenessProbe.successThreshold | int | `1` | Number of times the liveness probe must succeed, after having failed, to be considered successful (must be 1) |
+| server.rgw.livenessProbe.timeoutSeconds | int | `5` | Number of seconds after which the liveness probe times out |
+| server.rgw.readinessProbe.enabled | bool | `false` | Enable the RGW container readiness probe |
+| server.rgw.readinessProbe.failureThreshold | int | `5` | Number of times to retry the readiness probe after it fails, before the pod is marked Unready. |
+| server.rgw.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds to wait before the readiness probe is initiated |
+| server.rgw.readinessProbe.periodSeconds | int | `5` | How often (in seconds) to perform the readiness probe |
+| server.rgw.readinessProbe.successThreshold | int | `1` | Number of times the readiness probe must succeed, after having failed, to be considered successful |
+| server.rgw.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the readiness probe times out |
 | server.rgw.resources.limits | object | `{"cpu":"2000m","memory":"2Gi"}` | The resource limits for the Server RGW containers and processes |
 | server.rgw.resources.requests | object | `{"cpu":"250m","memory":"128Mi"}` | The resource requests for the Server RGW containers and processes |
+| server.rgw.startupProbe.enabled | bool | `false` | Enable the RGW container startup probe |
+| server.rgw.startupProbe.failureThreshold | int | `15` | Number of times the startup probe must succeed, after having failed, to be considered successful |
+| server.rgw.startupProbe.initialDelaySeconds | int | `0` | Number of seconds to wait before the startup probe is initiated |
+| server.rgw.startupProbe.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe |
+| server.rgw.startupProbe.successThreshold | int | `1` | Number of times to retry the startup probe after it fails, before the pod is marked Unready. |
+| server.rgw.startupProbe.timeoutSeconds | int | `5` | Number of seconds after which the startup probe times out |
 | server.service.instanceCount | int | `1` | Number of service instances for LoadBalancer service types |
 | server.service.nodePorts.http | string | `""` | Node port for S3 HTTP for LoadBalancer and NodePort service types |
 | server.service.nodePorts.https | string | `""` | Node port for S3 HTTPS for LoadBalancer and NodePort service types |

--- a/charts/cortx/templates/server/statefulset.yaml
+++ b/charts/cortx/templates/server/statefulset.yaml
@@ -100,6 +100,45 @@ spec:
             - name: motr-client
               containerPort: {{ include "cortx.server.motrClientPort" . | int }}
               protocol: TCP
+          {{- if .Values.server.rgw.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /swift/healthcheck
+              port: rgw-http
+            initialDelaySeconds: {{ .Values.server.rgw.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.rgw.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.rgw.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.server.rgw.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.server.rgw.livenessProbe.failureThreshold }}
+          {{- else if .Values.server.rgw.customLivenessProbe }}
+          livenessProbe: {{- toYaml .Values.server.rgw.customLivenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.server.rgw.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /swift/healthcheck
+              port: rgw-http
+            initialDelaySeconds: {{ .Values.server.rgw.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.rgw.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.rgw.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.server.rgw.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.server.rgw.readinessProbe.failureThreshold }}
+          {{- else if .Values.server.rgw.customReadinessProbe }}
+          readinessProbe: {{- toYaml .Values.server.rgw.customReadinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.server.rgw.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /swift/healthcheck
+              port: rgw-http
+            initialDelaySeconds: {{ .Values.server.rgw.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.rgw.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.rgw.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.server.rgw.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.server.rgw.startupProbe.failureThreshold }}
+          {{- else if .Values.server.rgw.customStartupProbe }}
+          startupProbe: {{- toYaml .Values.server.rgw.customStartupProbe | nindent 12 }}
+          {{- end }}
           resources: {{- toYaml .Values.server.rgw.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/cortx/values.yaml
+++ b/charts/cortx/values.yaml
@@ -385,6 +385,61 @@ server:
         cpu: 250m
         memory: 128Mi
 
+    ## Server RGW container liveness probe options
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    livenessProbe:
+      # -- Enable the RGW container liveness probe
+      enabled: false
+      # -- Number of seconds to wait before the liveness probe is initiated
+      initialDelaySeconds: 10
+      # -- How often (in seconds) to perform the liveness probe
+      periodSeconds: 5
+      # -- Number of seconds after which the liveness probe times out
+      timeoutSeconds: 5
+      # -- Number of times the liveness probe must succeed, after having failed, to be considered successful (must be 1)
+      successThreshold: 1
+      # -- Number of times to retry the liveness probe after it fails, before the pod is marked Unready.
+      failureThreshold: 5
+
+    ## Server RGW container readiness probe options
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    readinessProbe:
+      # -- Enable the RGW container readiness probe
+      enabled: false
+      # -- Number of seconds to wait before the readiness probe is initiated
+      initialDelaySeconds: 10
+      # -- How often (in seconds) to perform the readiness probe
+      periodSeconds: 5
+      # -- Number of seconds after which the readiness probe times out
+      timeoutSeconds: 1
+      # -- Number of times the readiness probe must succeed, after having failed, to be considered successful
+      successThreshold: 1
+      # -- Number of times to retry the readiness probe after it fails, before the pod is marked Unready.
+      failureThreshold: 5
+
+    ## Server RGW container startup probe options
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    startupProbe:
+      # -- Enable the RGW container startup probe
+      enabled: false
+      # -- Number of seconds to wait before the startup probe is initiated
+      initialDelaySeconds: 0
+      # -- How often (in seconds) to perform the startup probe
+      periodSeconds: 5
+      # -- Number of seconds after which the startup probe times out
+      timeoutSeconds: 5
+      # -- Number of times the startup probe must succeed, after having failed, to be considered successful
+      failureThreshold: 15
+      # -- Number of times to retry the startup probe after it fails, before the pod is marked Unready.
+      successThreshold: 1
+
+    # -- Override the default RGW liveness probe with a custom one.
+    customLivenessProbe: {}
+    # -- Override the default RGW readiness probe with a custom one.
+    customReadinessProbe: {}
+    # -- Override the default RGW startup probe with a custom one.
+    customStartupProbe: {}
+
   # Server S3 service
   service:
     # -- Kubernetes service type


### PR DESCRIPTION
## Description

Add container probes for the Server RGW containers. Each probe is an `httpGet` to the `/swift/healthcheck` API which returns always returns status `200 OK` when responding.

For now, the probes are disabled by default and will be enabled by default in the future (except the startup probe).

The probes are not exposed in the solution file, instead they can be customized using a custom values.yaml file.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds new functionality)
- [ ] Breaking change (bug fix or new feature that breaks existing functionality)
- [ ] Third-party dependency update
- [ ] Documentation additions or improvements
- [ ] Code quality improvements to existing code or test additions/updates

## Applicable issues

- This change fixes an issue: CORTX-32850

## How was this tested?

- Deployed with defaults, no probes defined
- Deploy with probes on, confirmed statefulset defines probes
- Manually caused probes to fail by attaching gdb to radosgw process to make it hang
- Defined custom probes and observed they were applied correctly
- Defined custom probes that failed intentionally, observed containers restarted, not ready, etc.

## Additional information

The probes are currently disabled for now so we can gather some experience as to what the right default settings are. Once we have a better sense of the correct default values, we can enable the liveness and readiness probes by default (leaving startup disabled, assuming it's not really needed).

The custom probes do not support templates, it would be nice if the did. Consider that for future updates.

## Checklist

- [X] The change is tested and works locally.
- [ ] New or changed settings in the solution YAML are documented clearly in the README.md file.
- [X] All commits are signed off and are in agreement with the [CORTX Community DCO and CLA policy](https://github.com/Seagate/cortx/blob/main/doc/dco_cla.md).

If this change requires newer CORTX or third party image versions:

- [ ] The `image` fields in [solution.example.yaml](../k8_cortx_cloud/solution.example.yaml) have been updated to use the required versions.
- [ ] The `appVersion` field of the [Helm chart](../charts/cortx/Chart.yaml) has been updated to use the new CORTX version.

If this change addresses a CORTX Jira issue:

- [ ] The title of the PR starts with the issue ID (e.g. `CORTX-XXXXX:`)

-----
[View rendered charts/cortx/README.md](https://github.com/keithpine/cortx-k8s/blob/CORTX-32850_rgw-probes/charts/cortx/README.md)